### PR TITLE
Spanish additional information

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -66,7 +66,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 87;Cérences Centre;cerences-centre;8738819;87388199;-1.437824;48.91686;9462;f;FR;f;Europe/Paris;t;FRDGZ;;t;;f;8703000;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 89;Reims;reims;8724856;;4.0333330000;49.2500000000;;t;FR;f;Europe/Paris;t;FRACQ;;t;;f;8796006;f;XIZ;t;;f;;f;;f;;f;;;;;;;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
 90;Reims Maison Blanche;reims-maison-blanche;8717127;87171272;4.022484;49.233685;89;f;FR;f;Europe/Paris;t;FRBBX;;t;;f;8701874;f;;f;;f;;f;;f;;f;;;;;;;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
-91;Champagne-Ardenne TGV;champagne-ardenne-tgv;8717192;87171926;3.994248;49.214385;89;f;FR;f;Europe/Paris;t;FREAH;CGV;t;;f;8705734;f;;f;;f;;f;;f;;f;;à 8 km de Reims;8km from Reims;8 km von Reims entfernt;8km da Reims;;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
+91;Champagne-Ardenne TGV;champagne-ardenne-tgv;8717192;87171926;3.994248;49.214385;89;f;FR;f;Europe/Paris;t;FREAH;CGV;t;;f;8705734;f;;f;;f;;f;;f;;f;;à 8 km de Reims;8km from Reims;8 km von Reims entfernt;8km da Reims;a 8 km de Reims;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
 92;Reims Ville;reims-ville;8717100;87171009;4.024156;49.259241;89;f;FR;t;Europe/Paris;t;FRRHE;RMS;t;;f;8700081;f;;f;;f;;f;;f;;f;;;;;;;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
 93;Laval;laval;8747840;87478404;-0.761089;48.076405;4714;f;FR;t;Europe/Paris;t;FRACR;LAL;t;;f;8701470;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 94;Accous;accous;8767278;87672782;-0.6000000000;42.9833330000;;f;FR;f;Europe/Paris;t;FRACS;;t;;f;8702617;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -89,7 +89,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 113;St-Pierre-Quiberon;st-pierre-quiberon;8747644;87476440;-3.138907;47.52106;111;f;FR;t;Europe/Paris;t;FRECU;;t;;f;8704642;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;圣皮耶尔屈伊伯龙
 114;Metz;metz;8719203;87192039;6.177665;49.109382;4827;f;FR;t;Europe/Paris;t;FRADE;MZE;t;;f;8700019;f;XMZ;t;;f;;f;;f;;f;;;;;;;Mety;;;メス;메스;;;;Мец;;;梅斯
 115;Forbach;forbach;;;6.9000000000;49.1833330000;;t;FR;f;Europe/Paris;f;FRADF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-117;Forbach Gare;forbach-gare;8719300;87193003;6.900254;49.189215;115;f;FR;t;Europe/Paris;t;FRBQT;FOB;t;;f;8700271;t;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;フォルバック;;;;;Форбах;;;福尔巴克
+117;Forbach Gare;forbach-gare;8719300;87193003;6.900254;49.189215;115;f;FR;t;Europe/Paris;t;FRBQT;FOB;t;;f;8700271;t;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;フォルバック;;;;;Форбах;;;福尔巴克
 118;Sarreguemines;sarreguemines;;;7.0674710000;49.1099500000;;t;FR;f;Europe/Paris;f;FRADG;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 119;Sarreguemines Poste;sarreguemines-poste;8740690;;7.054923;49.110155;118;f;FR;f;Europe/Paris;t;FRZDB;;t;;f;8705509;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 121;Sarreguemines;sarreguemines;8719361;87193615;7.068398594856262;49.10741472240868;118;f;FR;t;Europe/Paris;t;FRSGS;SGS;t;;f;8700439;f;;f;;f;;f;;f;;f;;;;Saargemünd;;;;;;サルグミーヌ;;;;;Саргемин;;;萨尔格米纳
@@ -339,7 +339,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 475;Laferté-sur-Amance;laferte-sur-amance;8714216;87142166;5.7000000000;47.8333330000;;f;FR;f;Europe/Paris;t;FRAUI;;t;;f;8701348;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 476;Vitrey—Vernois;vitrey-vernois;8714217;87142174;5.779407;47.830406;;f;FR;f;Europe/Paris;t;FRAUJ;;t;;f;8702240;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 477;Barges;barges;8714218;87142182;5.8500000000;47.8666670000;;f;FR;f;Europe/Paris;t;FRAUK;;t;;f;8700691;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-479;Bologne;bologne;8714222;87142224;5.1333330000;48.2000000000;4640;f;FR;t;Europe/Paris;t;FRAUP;;t;;f;8700754;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;;;;
+479;Bologne;bologne;8714222;87142224;5.1333330000;48.2000000000;4640;f;FR;t;Europe/Paris;t;FRAUP;;t;;f;8700754;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;;;;
 480;Vignory;vignory;8714223;87142232;5.124264;48.270113;5672;f;FR;t;Europe/Paris;t;FRAUQ;;t;;f;8702171;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 481;Aurillac;aurillac;8764500;87645002;2.4358856678009033;44.92094262161991;;f;FR;f;Europe/Paris;t;FRAUR;AUC;t;;f;8702724;f;;f;;f;;f;;f;;f;;;;;;;;;;オーリヤック;;;;;Орийак;;;欧里亚克
 482;Froncles;froncles;8714224;87142240;5.1500000000;48.3000000000;;f;FR;f;Europe/Paris;t;FRAUS;;t;;f;8701111;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -819,7 +819,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 1022;Dorlisheim;dorlisheim;8721433;87214338;7.4862380000;48.5248480000;;f;FR;f;Europe/Paris;t;FRBXY;DHM;t;;f;8701021;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1034;Lingolsheim;lingolsheim;8721450;87214502;7.67819;48.55943;;f;FR;f;Europe/Paris;t;FRBYK;LGH;t;;f;8701394;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1035;Holtzheim;holtzheim;8721451;87214510;7.6333330000;48.5500000000;;f;FR;f;Europe/Paris;t;FRBYL;HOZ;t;;f;8701259;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-1036;Entzheim Aéroport;entzheim-aeroport;8721452;87214528;7.6281702518463135;48.546941351718054;;f;FR;f;Europe/Paris;t;FRBYM;ENZ;t;;f;8701099;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;;;;;;;;;;;;;
+1036;Entzheim Aéroport;entzheim-aeroport;8721452;87214528;7.6281702518463135;48.546941351718054;;f;FR;f;Europe/Paris;t;FRBYM;ENZ;t;;f;8701099;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;Aeropuerto;;;;;;;;;;;;
 1037;Duppigheim;duppigheim;8721453;87214536;7.5942130000;48.5286560000;;f;FR;f;Europe/Paris;t;FRBYN;DUP;t;;f;8701047;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1038;Duttlenheim;duttlenheim;8721454;87214544;7.5657180000;48.5255300000;;f;FR;f;Europe/Paris;t;FRBYO;DTM;t;;f;8701045;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1039;Dachstein;dachstein;8721455;87214551;7.5323300000;48.5612720000;;f;FR;f;Europe/Paris;t;FRBYP;DCN;t;;f;8701022;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -901,7 +901,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 1129;Paris-Gare-du-Nord;paris-gare-du-nord;8727103;;2.355308;48.880849;4916;f;FR;f;Europe/Paris;f;FRCCP;;f;;f;8703374;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1137;Culmont-Chalindrey;culmont-chalindrey;8714212;87142125;5.443166;47.809956;;f;FR;f;Europe/Paris;t;FRCCY;CYN;t;;f;8700008;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1139;Capdenac;capdenac;8761310;87613109;2.078261375427246;44.57830228982263;;f;FR;f;Europe/Paris;t;FRCDC;CDC;t;;f;8700190;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-1143;Aéroport-Paris-Roissy-Charles-de-Gaulle CDG;aeroport-paris-roissy-charles-de-gaulle-cdg;9903148;;2.5707364082336426;49.00412433626132;;t;FR;f;Europe/Paris;t;FRCDG;;t;;f;;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;;;;;;;;;;;;;
+1143;Aéroport-Paris-Roissy-Charles-de-Gaulle CDG;aeroport-paris-roissy-charles-de-gaulle-cdg;9903148;;2.5707364082336426;49.00412433626132;;t;FR;f;Europe/Paris;t;FRCDG;;t;;f;;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;Aeropuerto;;;;;;;;;;;;
 1144;Aéroport-Paris-Roissy-Charles-de-Gaulle CDG;aeroport-paris-roissy-charles-de-gaulle-cdg;8727149;87001479;2.57113;49.004047;1143;f;FR;t;Europe/Paris;f;FRMLW;RYT;t;MLW;f;8704997;f;;f;MLW;t;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1150;Coudekerque-Branche;coudekerque-branche;8728140;87281402;2.4000000000;51.0333330000;;f;FR;f;Europe/Paris;t;FRCDK;;t;;f;8700890;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1151;Château-du-Loir;chateau-du-loir;8739660;87396606;0.41825294494628906;47.6952704158369;4832;f;FR;t;Europe/Paris;t;FRCDL;CDL;t;;f;8700210;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -1025,7 +1025,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 1347;Dompierre;dompierre;8729577;87295774;3.8636000000;50.1424000000;;f;FR;f;Europe/Paris;t;FRCMP;;t;;f;8701038;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1348;Velle-le-Châtel;velle-le-chatel;8718542;87185421;6.047214;47.602035;;f;FR;f;Europe/Paris;t;FRCMQ;;t;;f;8702177;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1349;Colmar;colmar;;;7.3666670000;48.0833330000;;t;FR;f;Europe/Paris;f;FRCMR;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-1350;Leval;leval;8729579;87295790;3.8333330000;50.1833330000;;f;FR;f;Europe/Paris;t;FRCMS;;t;;f;8701347;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;;;;
+1350;Leval;leval;8729579;87295790;3.8333330000;50.1833330000;;f;FR;f;Europe/Paris;t;FRCMS;;t;;f;8701347;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;;;;
 1351;Berlaimont;berlaimont;8729580;87295808;3.8109683990478516;50.1977331836537;;f;FR;f;Europe/Paris;t;FRCMT;;t;;f;8700768;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1352;Le Quesnoy;le-quesnoy;8729585;87295857;3.645529747009277;50.2503607826595;;f;FR;f;Europe/Paris;t;FRCMU;;t;;f;8701829;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1354;Quevy Frontière;quevy-frontiere;8729592;;;;6003;f;BE;f;Europe/Paris;f;FRCMX;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -1561,10 +1561,10 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 2087;Paimpol;paimpol;8747386;87473868;-3.046088218688965;48.777007776767704;;f;FR;f;Europe/Paris;t;FREAE;;t;;f;8704168;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Пемполь;;;潘波
 2088;Frynaudour;frynaudour;8747387;87473876;-3.128398;48.727763;;f;FR;f;Europe/Paris;t;FREAF;;t;;f;8703357;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2089;Dirinon;dirinon;8747401;87474015;-4.2666670000;48.4000000000;;f;FR;f;Europe/Paris;t;FREAG;;t;;f;8703219;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;迪里农
-2091;Meuse TGV;meuse-tgv;8714732;87147322;5.270808935165404;48.97869598842097;;f;FR;f;Europe/Paris;t;FREAJ;TGM;t;;f;8714732;f;;f;;f;;f;;f;;f;;à 30 km de Verdun et Bar-le-Duc;30km from Verdun and Bar-le-Duc;30 km von Verdun und Bar-le-Duc entfernt;30km da Verdun e Bar-le-Duc;;;;;;;;;;;;;
+2091;Meuse TGV;meuse-tgv;8714732;87147322;5.270808935165404;48.97869598842097;;f;FR;f;Europe/Paris;t;FREAJ;TGM;t;;f;8714732;f;;f;;f;;f;;f;;f;;à 30 km de Verdun et Bar-le-Duc;30km from Verdun and Bar-le-Duc;30 km von Verdun und Bar-le-Duc entfernt;30km da Verdun e Bar-le-Duc;A 30 km de Verdun y Bar-le-Duc;;;;;;;;;;;;
 2092;Pont-de-Buis;pont-de-buis;8747405;87474056;-4.0833330000;48.2500000000;;f;FR;f;Europe/Paris;t;FREAK;;t;;f;8704257;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2093;Châteaulin;chateaulin;8747406;87474064;-4.094334;48.201616;;f;FR;f;Europe/Paris;t;FREAL;;t;;f;8703061;f;;f;;f;;f;;f;;f;;;;;;;;;;シャトーラン;;;;;Шатолен;;;沙托兰
-2094;Lorraine TGV;lorraine-tgv;8714210;87142109;6.169692;48.947406;;f;FR;f;Europe/Paris;t;FREAM;TGL;t;;f;8700729;f;;f;;f;;f;;f;;f;;à 30 km de Metz et Nancy;30km from Metz and Nancy;30 km von Metz und Nancy entfernt;30km da Metz a Nancy;;;;;;;;;;;;;
+2094;Lorraine TGV;lorraine-tgv;8714210;87142109;6.169692;48.947406;;f;FR;f;Europe/Paris;t;FREAM;TGL;t;;f;8700729;f;;f;;f;;f;;f;;f;;à 30 km de Metz et Nancy;30km from Metz and Nancy;30 km von Metz und Nancy entfernt;30km da Metz a Nancy;A 30 km de Metz y Nancy;;;;;;;;;;;;
 2096;Le Juch;le-juch;8747413;;-4.2500000000;48.0666670000;;f;FR;f;Europe/Paris;t;FREAP;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2097;Bannalec;bannalec;8747418;87474189;-3.7000000000;47.9333330000;;f;FR;f;Europe/Paris;t;FREAQ;;t;;f;8700745;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Банналек;;;巴纳莱克
 2099;Kerhuon;kerhuon;8747421;87474213;-4.4000000000;48.4000000000;;f;FR;f;Europe/Paris;t;FREAS;;t;;f;8701336;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -1939,7 +1939,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 2560;Caudéran—Mérignac;cauderan-merignac;8758153;87581538;-0.627339;44.842967;;f;FR;f;Europe/Paris;t;FRFAM;;t;;f;8702985;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2562;Parempuyre;parempuyre;8758171;87581710;-0.5833330000;44.9500000000;5015;f;FR;t;Europe/Paris;t;FRFAO;;t;;f;8704180;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2563;Blanquefort;blanquefort;8758172;87581728;-0.6333330000;44.9166670000;;f;FR;f;Europe/Paris;t;FRFAP;;t;;f;8702842;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-2564;Bruges;bruges;8758173;87581736;-0.609440803527832;44.88707329080843;;f;FR;f;Europe/Paris;t;FRFAQ;;t;;f;8702931;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;;;;
+2564;Bruges;bruges;8758173;87581736;-0.609440803527832;44.88707329080843;;f;FR;f;Europe/Paris;t;FRFAQ;;t;;f;8702931;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;;;;
 2565;Pessac;pessac;8758175;87581751;-0.6314241886138916;44.804493622434926;;f;FR;f;Europe/Paris;t;FRFAR;;t;;f;8701804;f;;f;;f;;f;;f;;f;;;;;;;;;;ペサック;;;;;Пессак;;;佩萨克
 2566;Alouette;alouette;8758179;87581793;-0.6595391035079956;44.79345096061167;;f;FR;f;Europe/Paris;t;FRFAS;;t;;f;8700602;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2567;Bègles;begles;8758180;87581801;-0.5333330000;44.8000000000;;f;FR;f;Europe/Paris;t;FRFAT;;t;;f;8702797;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2055,7 +2055,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 2709;Nantiat;nantiat;8759244;87592444;1.1833330000;46.0166670000;;f;FR;f;Europe/Paris;t;FRFHL;;t;;f;8704084;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2710;Vaulry;vaulry;8759245;87592451;1.10872;46.025003;;f;FR;f;Europe/Paris;t;FRFHM;;t;;f;8704786;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2711;Bellac;bellac;8759248;87592485;1.046125888824463;46.12522527623879;;f;FR;f;Europe/Paris;t;FRFHO;;t;;f;8702800;f;;f;;f;;f;;f;;f;;;;;;;;;;ベラック;;;;;;;;贝拉克
-2712;St-Sébastien;st-sebastien;8759249;;1.5294277667999268;46.391582400989996;;f;FR;f;Europe/Paris;t;FRFHP;;t;;f;8702324;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;;;;
+2712;St-Sébastien;st-sebastien;8759249;;1.5294277667999268;46.391582400989996;;f;FR;f;Europe/Paris;t;FRFHP;;t;;f;8702324;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;;;;
 2713;La Coquille;la-coquille;8759250;87592501;0.9745270013809204;45.54083392855251;;f;FR;f;Europe/Paris;t;FRFHQ;;t;;f;8703561;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2714;Le Dorat;le-dorat;8759254;87592543;1.0793423652648926;46.21110341165666;;f;FR;f;Europe/Paris;t;FRFHS;;t;;f;8703704;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;勒多拉
 2715;Assier;assier;;;1.8833330000;44.6666670000;;t;FR;f;Europe/Paris;f;FRFHT;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2955,7 +2955,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 3866;La Chaise-Dieu;la-chaise-dieu;8773463;87734632;3.7000000000;45.3166670000;;f;FR;f;Europe/Paris;t;FRHMJ;;t;;f;8703550;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;拉谢斯德约
 3867;Sembadel;sembadel;8773464;87734640;3.6833330000;45.2666670000;;f;FR;f;Europe/Paris;t;FRHMK;;t;;f;8704477;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3869;Allègre;allegre;8773466;87734665;3.7000000000;45.2000000000;;f;FR;f;Europe/Paris;t;FRHMM;;t;;f;8702644;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-3870;Borne;borne;8773468;87734681;3.7833330000;45.1000000000;;f;FR;f;Europe/Paris;t;FRHMN;;t;;f;8702875;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;;;;
+3870;Borne;borne;8773468;87734681;3.7833330000;45.1000000000;;f;FR;f;Europe/Paris;t;FRHMN;;t;;f;8702875;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;;;;
 3871;Lavoûte-sur-Loire;lavoute-sur-loire;8773470;87734707;3.9000000000;45.1166670000;;f;FR;f;Europe/Paris;t;FRHMO;;t;;f;8703681;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3872;St-Vincent-le-Château;st-vincent-le-chateau;8773471;87734715;3.918631;45.148681;;f;FR;f;Europe/Paris;t;FRHMP;;t;;f;8704887;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3873;Vorey;vorey;8773472;87734723;3.911431;45.182903;;f;FR;f;Europe/Paris;t;FRHMQ;;t;;f;8704902;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3416,7 +3416,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4554;St-Didier-en-Velay;st-didier-en-velay;8763025;87630251;4.2833330000;45.3000000000;;f;FR;f;Europe/Paris;t;FRJBU;;t;;f;8704548;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4555;St-Pal-de-Mons;st-pal-de-mons;8763024;87630244;4.2833330000;45.2333330000;;f;FR;f;Europe/Paris;t;FRJBV;;t;;f;8704630;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4556;St-Loup-sur-Semouse;st-loup-sur-semouse;8718533;87185330;6.307407;47.880997;;f;FR;f;Europe/Paris;t;FRJBW;;t;;f;8702051;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4558;Lyon St-Exupéry TGV;lyon-st-exupery-tgv;8776290;87762906;5.075822;45.720907;10799;f;FR;f;Europe/Paris;t;FRJDQ;SXA;t;JDQ;t;8702384;f;;f;JDQ;t;;f;;f;;f;;Aéroport;Airport;Flughafen;Lione Aeroporto;;;;;リヨン;리옹;;;;Лион;;;里昂
+4558;Lyon St-Exupéry TGV;lyon-st-exupery-tgv;8776290;87762906;5.075822;45.720907;10799;f;FR;f;Europe/Paris;t;FRJDQ;SXA;t;JDQ;t;8702384;f;;f;JDQ;t;;f;;f;;f;;Aéroport;Airport;Flughafen;Lione Aeroporto;Aeropuerto;;;;リヨン;리옹;;;;Лион;;;里昂
 4561;Noailles Bourg;noailles-bourg;8744499;87444992;1.5333330000;45.1000000000;;f;FR;f;Europe/Paris;f;FRJEA;;t;;f;8701683;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4562;Meymac Bourg;meymac-bourg;8745006;87450064;2.138309;45.527325;4720;f;FR;f;Europe/Paris;t;FRJEB;;t;;f;8703986;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4564;La Baule-Escoublac;la-baule-escoublac;8748175;87481754;-2.3892045021057124;47.28866138517192;4613;f;FR;t;Europe/Paris;t;FRJEE;LBE;t;;f;8700084;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Ла-Боль;;;
@@ -3474,8 +3474,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4633;L’Estaque;lestaque;8775160;87751602;5.321506;43.363846;;f;FR;f;Europe/Paris;t;FRLES;;t;;f;8701085;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4636;Lentilly—Charpenay;lentilly-charpenay;8756691;87566919;4.682391;45.8164;;f;FR;f;Europe/Paris;t;FRLFJ;CNJ;t;;f;8706456;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4638;La Flotte Port;la-flotte-port;8732194;87321943;-1.3333330000;46.1833330000;;f;FR;f;Europe/Paris;t;FRLFP;;t;;f;8704442;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4640;Bologne;bologne;;;5.1333330000;48.2000000000;;t;FR;f;Europe/Paris;f;FRLGE;;t;;f;;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;;;;
-4641;Bologne Salle des Fêtes;bologne-salle-des-fetes;8710742;87107425;5.133074;48.198254;4640;f;FR;f;Europe/Paris;t;FRLGM;;t;;f;8705025;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;;;;
+4640;Bologne;bologne;;;5.1333330000;48.2000000000;;t;FR;f;Europe/Paris;f;FRLGE;;t;;f;;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;;;;
+4641;Bologne Salle des Fêtes;bologne-salle-des-fetes;8710742;87107425;5.133074;48.198254;4640;f;FR;f;Europe/Paris;t;FRLGM;;t;;f;8705025;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;;;;
 4642;Langres Gendarmerie;langres-gendarmerie;8733812;87338129;5.3333330000;47.8666670000;5032;f;FR;f;Europe/Paris;t;FRLGG;;t;;f;8705250;f;;f;;f;;f;;f;;f;;;;;;;;;;ラングル;;;;;Лангр;;;朗格勒
 4643;Longuyon;longuyon;8719427;87194274;5.604684948921203;49.44422047673474;5693;f;FR;t;Europe/Paris;t;FRLGN;LGN;t;;f;8700070;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4644;St-Léger;st-leger;8713977;;4.07810;48.23628;;f;FR;f;Europe/Paris;t;FRLGR;;t;;f;8705075;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3523,7 +3523,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4694;Lusigny-sur-Barse;lusigny-sur-barse;;;4.2666670000;48.2500000000;;t;FR;f;Europe/Paris;f;FRLSL;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4695;Lusigny-sur-Barse RN19;lusigny-sur-barse-rn19;8727995;87279950;4.280546;48.240224;4694;f;FR;f;Europe/Paris;t;FRPAP;;t;;f;8705178;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4696;Lusigny-sur-Barse Centre;lusigny-sur-barse-centre;8721598;87215988;4.254864;48.254562;4694;f;FR;t;Europe/Paris;t;FRYSC;;t;;f;8705179;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4697;Lison;lison;8744721;87447219;-1.0503315925598145;49.22701488963452;;f;FR;f;Europe/Paris;t;FRLSN;LSN;t;;f;8700027;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;;;;
+4697;Lison;lison;8744721;87447219;-1.0503315925598145;49.22701488963452;;f;FR;f;Europe/Paris;t;FRLSN;LSN;t;;f;8700027;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;;;;
 4698;Les Sables-d’Olonne;les-sables-dolonne;8748644;87486449;-1.7812657356262205;46.49976593713438;;f;FR;f;Europe/Paris;t;FRLSO;LSO;t;;f;8700200;f;;f;;f;;f;;f;;f;;;;;;;;;;レ・サーブル＝ドロンヌ;;;;;Ле-Сабль-д’Олон;;;莱萨布勒多洛讷
 4699;Lyon St-Paul;lyon-st-paul;8772115;87721159;4.826937;45.765997;4718;f;FR;f;Europe/Paris;t;FRLSP;LSP;t;;f;8703872;f;;f;;f;;f;;f;;f;;;;;Lione;;;;;リヨン;리옹;;;;Лион;;;里昂
 4701;La Souterraine;la-souterraine;8759237;87592378;1.4924025535583496;46.23969471575138;;f;FR;f;Europe/Paris;t;FRLST;LST;t;;f;8701994;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3572,7 +3572,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4754;Montluçon Rimard;montlucon-rimard;8732367;87323675;2.61151;46.33559;4671;f;FR;f;Europe/Paris;t;FRMLR;;t;;f;8704443;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4755;Monsempron-Libos;monsempron-libos;8758645;87586453;0.9414982795715332;44.48647163960303;;f;FR;f;Europe/Paris;t;FRMLS;MLS;t;;f;8704014;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4756;Mâcon—Loché TGV;macon-loche-tgv;8772570;87725705;4.778593;46.282787;5041;f;FR;f;Europe/Paris;t;FRMLT;MLH;t;;f;8700253;f;;f;;f;;f;;f;;f;;;;;;;;;;マコン;마콩;;;;Макон;;;马孔
-4757;Marne-la-Vallée—Chessy;marne-la-vallee-chessy;8711184;87111849;2.782871;48.870269;4819;f;FR;t;Europe/Paris;t;FRMLV;MLV;t;MLV;f;8704948;f;XED;f;MLV;t;;f;;f;;f;;Disneyland Paris;Disneyland Paris;Disneyland Paris;Disneyland Paris;;;;;;;;;;;;;
+4757;Marne-la-Vallée—Chessy;marne-la-vallee-chessy;8711184;87111849;2.782871;48.870269;4819;f;FR;t;Europe/Paris;t;FRMLV;MLV;t;MLV;f;8704948;f;XED;f;MLV;t;;f;;f;;f;;Disneyland Paris;Disneyland Paris;Disneyland Paris;Disneyland Paris;Disneyland Paris;;;;;;;;;;;;
 4759;Montmélian;montmelian;8774118;87741181;6.043113470077514;45.50303840300411;;f;FR;f;Europe/Paris;t;FRMML;MML;t;;f;8700159;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4760;Mont-sur-Meurthe;mont-sur-meurthe;8714114;87141143;6.4500000000;48.5500000000;4812;f;FR;t;Europe/Paris;t;FRMMT;;t;;f;8702344;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4762;Monnaie;monnaie;;;0.7833330000;47.5000000000;;t;FR;f;Europe/Paris;f;FRMNA;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3591,7 +3591,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4779;Molsheim;molsheim;8721457;87214577;7.500293254852295;48.537156634790605;;f;FR;f;Europe/Paris;t;FRMOL;MOL;t;;f;8700394;f;;f;;f;;f;;f;;f;;;;;;;;;;モルスアイム;;;;;Мольсайм;;;莫尔塞姆
 4782;Moret—Veneux-les-Sablons;moret-veneux-les-sablons;8768227;87682278;2.799501;48.378326;;f;FR;f;Europe/Paris;t;FRMOR;MOR;t;;f;8701643;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4784;Motteville;motteville;8741128;87411280;0.8500000000;49.6333330000;;f;FR;f;Europe/Paris;t;FRMOT;;t;;f;8704063;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4785;Aéroport Marseille-Provence Bus;aeroport-marseille-provence-bus;8733749;87337493;5.237088203430176;43.44129735202746;;f;FR;f;Europe/Paris;t;FRMPA;;t;;f;8705262;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;;;;;;;;;;;;;
+4785;Aéroport Marseille-Provence Bus;aeroport-marseille-provence-bus;8733749;87337493;5.237088203430176;43.44129735202746;;f;FR;f;Europe/Paris;t;FRMPA;;t;;f;8705262;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;Aeropuerto;;;;;;;;;;;;
 4786;Montpellier St-Roch;montpellier-st-roch;8777300;87773002;3.880383968353271;43.60423079220492;22598;f;FR;f;Europe/Paris;t;FRMPL;MPL;t;MPL;t;8700097;f;;f;MPL;t;;f;;f;;f;;;;;;;;;;モンペリエ;몽펠리에;;;;Монпелье;;;蒙彼利埃
 4787;Paris-Gare-Montparnasse-3-Vaugirard;paris-gare-montparnasse-3-vaugirard;8739110;;2.315953;48.838384;4916;f;FR;f;Europe/Paris;f;FRMPV;;t;;f;8704045;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4788;Morée Salle des Fêtes;moree-salle-des-fetes;8745339;87453399;1.2333330000;47.9000000000;;f;FR;f;Europe/Paris;t;FRMRD;;t;;f;8706412;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3759,7 +3759,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4999;Précy-sous-Thil;precy-sous-thil;8700235;87002352;4.3166670000;47.3833330000;;f;FR;f;Europe/Paris;t;FRPTH;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5000;Pontarlier;pontarlier;8771500;87715003;6.353300213813782;46.90051747821962;;f;FR;f;Europe/Paris;t;FRPTL;PTL;t;;f;8700406;f;;f;;f;;f;;f;;f;;;;;;;;;;ポンタルリエ;;;;;Понтарлье;;;蓬塔尔利耶
 5001;Poitiers;poitiers;;;0.3333330000;46.5833330000;;t;FR;f;Europe/Paris;f;FRPTR;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5002;Futuroscope;futuroscope;8732409;87324095;0.37731170654296875;46.66996566437575;5001;f;FR;f;Europe/Paris;t;FRTGO;FTU;t;;f;8703726;f;;f;;f;;f;;f;;f;;à 11 km de Poitiers;10km from Poitiers;10 km von Poitiers entfernt;10km da Poitiers;;;;;;;;;;;;;
+5002;Futuroscope;futuroscope;8732409;87324095;0.37731170654296875;46.66996566437575;5001;f;FR;f;Europe/Paris;t;FRTGO;FTU;t;;f;8703726;f;;f;;f;;f;;f;;f;;à 11 km de Poitiers;10km from Poitiers;10 km von Poitiers entfernt;10km da Poitiers;a 10 km de Poitiers;;;;;;;;;;;;
 5006;Pau;pau;;;-0.3666670000;43.3000000000;;t;FR;f;Europe/Paris;f;FRPUF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5007;Pau Ville;pau-ville;8744890;87448902;-0.3707617521286011;43.29459030491233;5006;f;FR;f;Europe/Paris;t;FRUJO;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;ポー;;;;;Пау;;;
 5008;Puyoô;puyoo;8767227;87672279;-0.9108352661132812;43.524530538838874;;f;FR;f;Europe/Paris;t;FRPUO;PUO;t;;f;8700061;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3986,7 +3986,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5294;Thésée;thesee;8732819;87328195;1.312029;47.322255;;f;FR;f;Europe/Paris;t;FRTHE;;t;;f;8704710;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5295;Thiers;thiers;8773447;87734475;3.54326;45.86113;5290;f;FR;t;Europe/Paris;t;FRTHI;THI;t;;f;8702106;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;泰夫河畔蒂耶尔
 5297;Thoiry Mairie;thoiry-mairie;8755607;87556076;5.980352;46.230758;5300;f;FR;t;Europe/Paris;t;FRTHO;;t;;f;8704714;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5298;Haute-Picardie TGV;haute-picardie-tgv;8731388;87313882;2.832198143005371;49.859082553758014;;f;FR;f;Europe/Paris;t;FRTHP;HPI;t;;f;8704957;f;;f;THP;t;;f;;f;;f;;à 40 km d’Amiens et Saint-Quentin;40km from Amiens and Saint-Quentin;40km von Amiens und Saint-Quentin entfernt;40km da Amiens e Saint-Quentin;;;;;;;;;;;;;
+5298;Haute-Picardie TGV;haute-picardie-tgv;8731388;87313882;2.832198143005371;49.859082553758014;;f;FR;f;Europe/Paris;t;FRTHP;HPI;t;;f;8704957;f;;f;THP;t;;f;;f;;f;;à 40 km d’Amiens et Saint-Quentin;40km from Amiens and Saint-Quentin;40km von Amiens und Saint-Quentin entfernt;40km da Amiens e Saint-Quentin;a 40 km de Amiens y Saint-Quentin;;;;;;;;;;;;
 5299;Thouars;thouars;8748700;87487009;-0.209799;46.985204;;f;FR;f;Europe/Paris;t;FRTHR;;t;;f;8704717;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Туар;;;圖阿爾
 5300;Thoiry;thoiry;;;;;;t;FR;f;Europe/Paris;f;FRTHV;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5304;Toulon;toulon;8775500;87755009;5.929599;43.128409;;f;FR;f;Europe/Paris;t;FRTLN;TLN;t;TLN;t;8700108;f;;f;;f;8775500;t;;f;;f;;;;;Tolone;Tolón;;;;トゥーロン;툴롱;;Tulon;;Тулон;;;土伦
@@ -4016,7 +4016,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5333;Toutry;toutry;8713999;87139998;4.115225;47.503253;;f;FR;f;Europe/Paris;t;FRTRY;;t;;f;8705104;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5334;Troyes Delestraint Belgique;troyes-delestraint-belgique;8713965;87139659;4.07392680644989;48.2883687684885;5342;f;FR;f;Europe/Paris;t;FRTSA;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5335;Genève;geneve;8585444;;;;;t;CH;f;Europe/Paris;f;FRTTX;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5336;Genève Cornavin;geneve-cornavin;8501008;85010082;6.142428;46.210208;5335;f;CH;t;Europe/Zurich;t;CHGVA;;t;;f;8501008;t;XGC;t;;f;8501008;t;;f;;f;;;Geneva Main station;Genf Hauptbahnhof;Ginevra Stazione centrale;Ginebra;Ženeva;;Genf;ジュネーヴ;제네바;;Genewa;Genebra;Женева;;Cenevre;日内瓦
+5336;Genève Cornavin;geneve-cornavin;8501008;85010082;6.142428;46.210208;5335;f;CH;t;Europe/Zurich;t;CHGVA;;t;;f;8501008;t;XGC;t;;f;8501008;t;;f;;f;;;Geneva Main station;Genf Hauptbahnhof;Ginevra Stazione centrale;Ginebra Estación central;Ženeva;;Genf;ジュネーヴ;제네바;;Genewa;Genebra;Женева;;Cenevre;日内瓦
 5337;Genève;geneve;8585440;;;;5335;f;CH;f;Europe/Zurich;f;CHAFH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5338;Tours;tours;;;;;;t;FR;f;Europe/Paris;f;FRTUF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5339;La Tuque;la-tuque;8713435;87134353;0.656392;44.139966;;f;FR;f;Europe/Paris;t;FRTUQ;;t;;f;8705049;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4084,7 +4084,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5407;Renneville;renneville;8744357;87443572;1.7230618000030518;43.38003708644065;;f;FR;f;Europe/Paris;t;FRUHM;;t;;f;8705980;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5408;Villefranche-de-Lauragais Église;villefranche-de-lauragais-eglise;8744358;87443580;1.70475;43.398931;;f;FR;f;Europe/Paris;t;FRUHN;;t;;f;8705981;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5409;Villefranche-de-Lauragais Collège;villefranche-de-lauragais-college;8744359;87443598;1.699554;43.409565;;f;FR;f;Europe/Paris;t;FRUHO;;t;;f;8705982;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5410;St-Rome;st-rome;8744360;87443606;1.6845130920410156;43.42195172684425;;f;FR;f;Europe/Paris;t;FRUHP;;t;;f;8705983;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;;;;
+5410;St-Rome;st-rome;8744360;87443606;1.6845130920410156;43.42195172684425;;f;FR;f;Europe/Paris;t;FRUHP;;t;;f;8705983;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;;;;
 5411;Villenouvelle Vieille Halle;villenouvelle-vieille-halle;8744686;87446864;1.651686;43.440218;;f;FR;f;Europe/Paris;t;FRUHQ;;t;;f;8705984;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5412;Rivières;rivieres;8744284;87442848;1.9666670000;43.9166670000;;f;FR;f;Europe/Paris;t;FRUHR;;t;;f;8706042;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5413;Ayguesvives—Ticaille;ayguesvives-ticaille;8744361;87443614;1.60274;43.44972;;f;FR;f;Europe/Paris;t;FRUHS;;t;;f;8705985;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4408,7 +4408,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5786;Ste-Feyre;ste-feyre;8744500;87445007;1.925321817398071;46.140102683330724;;f;FR;f;Europe/Paris;t;FRXJK;;t;;f;8704670;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5788;St-Jean-de-Luz—Ciboure;st-jean-de-luz-ciboure;8767712;87677120;-1.661107;43.385825;;f;FR;f;Europe/Paris;t;FRXJZ;SJZ;t;XJZ;t;8700109;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5790;Landerneau;landerneau;8747423;87474239;-4.2563652992248535;48.453883478155966;;f;FR;f;Europe/Paris;t;FRXLD;LDO;t;XLD;t;8700453;f;;f;;f;;f;;f;;f;;;;;;;;;;ランデルノー;;;;;;;;朗代尔诺
-5791;Lens;lens;8734502;87345025;2.8282284736633296;50.426784045124485;;f;FR;f;Europe/Paris;t;FRXLE;LNS;t;;f;8700244;f;;f;;f;;f;;f;;f;;;France;Frankreich;Francia;;;;;ランス;;;;;;;;
+5791;Lens;lens;8734502;87345025;2.8282284736633296;50.426784045124485;;f;FR;f;Europe/Paris;t;FRXLE;LNS;t;;f;8700244;f;;f;;f;;f;;f;;f;;;France;Frankreich;Francia;Francia;;;;ランス;;;;;;;;
 5792;Luchon;luchon;8761123;87611236;0.5965662002563477;42.79727431598283;;f;FR;f;Europe/Paris;t;FRXLH;LUC;t;;f;8703852;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5793;Lons-le-Saunier;lons-le-saunier;8771823;87718239;5.551185607910156;46.66846377007404;;f;FR;f;Europe/Paris;t;FRXLL;LLS;t;;f;8700189;f;;f;;f;;f;;f;;f;;;;;;;;;;ロン＝ル＝ソーニエ;;;;;Лон-ле-Сонье;;;隆勒索涅
 5794;Laon;laon;8729601;87296012;3.6237716674804688;49.5709975971829;;f;FR;f;Europe/Paris;t;FRXLN;LAO;t;;f;8700252;f;;f;;f;;f;;f;;f;;;;;;;;;;ラン;랑;;;;Лан;;;拉昂
@@ -4464,7 +4464,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5845;Auray;auray;8747620;87476200;-2.999417781829834;47.68021184001663;;f;FR;f;Europe/Paris;t;FRXUY;ARY;t;XUY;t;8700206;f;;f;;f;;f;;f;;f;;;;;;;;;;オーレー;오레;;;;Оре;;;
 5846;Vendôme;vendome;;;;;;t;FR;f;Europe/Paris;f;FRXVD;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5847;Villefranche-sur-Saône;villefranche-sur-saone;8772133;87721332;4.721143;45.98448;;f;FR;f;Europe/Paris;t;FRXVF;VIS;t;;f;8702170;f;;f;;f;;f;;f;;f;;;;;;Villefranche sobre Saona;;;;ヴィルフランシュ＝シュル＝ソーヌ;;;;;Вильфранш-сюр-Сон;;;
-5848;Vienne;vienne;8772258;87722587;4.8744;45.521023;;f;FR;f;Europe/Paris;t;FRXVI;VIE;t;;f;8700095;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;Вьенн;;;
+5848;Vienne;vienne;8772258;87722587;4.8744;45.521023;;f;FR;f;Europe/Paris;t;FRXVI;VIE;t;;f;8700095;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;Francia;;;;;;;;;Вьенн;;;
 5849;Buxières-Les-Villiers;buxieres-les-villiers;8721522;87215228;5.0333330000;48.1000000000;;f;FR;f;Europe/Paris;t;FRXVL;;t;;f;8705159;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5850;Verdun;verdun;8717577;87175778;5.379163;49.165475;;f;FR;f;Europe/Paris;t;FRXVN;;t;;f;8700523;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5851;Vesoul;vesoul;8718500;87185009;6.152037;47.617541;;f;FR;f;Europe/Paris;t;FRXVO;VES;t;;f;8700385;f;;f;;f;;f;;f;;f;;;;;;;;;;ヴズー;;;;;Везуль;;;沃苏勒
@@ -4493,8 +4493,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5884;Berthelming Mairie;berthelming-mairie;8747756;;7.0000000000;48.8166670000;;f;FR;f;Europe/Paris;t;FRZHB;;t;;f;8706467;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5890;Zornhoff;zornhoff;;;;;;t;FR;f;Europe/Paris;f;FRZNF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5892;London St-Pancras;london-st-pancras;7015400;70154005;-0.1263610000;51.5319210000;8267;f;GB;t;Europe/London;t;GBSPX;;t;;f;7004428;t;;f;;f;;f;;f;;f;;Londres;;;Londra;Londres;Londýn;;;ロンドン;런던;Londen;Londyn;Londres;Лондон;;Londra;伦敦
-5893;Bruxelles-Midi;bruxelles-midi;8814001;88140010;4.335695;50.835374;5974;f;BE;t;Europe/Brussels;t;BEBMI;;t;;f;8800004;t;ZYR;t;;f;;f;;f;;f;;;Brussels South Station;Brüssel Südbahnhof;Stazione Sud;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
-5894;Amsterdam-Centraal;amsterdam-centraal;8400058;84000588;4.899426;52.37919;8657;f;NL;t;Europe/Amsterdam;t;NLAMA;;t;;f;8400058;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;;;;Amszterdam;アムステルダム;암스테르담;;;Amesterdão;Амстердам;;;阿姆斯特丹
+5893;Bruxelles-Midi;bruxelles-midi;8814001;88140010;4.335695;50.835374;5974;f;BE;t;Europe/Brussels;t;BEBMI;;t;;f;8800004;t;ZYR;t;;f;;f;;f;;f;;;Brussels South Station;Brüssel Südbahnhof;Stazione Sud;Bruselas Estación sur;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+5894;Amsterdam-Centraal;amsterdam-centraal;8400058;84000588;4.899426;52.37919;8657;f;NL;t;Europe/Amsterdam;t;NLAMA;;t;;f;8400058;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;Estación central;;;Amszterdam;アムステルダム;암스테르담;;;Amesterdão;Амстердам;;;阿姆斯特丹
 5901;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5902;Soignies;soignies;8883113;;4.069281;50.573177;;f;BE;f;Europe/Brussels;f;BEAAB;;f;;f;8800144;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5903;Tubize;tubize;8883808;;4.205693;50.691834;;f;BE;f;Europe/Brussels;f;BEAAC;;f;;f;8800402;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4523,7 +4523,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5926;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5927;La Louvière Centre;la-louviere-centre;8882107;;;;;f;BE;f;Europe/Brussels;f;BEABA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5928;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5929;Antwerpen-Centraal;antwerpen-centraal;8821006;88210060;4.42100465297699;51.21552672202654;5964;f;BE;t;Europe/Brussels;t;BEABC;;t;;f;8800007;t;XAN;t;;f;;f;;f;;f;;Anvers Gare centrale;Antwerp Main station;Hauptbahnhof;Anversa Stazione centrale;;;;;;;;;;;;;
+5929;Antwerpen-Centraal;antwerpen-centraal;8821006;88210060;4.42100465297699;51.21552672202654;5964;f;BE;t;Europe/Brussels;t;BEABC;;t;;f;8800007;t;XAN;t;;f;;f;;f;;f;;Anvers Gare centrale;Antwerp Main station;Hauptbahnhof;Anversa Stazione centrale;Estación central;;;;;;;;;;;;
 5930;Zeebrugge;zeebrugge;8891553;;;;;f;BE;f;Europe/Brussels;f;BEABD;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5931;Waregem;waregem;8896149;;3.425303;50.890855;;f;BE;f;Europe/Brussels;f;BEABE;;f;;f;8800092;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5932;Torhout;torhout;8891314;;3.105656;51.064455;;f;BE;f;Europe/Brussels;f;BEABF;;f;;f;8800087;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4539,7 +4539,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5942;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5943;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5944;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5945;Bruxelles-National-Aéroport;bruxelles-national-aeroport;8819406;;4.483022689819336;50.8985400058829;5974;f;BE;f;Europe/Brussels;t;BEABT;;t;;f;8800043;t;;f;;f;;f;;f;;f;;;Brussels Airport;Brüssel Flughafen;Aeroporto;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+5945;Bruxelles-National-Aéroport;bruxelles-national-aeroport;8819406;;4.483022689819336;50.8985400058829;5974;f;BE;f;Europe/Brussels;t;BEABT;;t;;f;8800043;t;;f;;f;;f;;f;;f;;;Brussels Airport;Brüssel Flughafen;Aeroporto;Bruselas Aeropuerto;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 5946;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5947;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5948;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4887,7 +4887,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6291;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6292;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6293;Boncourt;boncourt;8500128;;7.016763;47.493212;;f;CH;f;Europe/Zurich;f;CHBCT;;f;;f;8500128;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6294;Burgdorf;burgdorf;8508005;;7.6216920000;47.0607050000;;f;CH;f;Europe/Zurich;t;CHBDF;;f;;f;8508005;t;;f;;f;8508005;t;;f;;f;;Berthoud, Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;Бургдорф;;;布格多夫
+6294;Burgdorf;burgdorf;8508005;;7.6216920000;47.0607050000;;f;CH;f;Europe/Zurich;t;CHBDF;;f;;f;8508005;t;;f;;f;8508005;t;;f;;f;;Berthoud, Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;Бургдорф;;;布格多夫
 6295;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6296;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6297;Brügg;brugg;8500309;;8.2088320000;47.4808510000;;f;CH;f;Europe/Zurich;t;CHBGG;;f;;f;8500309;t;;f;;f;;f;;f;;f;;;;;;;;;;;브루그;;;;Брюгг;;;布魯格
@@ -4913,7 +4913,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6317;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6318;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6319;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6320;Genève Aéroport;geneve-aeroport;8501026;;6.112098;46.232376;5335;f;CH;f;Europe/Zurich;f;CHGAE;;f;;f;8501026;t;;f;;f;;f;;f;;f;;;Geneva Airport;Genf Flughafen;Ginevra Aeroporto;;;;;;;;;;;;;
+6320;Genève Aéroport;geneve-aeroport;8501026;;6.112098;46.232376;5335;f;CH;f;Europe/Zurich;f;CHGAE;;f;;f;8501026;t;;f;;f;;f;;f;;f;;;Geneva Airport;Genf Flughafen;Ginevra Aeroporto;Ginebra Aeropuerto;;;;;;;;;;;;
 6321;Glovelier;glovelier;8500123;;7.209276;47.335226;;f;CH;f;Europe/Zurich;f;CHGLV;;f;;f;8500123;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6322;Guemmenen;guemmenen;8504486;;;;;f;CH;f;Europe/Zurich;f;CHGMN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6323;Grimentz Poste;grimentz-poste;8501768;;;;;f;CH;f;Europe/Zurich;f;CHGMZ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5313,7 +5313,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6723;Landau (Isar);landau-isar;8026420;;12.69506;48.682889;;f;DE;f;Europe/Berlin;t;DEABD;;f;;f;8003506;t;;f;;f;;f;;f;;f;;;;;;;;;;;;Landau in der Pfalz;;;Ландау-на-Изаре;;;伊萨尔河畔兰道
 6724;;;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6725;Mechernich;mechernich;8015431;;6.642506;50.591416;;f;DE;f;Europe/Berlin;t;DEABF;;f;;f;8003927;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6726;Aschaffenburg Hbf;aschaffenburg-hbf;8022609;;9.143692;49.980554;;f;DE;f;Europe/Berlin;t;DEABG;;f;;f;8000010;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;アシャッフェンブルク;아샤펜부르크;;;;Ашаффенбург;;;阿沙芬堡
+6726;Aschaffenburg Hbf;aschaffenburg-hbf;8022609;;9.143692;49.980554;;f;DE;f;Europe/Berlin;t;DEABG;;f;;f;8000010;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;アシャッフェンブルク;아샤펜부르크;;;;Ашаффенбург;;;阿沙芬堡
 6727;Allensbach;allensbach;8014581;;9.068228;47.714886;;f;DE;f;Europe/Berlin;t;DEABH;;f;;f;8000496;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6728;Morsum Bahnhof;morsum-bahnhof;;;8.431917;54.872007;;f;DE;f;Europe/Berlin;f;DEABI;;f;;f;8007777;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6729;Munster (Örtze);munster-ortze;8013643;;10.096072;52.993423;;f;DE;f;Europe/Berlin;t;DEABJ;;f;;f;8004183;t;;f;;f;;f;;f;;f;;;;;;;;;;ミュンスター;뮌스터;;;;Мюнстер;;;明斯特
@@ -5397,7 +5397,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6807;Bayerisch Gmain;bayerisch-gmain;8020103;;12.89507;47.720378;;f;DE;f;Europe/Berlin;t;DEAEK;;f;;f;8000831;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6808;Blaufelden;blaufelden;8029722;;9.967679;49.296232;;f;DE;f;Europe/Berlin;t;DEAEL;;f;;f;8001014;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6809;Bad Bentheim;bad-bentheim;8021156;;7.158541;52.309848;;f;DE;f;Europe/Berlin;t;DEAEM;;f;;f;8000879;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6810;Berchtesgaden Hbf;berchtesgaden-hbf;8020097;;12.999058;47.626683;;f;DE;f;Europe/Berlin;t;DEAEN;;f;;f;8000885;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ベルヒテスガーデン;베르히테스가덴;;;;Берхтесгаден;;;贝希特斯加登
+6810;Berchtesgaden Hbf;berchtesgaden-hbf;8020097;;12.999058;47.626683;;f;DE;f;Europe/Berlin;t;DEAEN;;f;;f;8000885;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ベルヒテスガーデン;베르히테스가덴;;;;Берхтесгаден;;;贝希特斯加登
 6811;Burg (Dithm);burg-dithm;8001504;;9.247679;54.007802;;f;DE;f;Europe/Berlin;t;DEAEO;;f;;f;8001273;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6812;Bestwig;bestwig;8008518;;8.397839;51.361908;;f;DE;f;Europe/Berlin;t;DEAEP;;f;;f;8000927;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6813;Bad Steben;bad-steben;8026021;;11.646765;50.365094;;f;DE;f;Europe/Berlin;t;DEAEQ;;f;;f;8000756;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5434,12 +5434,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6844;Bergen (Oberbay);bergen-oberbay;8020143;;12.592844;47.825273;;f;DE;f;Europe/Berlin;t;DEAFV;;f;;f;8000888;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6845;Coburg;coburg;8022803;;10.957374;50.263094;;f;DE;f;Europe/Berlin;t;DEAFW;;f;;f;8001338;t;;f;;f;;f;;f;;f;;Cobourg;;;Coburgo;Coburgo;;;;コーブルク;;;Powiat Coburg;Coburgo;Кобург;;;科堡
 6846;Calw;calw;8029473;;8.742027;48.714729;;f;DE;f;Europe/Berlin;t;DEAFX;;f;;f;8000063;t;;f;;f;;f;;f;;f;;;;;;;;;;カルフ;;;;;Кальв;;;卡尔夫
-6847;Castrop-Rauxel Hbf;castrop-rauxel-hbf;8010036;;7.304562;51.573694;;f;DE;f;Europe/Berlin;t;DEAFY;;f;;f;8001327;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+6847;Castrop-Rauxel Hbf;castrop-rauxel-hbf;8010036;;7.304562;51.573694;;f;DE;f;Europe/Berlin;t;DEAFY;;f;;f;8001327;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 6848;Calmbach Bahnhof;calmbach-bahnhof;8029457;;8.571133;48.776485;;f;DE;f;Europe/Berlin;t;DEAFZ;;f;;f;8001320;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6849;Cham (Oberpf);cham-oberpf;8026249;;12.656829;49.221864;;f;DE;f;Europe/Berlin;t;DEAGA;;f;;f;8001330;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6850;Augsburg Hbf;augsburg-hbf;8002140;;10.885568;48.365444;;f;DE;f;Europe/Berlin;t;DEAGB;;t;;f;8000013;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Augsburgo;;;;アウクスブルク;아우크스부르크;;;Augsburgo;Аугсбург;;;奥格斯堡
+6850;Augsburg Hbf;augsburg-hbf;8002140;;10.885568;48.365444;;f;DE;f;Europe/Berlin;t;DEAGB;;t;;f;8000013;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Augsburgo Estación central;;;;アウクスブルク;아우크스부르크;;;Augsburgo;Аугсбург;;;奥格斯堡
 6851;Öhringen-Cappel;ohringen-cappel;8001594;;9.526686;49.201917;;f;DE;f;Europe/Berlin;t;DEAGC;;f;;f;8004620;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6852;Deggendorf Hbf;deggendorf-hbf;8026450;;12.949725;48.839436;;f;DE;f;Europe/Berlin;t;DEAGD;;f;;f;8001397;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Деггендорф;;;德根多尔夫
+6852;Deggendorf Hbf;deggendorf-hbf;8026450;;12.949725;48.839436;;f;DE;f;Europe/Berlin;t;DEAGD;;f;;f;8001397;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Деггендорф;;;德根多尔夫
 6853;Derneburg (Han);derneburg-han;8013377;;10.143715;52.096848;;f;DE;f;Europe/Berlin;t;DEAGE;;f;;f;8000071;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6854;Detmold;detmold;8013460;;8.872568;51.940814;;f;DE;f;Europe/Berlin;t;DEAGF;;f;;f;8001420;t;;f;;f;;f;;f;;f;;;;;;;;;;デトモルト;데트몰트;;;;Детмольд;;;代特莫尔德
 6855;Diez;diez;8019612;;8.019618;50.370128;;f;DE;f;Europe/Berlin;t;DEAGG;;f;;f;8001457;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5472,7 +5472,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6882;Erkrath;erkrath;8008085;;6.902412;51.220454;;f;DE;f;Europe/Berlin;t;DEAHH;;f;;f;8001841;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Эркрат;;;埃尔克拉特
 6883;Erlangen;erlangen;8022163;;11.001906;49.595896;;f;DE;f;Europe/Berlin;t;DEAHI;;f;;f;8001844;t;;f;;f;;f;;f;;f;;;;;;;;;;エアランゲン;에를랑겐;;;;Эрланген;;;埃尔朗根
 6884;Erzingen (Baden);erzingen-baden;8014481;;8.430119;47.659539;;f;DE;f;Europe/Berlin;t;DEAHJ;;f;;f;8001865;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6885;Eschweiler Hbf;eschweiler-hbf;8015336;;6.251934;50.81353;;f;DE;f;Europe/Berlin;t;DEAHK;;f;;f;8001886;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;エシュヴァイラー;에슈바일러;;;;Эшвайлер;;;埃施韦勒
+6885;Eschweiler Hbf;eschweiler-hbf;8015336;;6.251934;50.81353;;f;DE;f;Europe/Berlin;t;DEAHK;;f;;f;8001886;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;エシュヴァイラー;에슈바일러;;;;Эшвайлер;;;埃施韦勒
 6886;Esens (Ostfriesl);esens-ostfriesl;8021445;;7.616209;53.636215;;f;DE;f;Europe/Berlin;t;DEAHL;;f;;f;8001890;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6887;Essen-Altenessen;essen-altenessen;8010158;;7.007199;51.484305;;f;DE;f;Europe/Berlin;t;DEAHM;;f;;f;8001900;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6888;Euerdorf;euerdorf;8022552;;10.027305;50.149245;;f;DE;f;Europe/Berlin;t;DEAHN;;f;;f;8001935;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5492,11 +5492,11 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6902;Fischen;fischen;8002379;;10.271712;47.45659;;f;DE;f;Europe/Berlin;t;DEAIB;;f;;f;8001995;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6903;Flensburg;flensburg;8001427;;9.436884;54.774088;;f;DE;f;Europe/Berlin;t;DEAIC;;f;;f;8000103;t;;f;;f;;f;;f;;f;;Flensbourg;;;Flensburgo;Flensburgo;;Flensborg;;フレンスブルク;플렌스부르크;;;;Фленсбург;;;弗伦斯堡
 6904;Freising;freising;8020487;;11.744541;48.395198;;f;DE;f;Europe/Berlin;t;DEAID;;f;;f;8002078;t;;f;;f;;f;;f;;f;;;;;Frisinga;Frisinga;;;;フライジング;프라이징;;Fryzynga;Frisinga;Фрайзинг;;;弗赖辛
-6906;Frankenthal Hbf;frankenthal-hbf;8019073;;8.349702;49.53557;;f;DE;f;Europe/Berlin;t;DEAIF;;f;;f;8000332;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Франкенталь;;;弗兰肯塔尔
+6906;Frankenthal Hbf;frankenthal-hbf;8019073;;8.349702;49.53557;;f;DE;f;Europe/Berlin;t;DEAIF;;f;;f;8000332;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Франкенталь;;;弗兰肯塔尔
 6907;Fröndenberg;frondenberg;8008205;;7.763039;51.47119;;f;DE;f;Europe/Berlin;t;DEAIG;;f;;f;8000113;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6908;Sigmaringen;sigmaringen;8029254;;9.221853;48.086985;;f;DE;f;Europe/Berlin;t;DEAIH;;f;;f;8000069;t;;f;;f;;f;;f;;f;;;;;;Sigmaringa;;;;;;;;;Зигмаринген;;;西格马林根
 6909;Friedrichssegen;friedrichssegen;8019599;;7.650665;50.311869;;f;DE;f;Europe/Berlin;t;DEAII;;f;;f;8002114;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6910;Freudenstadt Hbf;freudenstadt-hbf;8029492;;8.428807;48.460325;7606;f;DE;f;Europe/Berlin;t;DEAIJ;;f;;f;8000110;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+6910;Freudenstadt Hbf;freudenstadt-hbf;8029492;;8.428807;48.460325;7606;f;DE;f;Europe/Berlin;t;DEAIJ;;f;;f;8000110;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 6911;Freudenstadt Stadt;freudenstadt-stadt;8029493;;8.410649;48.467777;7606;f;DE;f;Europe/Berlin;t;DEAIK;;f;;f;8002091;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6912;Friedberg (Hess);friedberg-hess;8011379;;8.762055;50.332607;;f;DE;f;Europe/Berlin;t;DEAIL;;f;;f;8000111;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6913;Feldberg-Bärental;feldberg-barental;8014376;;8.098292;47.871442;;f;DE;f;Europe/Berlin;t;DEAIM;;f;;f;8001971;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5507,7 +5507,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6918;Frankfurt (Main) West;frankfurt-main-west;8011124;;8.639334;50.118862;;f;DE;f;Europe/Berlin;t;DEAIR;;f;;f;8002042;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 6919;Gaggenau Bf;gaggenau-bf;8014254;;8.319975;48.805772;;f;DE;f;Europe/Berlin;t;DEAIS;;f;;f;8002167;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6920;Geldern;geldern;8015025;;6.319335;51.513287;;f;DE;f;Europe/Berlin;t;DEAIT;;f;;f;8002222;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6921;Hannover Hbf;hannover-hbf;8013547;;9.741016;52.376763;7623;f;DE;f;Europe/Berlin;t;DEAIU;;f;;f;8000152;t;;f;;f;;f;;f;;f;;Hanovre Gare centrale;Hanover Main station;;Stazione centrale;Hanóver;;;;ハノーファー;하노버;;Hanower;Hanôver;Ганновер;;;汉诺威
+6921;Hannover Hbf;hannover-hbf;8013547;;9.741016;52.376763;7623;f;DE;f;Europe/Berlin;t;DEAIU;;f;;f;8000152;t;;f;;f;;f;;f;;f;;Hanovre Gare centrale;Hanover Main station;;Stazione centrale;Hanóver Estación central;;;;ハノーファー;하노버;;Hanower;Hanôver;Ганновер;;;汉诺威
 6922;Gerolstein;gerolstein;8025037;;6.660368;50.224009;;f;DE;f;Europe/Berlin;t;DEAIV;;f;;f;8000123;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6923;Gernsbach Bf;gernsbach-bf;8014256;;8.336712;48.768305;;f;DE;f;Europe/Berlin;t;DEAIW;;f;;f;8002248;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6924;Geseke;geseke;8010363;;8.510294;51.64523;;f;DE;f;Europe/Berlin;t;DEAIX;;f;;f;8002262;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гезеке;;;格塞克
@@ -5548,7 +5548,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6959;Herborn (Dillkr);herborn-dillkr;8011573;;8.308136;50.6844;;f;DE;f;Europe/Berlin;t;DEAKG;;f;;f;8000161;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6960;Haste;haste;8013569;;9.388495;52.379334;;f;DE;f;Europe/Berlin;t;DEAKH;;f;;f;8002634;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6961;Herzogenrath;herzogenrath;8015190;;6.094488;50.870917;;f;DE;f;Europe/Berlin;t;DEAKI;;f;;f;8002806;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6962;Hildesheim Hbf;hildesheim-hbf;8013413;;9.953494;52.160627;;f;DE;f;Europe/Berlin;t;DEAKJ;;f;;f;8000169;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ヒルデスハイム;힐데스하임;;;;Хильдесхайм;;;希尔德斯海姆
+6962;Hildesheim Hbf;hildesheim-hbf;8013413;;9.953494;52.160627;;f;DE;f;Europe/Berlin;t;DEAKJ;;f;;f;8000169;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ヒルデスハイム;힐데스하임;;;;Хильдесхайм;;;希尔德斯海姆
 6963;Hinterzarten;hinterzarten;8014372;;8.106256;47.906329;;f;DE;f;Europe/Berlin;t;DEAKK;;f;;f;8002848;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6964;Hirschau;hirschau;8026195;;;;;f;DE;f;Europe/Berlin;f;DEAKL;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6965;Höfen (Enz) Bf;hofen-enz-bf;8029458;;8.581039;48.798562;;f;DE;f;Europe/Berlin;t;DEAKM;;f;;f;8002891;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5575,10 +5575,10 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6986;Gifhorn;gifhorn;8013020;;10.545281;52.456156;;f;DE;f;Europe/Berlin;t;DEALH;;f;;f;8000185;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6987;Ibbenbüren;ibbenburen;8021162;;7.721482;52.276866;;f;DE;f;Europe/Berlin;t;DEALI;;f;;f;8003036;t;;f;;f;;f;;f;;f;;;Ibbenbueren;;;;;;;;;;;;Иббенбюрен;;;伊本比伦
 6988;Illertissen;illertissen;8002241;;10.099938;48.22283;;f;DE;f;Europe/Berlin;t;DEALJ;;f;;f;8003057;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6989;Ingolstadt Hbf;ingolstadt-hbf;8020424;;11.437335;48.744537;;f;DE;f;Europe/Berlin;t;DEALK;;f;;f;8000183;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;インゴルシュタット;;;;;Ингольштадт;;;
+6989;Ingolstadt Hbf;ingolstadt-hbf;8020424;;11.437335;48.744537;;f;DE;f;Europe/Berlin;t;DEALK;;f;;f;8000183;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;インゴルシュタット;;;;;Ингольштадт;;;
 6990;Itzehoe;itzehoe;8001494;;9.510389;53.923384;;f;DE;f;Europe/Berlin;t;DEALL;;f;;f;8003102;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6991;Immensen-Arpke;immensen-arpke;8013028;;10.084476;52.391353;;f;DE;f;Europe/Berlin;t;DEALM;;f;;f;8003064;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6992;Passau Hbf;passau-hbf;8000460;;13.450775;48.573634;;f;DE;f;Europe/Berlin;t;DEALN;;f;;f;8000298;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Pasov;;;パッサウ;파사우;;Pasawa;;Пассау;;;帕绍
+6992;Passau Hbf;passau-hbf;8000460;;13.450775;48.573634;;f;DE;f;Europe/Berlin;t;DEALN;;f;;f;8000298;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;Pasov;;;パッサウ;파사우;;Pasawa;;Пассау;;;帕绍
 6993;Jever;jever;8021669;;7.892978;53.568715;;f;DE;f;Europe/Berlin;t;DEALO;;f;;f;8003124;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6994;Salzburg;salzburg;8020060;;;;;f;DE;f;Europe/Berlin;f;DEALP;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6995;Jodbad sulzbrunn;jodbad-sulzbrunn;8002315;;;;;f;DE;f;Europe/Berlin;f;DEALQ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5630,7 +5630,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7041;Ibbenbüren-Laggenbeck;ibbenburen-laggenbeck;8021163;;7.780963;52.264857;;f;DE;f;Europe/Berlin;t;DEANK;;f;;f;8003491;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7042;Lahr (Schwarzw);lahr-schwarzw;8014319;;7.834737;48.340436;;f;DE;f;Europe/Berlin;t;DEANL;;f;;f;8003494;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Лар;;;拉爾
 7043;Laufen (Oberbay);laufen-oberbay;8020116;;12.922362;47.933656;;f;DE;f;Europe/Berlin;t;DEANM;;f;;f;8003584;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7044;Landshut (Bay) Hbf;landshut-bay-hbf;8026353;;12.135931;48.547494;;f;DE;f;Europe/Berlin;t;DEANN;;f;;f;8000217;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ランツフート;란츠후트;;;;Ландсхут;;;兰茨胡特
+7044;Landshut (Bay) Hbf;landshut-bay-hbf;8026353;;12.135931;48.547494;;f;DE;f;Europe/Berlin;t;DEANN;;f;;f;8000217;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ランツフート;란츠후트;;;;Ландсхут;;;兰茨胡特
 7045;Langelsheim;langelsheim;8013401;;10.343177;51.930116;;f;DE;f;Europe/Berlin;t;DEANO;;f;;f;8003522;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7046;Langenargen;langenargen;8029168;;9.544836;47.599491;;f;DE;f;Europe/Berlin;t;DEANP;;f;;f;8003524;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Лангенарген;;;兰格纳尔格恩
 7047;Langenau (Württ);langenau-wurtt;8029712;;10.125988;48.493333;;f;DE;f;Europe/Berlin;t;DEANQ;;f;;f;8003525;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5650,7 +5650,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7061;Linz (Rhein);linz-rhein;8019482;;7.27603;50.569338;;f;DE;f;Europe/Berlin;t;DEAOE;;f;;f;8003708;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7062;Lippstadt;lippstadt;8010366;;8.348785;51.670688;;f;DE;f;Europe/Berlin;t;DEAOF;;f;;f;8000571;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Липпштадт;;;利普施塔特
 7063;Löhne (Westf);lohne-westf;8013588;;8.713495;52.196656;;f;DE;f;Europe/Berlin;t;DEAOG;;f;;f;8000233;t;;f;;f;;f;;f;;f;;;;;;;;;;レーネ;;;;;Лёне;;;勒讷
-7064;Lörrach Hbf;lorrach-hbf;8014441;;7.665416;47.614054;;f;DE;f;Europe/Berlin;t;DEAOH;;f;;f;8003729;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Лёррах;;;罗拉赫
+7064;Lörrach Hbf;lorrach-hbf;8014441;;7.665416;47.614054;;f;DE;f;Europe/Berlin;t;DEAOH;;f;;f;8003729;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Лёррах;;;罗拉赫
 7065;Lohr Bahnhof;lohr-bahnhof;8022602;;9.580712;50.004411;;f;DE;f;Europe/Berlin;t;DEAOI;;f;;f;8003740;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7066;Lorch (Rhein);lorch-rhein;8011003;;7.812839;50.040296;;f;DE;f;Europe/Berlin;t;DEAOJ;;f;;f;8003751;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7067;Ludwigsburg;ludwigsburg;8029017;;9.18542;48.891861;;f;DE;f;Europe/Berlin;t;DEAOK;;f;;f;8000235;t;;f;;f;;f;;f;;f;;Ludwigsbourg;;;;Luisburgo;;;;ルートヴィヒスブルク;;;;Ludwigsburgo;Людвигсбург;;;路德维希堡
@@ -5666,7 +5666,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7077;Lübeck-Travemünde Strand;lubeck-travemunde-strand;8001677;;10.875931;53.964636;;f;DE;f;Europe/Berlin;t;DEAOU;;f;;f;8003778;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7078;Löwental;lowental;8029159;;9.499242;47.6614;;f;DE;f;Europe/Berlin;t;DEAOV;;f;;f;8003733;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7079;Lüneburg;luneburg;8001173;;10.419891;53.249652;;f;DE;f;Europe/Berlin;t;DEAOW;;f;;f;8000238;t;;f;;f;;f;;f;;f;;Lunebourg;;;Luneburgo;Luneburgo;;;;リューネブルク;뤼네부르크;;;Luneburgo;Люнебург;;;吕讷堡
-7080;Lünen Hbf;lunen-hbf;8010098;;7.529481;51.61713;;f;DE;f;Europe/Berlin;t;DEAOX;;f;;f;8000239;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;リューネン;뤼넨;;;;Люнен;;;吕嫩
+7080;Lünen Hbf;lunen-hbf;8010098;;7.529481;51.61713;;f;DE;f;Europe/Berlin;t;DEAOX;;f;;f;8000239;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;リューネン;뤼넨;;;;Люнен;;;吕嫩
 7081;Ludwigshafen (Bodensee);ludwigshafen-bodensee;8014597;;9.053189;47.815655;;f;DE;f;Europe/Berlin;t;DEAOY;;f;;f;8003764;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7082;Leverkusen-Schlebusch;leverkusen-schlebusch;8008187;;7.015127;51.031618;;f;DE;f;Europe/Berlin;t;DEAOZ;;f;;f;8003669;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7083;Leverkusen Mitte;leverkusen-mitte;8008189;;6.991657;51.03151;;f;DE;f;Europe/Berlin;t;DEAPA;;f;;f;8006713;t;;f;;f;;f;;f;;f;;;;;;;;;;レバークーゼン;레버쿠젠;;;;Леверкузен;;;勒沃库森
@@ -5686,7 +5686,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7097;Meckenbeuren;meckenbeuren;8029156;;9.558526;47.699496;;f;DE;f;Europe/Berlin;t;DEAPO;;f;;f;8003930;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7098;Appenweier;appenweier;8014289;;7.973189;48.541462;;f;DE;f;Europe/Berlin;t;DEAPP;;f;;f;8000596;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7099;Meldorf;meldorf;8001529;;9.080408;54.088328;;f;DE;f;Europe/Berlin;t;DEAPQ;;f;;f;8003954;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Мельдорф;;;梅尔多尔夫
-7100;Melle;melle;8021169;;8.343221;52.209258;;f;DE;f;Europe/Berlin;t;DEAPR;;f;;f;8003956;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;;;;;;;;;;;;;
+7100;Melle;melle;8021169;;8.343221;52.209258;;f;DE;f;Europe/Berlin;t;DEAPR;;f;;f;8003956;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;Alemania;;;;;;;;;;;;
 7101;Melsungen;melsungen;8005406;;9.546076;51.126004;;f;DE;f;Europe/Berlin;t;DEAPS;;f;;f;8003961;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7102;Memmingen;memmingen;8002252;;10.186854;47.985578;;f;DE;f;Europe/Berlin;t;DEAPT;;f;;f;8000249;t;;f;;f;;f;;f;;f;;;;;;;;;;メミンゲン;;;;;Мемминген;;;梅明根
 7103;Meppen;meppen;8021078;;7.298018;52.696024;;f;DE;f;Europe/Berlin;t;DEAPU;;f;;f;8003978;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5695,7 +5695,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7106;Merzig (Saar);merzig-saar;8025349;;6.634191;49.436419;;f;DE;f;Europe/Berlin;t;DEAPX;;f;;f;8003992;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7107;Mettlach;mettlach;8025352;;6.598316;49.495478;;f;DE;f;Europe/Berlin;t;DEAPY;;f;;f;8004004;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7108;Mölln (Lauenb);molln-lauenb;8001684;;10.682573;53.624313;;f;DE;f;Europe/Berlin;t;DEAPZ;;f;;f;8004057;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Мёльн;;;默尔恩
-7109;Mönchengladbach Hbf;monchengladbach-hbf;8015165;;6.44611;51.196579;;f;DE;f;Europe/Berlin;t;DEAQA;;f;;f;8000253;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;メンヒェングラートバッハ;묀헨글라트바흐;;;;Мёнхенгладбах;;;门兴格拉德巴赫
+7109;Mönchengladbach Hbf;monchengladbach-hbf;8015165;;6.44611;51.196579;;f;DE;f;Europe/Berlin;t;DEAQA;;f;;f;8000253;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;メンヒェングラートバッハ;묀헨글라트바흐;;;;Мёнхенгладбах;;;门兴格拉德巴赫
 7110;Morlesau;morlesau;8022557;;9.798799;50.117109;;f;DE;f;Europe/Berlin;t;DEAQB;;f;;f;8004090;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7111;Mühlacker;muhlacker;8029006;;8.846104;48.953195;;f;DE;f;Europe/Berlin;t;DEAQC;;f;;f;8000339;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Мюлакер;;;米赫拉克尔
 7112;;;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5724,8 +5724,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7135;Nesselwang;nesselwang;8002321;;10.504416;47.623942;;f;DE;f;Europe/Berlin;t;DEARB;;f;;f;8004240;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7136;Neumarkt (Oberpf);neumarkt-oberpf;8022353;;11.456985;49.27322;;f;DE;f;Europe/Berlin;t;DEARC;;f;;f;8004305;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7137;Neumünster;neumunster;8001295;;9.979716;54.075554;;f;DE;f;Europe/Berlin;t;DEARD;;f;;f;8000271;t;;f;;f;;f;;f;;f;;;;;;;;;;ノイミュンスター;노이뮌스터;;;;Ноймюнстер;;;新明斯特
-7138;Neunkirchen (Saar) Hbf;neunkirchen-saar-hbf;8025446;;7.176655;49.353287;;f;DE;f;Europe/Berlin;t;DEARE;;f;;f;8000272;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
-7139;Neuss Hbf;neuss-hbf;8015149;;6.684396;51.204444;;f;DE;f;Europe/Berlin;t;DEARF;;f;;f;8000274;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ノイス;노이스;;;;Нойс;;;诺伊斯
+7138;Neunkirchen (Saar) Hbf;neunkirchen-saar-hbf;8025446;;7.176655;49.353287;;f;DE;f;Europe/Berlin;t;DEARE;;f;;f;8000272;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
+7139;Neuss Hbf;neuss-hbf;8015149;;6.684396;51.204444;;f;DE;f;Europe/Berlin;t;DEARF;;f;;f;8000274;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ノイス;노이스;;;;Нойс;;;诺伊斯
 7140;Neustadt (Aisch) Bahnhof;neustadt-aisch-bahnhof;8022500;;10.588034;49.576875;;f;DE;f;Europe/Berlin;t;DEARG;;f;;f;8004323;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7141;Neustadt (Holst);neustadt-holst;8001644;;10.80827;54.104499;;f;DE;f;Europe/Berlin;t;DEARH;;f;;f;8004327;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7142;Neustadt am Rübenberge;neustadt-am-rubenberge;8013728;;9.455276;52.503511;;f;DE;f;Europe/Berlin;t;DEARI;;f;;f;8004322;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Нойштадт-ам-Рюбенберге;;;吕本山麓诺伊施塔特
@@ -5755,14 +5755,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7167;Oberaudorf;oberaudorf;8020179;;12.175259;47.652788;;f;DE;f;Europe/Berlin;t;DEASH;;f;;f;8004507;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7168;Oberkochen;oberkochen;8029698;;10.107776;48.782346;;f;DE;f;Europe/Berlin;t;DEASI;;f;;f;8004549;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7169;Oberkotzau;oberkotzau;8026024;;11.9322;50.266393;;f;DE;f;Europe/Berlin;t;DEASJ;;f;;f;8000287;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7170;Oberhausen Hbf;oberhausen-hbf;8010263;;6.852036;51.475118;;f;DE;f;Europe/Berlin;t;DEASK;;f;;f;8000286;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;オーバーハウゼン;오버하우젠;;;;Оберхаузен;;;奥伯豪森
+7170;Oberhausen Hbf;oberhausen-hbf;8010263;;6.852036;51.475118;;f;DE;f;Europe/Berlin;t;DEASK;;f;;f;8000286;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;オーバーハウゼン;오버하우젠;;;;Оберхаузен;;;奥伯豪森
 7171;Oberndorf (Neckar);oberndorf-neckar;8029406;;8.575637;48.295382;;f;DE;f;Europe/Berlin;t;DEASL;;f;;f;8004563;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7172;Oberstaufen;oberstaufen;8002347;;10.025282;47.554203;;f;DE;f;Europe/Berlin;t;DEASM;;f;;f;8004584;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7173;Uhldingen-Mühlhofen;uhldingen-muhlhofen;8014607;;9.248416;47.736999;;f;DE;f;Europe/Berlin;t;DEASN;;f;;f;8004595;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7174;Oberwesel;oberwesel;8019034;;7.731541;50.104461;;f;DE;f;Europe/Berlin;t;DEASO;;f;;f;8004601;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7175;Oberstdorf;oberstdorf;8002381;;10.278095;47.411032;;f;DE;f;Europe/Berlin;t;DEASP;;f;;f;8004585;t;;f;;f;;f;;f;;f;;;;;;;;;;オーベルストドルフ;;;;;Оберстдорф;;;奥伯斯多夫
 7176;Westerstede-Ocholt;westerstede-ocholt;8021232;;7.88647;53.202162;;f;DE;f;Europe/Berlin;t;DEASQ;;f;;f;8004610;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7177;Offenbach (Main) Hbf;offenbach-main-hbf;8011059;;8.760743;50.099265;;f;DE;f;Europe/Berlin;t;DEASR;;f;;f;8000349;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+7177;Offenbach (Main) Hbf;offenbach-main-hbf;8011059;;8.760743;50.099265;;f;DE;f;Europe/Berlin;t;DEASR;;f;;f;8000349;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 7178;Oldenburg (Oldb);oldenburg-oldb;8021204;;8.22246;53.144343;;f;DE;f;Europe/Berlin;t;DEASS;;f;;f;8000291;t;;f;;f;;f;;f;;f;;Oldenbourg;;;;Oldenburgo;;;;オルデンブルク;올덴부르크;;;Oldemburgo;Ольденбург;;;霍尔斯泰因地区奥尔登堡
 7179;Olsberg;olsberg;8008515;;8.484207;51.360497;;f;DE;f;Europe/Berlin;t;DEAST;;f;;f;8004676;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7180;Opladen;opladen;8008186;;7.008772;51.066172;;f;DE;f;Europe/Berlin;t;DEASU;;f;;f;8000853;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5774,8 +5774,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7186;Oldenburg (Holst);oldenburg-holst;8001650;;10.883222;54.283573;;f;DE;f;Europe/Berlin;t;DEATA;;f;;f;8004669;t;;f;;f;;f;;f;;f;;Oldenbourg;;;;Oldenburgo;;;;オルデンブルク;올덴부르크;;;Oldemburgo;Ольденбург;;;霍尔斯泰因地区奥尔登堡
 7187;Obernburg-Elsenfeld;obernburg-elsenfeld;8022629;;9.154218;49.840736;;f;DE;f;Europe/Berlin;t;DEATB;;f;;f;8004560;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7188;Osterhofen (Oberbay);osterhofen-oberbay;8053415;;11.986881;47.687657;;f;DE;f;Europe/Berlin;t;DEATC;;f;;f;8004701;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7189;Osnabrück Hbf;osnabruck-hbf;8021025;;8.061777;52.272848;;f;DE;f;Europe/Berlin;t;DEATD;;f;;f;8000294;t;;f;;f;;f;;f;108021025;t;;Gare centrale;Main station;;Stazione centrale;;;;;オスナブリュック;오스나브뤼크;;;;Оснабрюк;;;奥斯纳布吕克
-7190;Paderborn Hbf;paderborn-hbf;8010358;;8.740508;51.712982;;f;DE;f;Europe/Berlin;t;DEATE;;f;;f;8000297;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;パーダーボルン;파더보른;;;;Падерборн;;;帕德博恩
+7189;Osnabrück Hbf;osnabruck-hbf;8021025;;8.061777;52.272848;;f;DE;f;Europe/Berlin;t;DEATD;;f;;f;8000294;t;;f;;f;;f;;f;108021025;t;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;オスナブリュック;오스나브뤼크;;;;Оснабрюк;;;奥斯纳布吕克
+7190;Paderborn Hbf;paderborn-hbf;8010358;;8.740508;51.712982;;f;DE;f;Europe/Berlin;t;DEATE;;f;;f;8000297;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;パーダーボルン;파더보른;;;;Падерборн;;;帕德博恩
 7191;Übach-Palenberg;ubach-palenberg;8015189;;6.097266;50.924331;;f;DE;f;Europe/Berlin;t;DEATF;;f;;f;8005935;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Ибах-Паленберг;;;于巴赫-帕伦贝格
 7192;Papenburg (Ems);papenburg-ems;8021086;;7.386705;53.089707;;f;DE;f;Europe/Berlin;t;DEATG;;f;;f;8004751;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7193;Parsberg;parsberg;8026304;;11.723353;49.164351;;f;DE;f;Europe/Berlin;t;DEATH;;f;;f;8004755;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5783,7 +5783,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7195;Peine;peine;8013252;;10.23216;52.318801;;f;DE;f;Europe/Berlin;t;DEATJ;;f;;f;8004760;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7196;Piding;piding;8020106;;12.91153;47.759544;;f;DE;f;Europe/Berlin;t;DEATK;;f;;f;8004815;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7197;Gummersbach;gummersbach;8008392;;7.56631;51.023635;;f;DE;f;Europe/Berlin;t;DEATL;;f;;f;8002462;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гуммерсбах;;;古梅尔斯巴赫
-7198;Pforzheim Hbf;pforzheim-hbf;8029500;;8.703095;48.894154;7695;f;DE;f;Europe/Berlin;t;DEATM;;f;;f;8000299;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;プフォルツハイム;포르츠하임;;;;Пфорцхайм;;;普福尔茨海姆
+7198;Pforzheim Hbf;pforzheim-hbf;8029500;;8.703095;48.894154;7695;f;DE;f;Europe/Berlin;t;DEATM;;f;;f;8000299;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;プフォルツハイム;포르츠하임;;;;Пфорцхайм;;;普福尔茨海姆
 7199;Brötzingen Mitte;brotzingen-mitte;8029464;;8.66703;48.889461;7695;f;DE;f;Europe/Berlin;t;DEATN;;f;;f;8004799;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7200;Pfronten-Steinach;pfronten-steinach;8002325;;10.574568;47.566114;;f;DE;f;Europe/Berlin;t;DEATO;;f;;f;8004807;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7201;Plochingen;plochingen;8029060;;9.410807;48.713084;;f;DE;f;Europe/Berlin;t;DEATP;;f;;f;8000302;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5798,27 +5798,27 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7210;Pankofen;pankofen;8026449;;12.899421;48.799641;;f;DE;f;Europe/Berlin;t;DEATY;;f;;f;8004749;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7211;Pommelsbrunn;pommelsbrunn;8022326;;11.513617;49.501465;;f;DE;f;Europe/Berlin;t;DEATZ;;f;;f;8004858;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7212;Ramsenthal;ramsenthal;8022246;;11.593333;50.007926;;f;DE;f;Europe/Berlin;t;DEAUA;;f;;f;8004936;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7213;Reutlingen Hbf;reutlingen-hbf;8029308;;9.209196;48.49603;;f;DE;f;Europe/Berlin;t;DEAUB;;f;;f;8000314;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ロイトリンゲン;로이틀링겐;;;;Ройтлинген;;;罗伊特林根
+7213;Reutlingen Hbf;reutlingen-hbf;8029308;;9.209196;48.49603;;f;DE;f;Europe/Berlin;t;DEAUB;;f;;f;8000314;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ロイトリンゲン;로이틀링겐;;;;Ройтлинген;;;罗伊特林根
 7214;Rastede;rastede;8021213;;8.191006;53.2446;;f;DE;f;Europe/Berlin;t;DEAUC;;f;;f;8004945;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7215;Ratzeburg;ratzeburg;8001321;;10.740608;53.698295;;f;DE;f;Europe/Berlin;t;DEAUD;;f;;f;8004952;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7216;Rottenburg (Neckar);rottenburg-neckar;8029322;;8.935367;48.472389;;f;DE;f;Europe/Berlin;t;DEAUE;;f;;f;8005197;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7217;Recklinghausen Hbf;recklinghausen-hbf;8010138;;7.203487;51.616357;;f;DE;f;Europe/Berlin;t;DEAUF;;f;;f;8000307;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;レックリングハウゼン;레클링하우젠;;;;Реклингхаузен;;;雷克林豪森
+7217;Recklinghausen Hbf;recklinghausen-hbf;8010138;;7.203487;51.616357;;f;DE;f;Europe/Berlin;t;DEAUF;;f;;f;8000307;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;レックリングハウゼン;레클링하우젠;;;;Реклингхаузен;;;雷克林豪森
 7218;Regen;regen;8026465;;13.136467;48.96862;;f;DE;f;Europe/Berlin;t;DEAUG;;f;;f;8004981;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7219;Reichenau (Baden);reichenau-baden;8014583;;9.126316;47.689185;;f;DE;f;Europe/Berlin;t;DEAUH;;f;;f;8004997;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7220;Remagen;remagen;8019001;;7.229781;50.577213;;f;DE;f;Europe/Berlin;t;DEAUI;;f;;f;8000310;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7221;Remscheid Hbf;remscheid-hbf;8008453;;7.199622;51.17727;7705;f;DE;f;Europe/Berlin;t;DEAUJ;;f;;f;8005033;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;レムシャイト;렘샤이트;;;;Ремшайд;;;雷姆沙伊德
+7221;Remscheid Hbf;remscheid-hbf;8008453;;7.199622;51.17727;7705;f;DE;f;Europe/Berlin;t;DEAUJ;;f;;f;8005033;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;レムシャイト;렘샤이트;;;;Ремшайд;;;雷姆沙伊德
 7222;Remscheid-Lennep;remscheid-lennep;8008452;;7.252829;51.190727;7705;f;DE;f;Europe/Berlin;t;DEAUK;;f;;f;8000311;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7223;Rendsburg;rendsburg;8001409;;9.670712;54.302594;;f;DE;f;Europe/Berlin;t;DEAUL;;f;;f;8000312;t;;f;;f;;f;;f;;f;;Rendsbourg;;;;;;Rendsborg;;;;;;;Рендсбург;;;伦茨堡
 7224;Retzbach-Zellingen;retzbach-zellingen;8022544;;9.814215;49.905152;;f;DE;f;Europe/Berlin;t;DEAUM;;f;;f;8005049;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7225;Rheine;rheine;8021065;;7.434258;52.2763;;f;DE;f;Europe/Berlin;t;DEAUN;;f;;f;8000316;t;;f;;f;;f;;f;;f;;;;;;;;;;;라이네;;;;Райне;;;赖内
 7226;Rheinfelden (Baden);rheinfelden-baden;8014462;;7.784208;47.556918;;f;DE;f;Europe/Berlin;t;DEAUO;;f;;f;8005064;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7227;Rheinhausen;rheinhausen;8015111;;6.706483;51.393505;;f;DE;f;Europe/Berlin;t;DEAUP;;f;;f;8000317;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7228;Rheydt Hbf;rheydt-hbf;8015172;;6.439359;51.163049;;f;DE;f;Europe/Berlin;t;DEAUQ;;f;;f;8000318;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+7228;Rheydt Hbf;rheydt-hbf;8015172;;6.439359;51.163049;;f;DE;f;Europe/Berlin;t;DEAUQ;;f;;f;8000318;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 7229;Rieneck;rieneck;8022599;;9.664419;50.090995;;f;DE;f;Europe/Berlin;t;DEAUR;;f;;f;8005092;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7230;Röthenbach (Allgäu);rothenbach-allgau;8002349;;9.953539;47.620616;;f;DE;f;Europe/Berlin;t;DEAUS;;f;;f;8005138;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7231;Rosenheim;rosenheim;8020174;;12.119113;47.850128;;f;DE;f;Europe/Berlin;t;DEAUT;;f;;f;8000320;t;;f;;f;;f;;f;;f;;;;;;;;;;ローゼンハイム;로젠하임;;;;Розенхайм;;;罗森海姆
 7232;Rot am See;rot-am-see;8029720;;10.030388;49.249398;;f;DE;f;Europe/Berlin;t;DEAUU;;f;;f;8005179;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7233;Regensburg Hbf;regensburg-hbf;8026294;;12.099615;49.011669;;f;DE;f;Europe/Berlin;t;DEAUV;;f;;f;8000309;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Ratisbona;Řezno;;;レーゲンスブルク;레겐스부르크;;Ratyzbona;Regensburgo;Регенсбург;;;雷根斯堡
+7233;Regensburg Hbf;regensburg-hbf;8026294;;12.099615;49.011669;;f;DE;f;Europe/Berlin;t;DEAUV;;f;;f;8000309;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Ratisbona Estación central;Řezno;;;レーゲンスブルク;레겐스부르크;;Ratyzbona;Regensburgo;Регенсбург;;;雷根斯堡
 7234;Bad Schwartau;bad-schwartau;8001672;;10.702727;53.916148;;f;DE;f;Europe/Berlin;t;DEAUW;;f;;f;8000749;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7235;Rotenburg a.d. Fulda;rotenburg-a-d-fulda;8005412;;9.733339;50.997854;;f;DE;f;Europe/Berlin;t;DEAUX;;f;;f;8005182;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7236;Rotenburg (Wümme);rotenburg-wumme;8001239;;9.390095;53.112351;;f;DE;f;Europe/Berlin;t;DEAUY;;f;;f;8000321;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Ротенбург-на-Фульде;;;
@@ -5839,7 +5839,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7251;Rueckstetten;rueckstetten;8020115;;;;;f;DE;f;Europe/Berlin;f;DEAVN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7252;Runkel;runkel;8011449;;8.159373;50.405285;;f;DE;f;Europe/Berlin;t;DEAVO;;f;;f;8005229;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7253;Saarburg (Bz Trier);saarburg-bz-trier;8025356;;6.556866;49.606243;;f;DE;f;Europe/Berlin;t;DEAVP;;f;;f;8005245;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7254;Saarlouis Hbf;saarlouis-hbf;8025361;;6.75017;49.327829;;f;DE;f;Europe/Berlin;t;DEAVQ;;f;;f;8005247;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ザールルイ;자를루이;;;;Саарлуисе;;;萨尔路易
+7254;Saarlouis Hbf;saarlouis-hbf;8025361;;6.75017;49.327829;;f;DE;f;Europe/Berlin;t;DEAVQ;;f;;f;8005247;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ザールルイ;자를루이;;;;Саарлуисе;;;萨尔路易
 7255;Sachsenhausen (Nordb);sachsenhausen-nordb;8005270;;13.25187;52.772271;;f;DE;f;Europe/Berlin;t;DEAVR;;f;;f;8012831;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7256;Bad Säckingen;bad-sackingen;8014466;;7.94863;47.555857;;f;DE;f;Europe/Berlin;t;DEAVS;;f;;f;8005255;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бад-Зекинген;;;巴德塞金根
 7257;Einbeck Salzderhelden;einbeck-salzderhelden;8013058;;9.922922;51.798218;;f;DE;f;Europe/Berlin;t;DEAVT;;f;;f;8005264;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5870,7 +5870,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7282;Scharbeutz;scharbeutz;8001641;;10.745777;54.019003;;f;DE;f;Europe/Berlin;t;DEAWS;;f;;f;8005321;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7283;Schwandorf;schwandorf;8026226;;12.104433;49.326283;;f;DE;f;Europe/Berlin;t;DEAWT;;f;;f;8000027;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7284;Schluchsee;schluchsee;8014379;;8.177127;47.816868;;f;DE;f;Europe/Berlin;t;DEAWU;;f;;f;8005371;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7285;Schweinfurt Hbf;schweinfurt-hbf;8022470;;10.212923;50.035316;7715;f;DE;f;Europe/Berlin;t;DEAWV;;f;;f;8000032;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Швайнфурт;;;施韦因富特
+7285;Schweinfurt Hbf;schweinfurt-hbf;8022470;;10.212923;50.035316;7715;f;DE;f;Europe/Berlin;t;DEAWV;;f;;f;8000032;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Швайнфурт;;;施韦因富特
 7286;Schweinfurt Stadt;schweinfurt-stadt;8022471;;10.243064;50.04631;7715;f;DE;f;Europe/Berlin;t;DEAWW;;f;;f;8005481;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Швайнфурт;;;施韦因富特
 7287;Schwerte (Ruhr);schwerte-ruhr;8008015;;7.558957;51.442281;;f;DE;f;Europe/Berlin;t;DEAWX;;f;;f;8000037;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7288;Seesen;seesen;8013095;;10.173901;51.887265;;f;DE;f;Europe/Berlin;t;DEAWY;;f;;f;8000043;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5880,14 +5880,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7292;Singen (Hohentwiel);singen-hohentwiel;8000494;;8.840378;47.758438;;f;DE;f;Europe/Berlin;t;DEAXC;;f;;f;8000073;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7293;Bad Sobernheim;bad-sobernheim;8025269;;7.64982;49.782845;;f;DE;f;Europe/Berlin;t;DEAXD;;f;;f;8005583;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7294;Solingen ohligs;solingen-ohligs;;;;;7711;f;DE;f;Europe/Berlin;f;DEAXE;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7295;Soest;soest;8010373;;8.104593;51.578422;;f;DE;f;Europe/Berlin;t;DEAXF;;f;;f;8000076;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;;;;;ゾースト;;;;;Зост;;;索斯特
+7295;Soest;soest;8010373;;8.104593;51.578422;;f;DE;f;Europe/Berlin;t;DEAXF;;f;;f;8000076;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;Alemania;;;;ゾースト;;;;;Зост;;;索斯特
 7296;Sontheim-Brenz;sontheim-brenz;8029709;;10.284738;48.560159;;f;DE;f;Europe/Berlin;t;DEAXG;;f;;f;8005608;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7297;Solingen Hbf;solingen-hbf;8008179;;7.004241;51.160909;7711;f;DE;f;Europe/Berlin;t;DEAXH;;f;;f;8000087;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ゾーリンゲン;졸링겐;;;;Золинген;;;索林根
+7297;Solingen Hbf;solingen-hbf;8008179;;7.004241;51.160909;7711;f;DE;f;Europe/Berlin;t;DEAXH;;f;;f;8000087;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ゾーリンゲン;졸링겐;;;;Золинген;;;索林根
 7298;Schwelm;schwelm;8008136;;7.289685;51.290525;;f;DE;f;Europe/Berlin;t;DEAXI;;f;;f;8000033;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7299;Speyer Hbf;speyer-hbf;8019092;;8.427953;49.324117;;f;DE;f;Europe/Berlin;t;DEAXJ;;f;;f;8005628;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Espira;Špýr;;;シュパイアー;슈파이어;;Spira;;Шпайер;;;施派尔
+7299;Speyer Hbf;speyer-hbf;8019092;;8.427953;49.324117;;f;DE;f;Europe/Berlin;t;DEAXJ;;f;;f;8005628;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Espira Estación central;Špýr;;;シュパイアー;슈파이어;;Spira;;Шпайер;;;施派尔
 7300;Stadthagen;stadthagen;8013572;;9.188836;52.332375;;f;DE;f;Europe/Berlin;t;DEAXK;;f;;f;8005662;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7301;Steinach (b Rothenburg);steinach-b-rothenburg;8022693;;10.273537;49.45322;;f;DE;f;Europe/Berlin;t;DEAXL;;f;;f;8000091;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7302;Stolberg (Rheinland) Hbf;stolberg-rheinland-hbf;8015338;;6.218431;50.794914;;f;DE;f;Europe/Berlin;t;DEAXM;;f;;f;8000348;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+7302;Stolberg (Rheinland) Hbf;stolberg-rheinland-hbf;8015338;;6.218431;50.794914;;f;DE;f;Europe/Berlin;t;DEAXM;;f;;f;8000348;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 7303;Straubing;straubing;8026397;;12.574093;48.876975;;f;DE;f;Europe/Berlin;t;DEAXN;;f;;f;8000095;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Штраубинг;;;施特劳宾
 7304;Stubben;stubben;8013778;;8.780429;53.405453;;f;DE;f;Europe/Berlin;t;DEAXO;;f;;f;8005763;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7305;Stadtallendorf;stadtallendorf;8005382;;9.015281;50.825432;;f;DE;f;Europe/Berlin;t;DEAXP;;f;;f;8005661;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5912,7 +5912,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7324;Schwarzenfeld (Opf);schwarzenfeld-opf;8026186;;12.130637;49.392749;;f;DE;f;Europe/Berlin;t;DEAYI;;f;;f;8005469;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7325;Spieka;spieka;8001595;;;;;f;DE;f;Europe/Berlin;f;DEAYJ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7326;Süderbrarup;suderbrarup;8001397;;9.770905;54.637407;;f;DE;f;Europe/Berlin;t;DEAYK;;f;;f;8005782;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7327;Sinsheim (Elsenz) Hbf;sinsheim-elsenz-hbf;8014186;;8.875103;49.250351;;f;DE;f;Europe/Berlin;t;DEAYL;;f;;f;8005578;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+7327;Sinsheim (Elsenz) Hbf;sinsheim-elsenz-hbf;8014186;;8.875103;49.250351;;f;DE;f;Europe/Berlin;t;DEAYL;;f;;f;8005578;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 7328;Teisendorf;teisendorf;8020114;;12.834447;47.8494;;f;DE;f;Europe/Berlin;t;DEAYM;;f;;f;8005833;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7329;Tiengen (Hochrhein);tiengen-hochrhein;8014478;;8.271999;47.635475;;f;DE;f;Europe/Berlin;t;DEAYN;;f;;f;8005871;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7330;Timmendorferstrand;timmendorferstrand;8001640;;10.762272;53.99421;;f;DE;f;Europe/Berlin;t;DEAYO;;f;;f;8005874;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5928,7 +5928,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7340;Tauberbischofsheim;tauberbischofsheim;8029766;;9.658298;49.623628;;f;DE;f;Europe/Berlin;t;DEAYY;;f;;f;8005827;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7341;Timmdorf;timmdorf;8001363;;;;;f;DE;f;Europe/Berlin;f;DEAYZ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7342;Tarp;tarp;8001422;;9.398177;54.664374;;f;DE;f;Europe/Berlin;t;DEAZA;;f;;f;8005825;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7343;Tübingen Hbf;tubingen-hbf;8029317;;9.055409;48.515807;;f;DE;f;Europe/Berlin;t;DEAZB;;f;;f;8000141;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Tubinga;;;;テュービンゲン;튀빙겐;;Tybinga;Tubinga;Тюбинген;;;蒂宾根
+7343;Tübingen Hbf;tubingen-hbf;8029317;;9.055409;48.515807;;f;DE;f;Europe/Berlin;t;DEAZB;;f;;f;8000141;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Tubinga Estación central;;;;テュービンゲン;튀빙겐;;Tybinga;Tubinga;Тюбинген;;;蒂宾根
 7344;Untergrainau;untergrainau;8020288;;11.042816;47.481112;;f;DE;f;Europe/Berlin;t;DEAZC;;f;;f;8017042;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7345;Trebgast;trebgast;8022244;;11.552073;50.066311;;f;DE;f;Europe/Berlin;t;DEAZD;;f;;f;8005895;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7346;Tutting;tutting;8026573;;;;;f;DE;f;Europe/Berlin;f;DEAZE;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5962,7 +5962,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7374;Waiblingen;waiblingen;8029515;;9.29988;48.826123;;f;DE;f;Europe/Berlin;t;DEBAG;;f;;f;8000180;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7375;Waldeck;waldeck;8005273;;;;;f;DE;f;Europe/Berlin;f;DEBAH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7376;Waldshut;waldshut;8014477;;8.219529;47.621371;;f;DE;f;Europe/Berlin;t;DEBAI;;f;;f;8006167;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Вальдсхут-Тинген;;;瓦尔茨胡特田根
-7377;Wanne-Eickel Hbf;wanne-eickel-hbf;8010127;;7.165787;51.531256;;f;DE;f;Europe/Berlin;t;DEBAJ;;f;;f;8000192;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+7377;Wanne-Eickel Hbf;wanne-eickel-hbf;8010127;;7.165787;51.531256;;f;DE;f;Europe/Berlin;t;DEBAJ;;f;;f;8000192;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 7378;Warburg (Westf);warburg-westf;8008521;;9.163846;51.492953;;f;DE;f;Europe/Berlin;t;DEBAK;;f;;f;8000196;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7379;Wasserburg (Bodensee);wasserburg-bodensee;8002374;;9.638944;47.571822;;f;DE;f;Europe/Berlin;t;DEBAL;;f;;f;8006218;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7380;Weiden (Oberpf);weiden-oberpf;8026137;;12.153847;49.670489;;f;DE;f;Europe/Berlin;t;DEBAM;;f;;f;8000204;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5981,7 +5981,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7394;Wiesau (Oberpf);wiesau-oberpf;8026094;;12.191287;49.911013;;f;DE;f;Europe/Berlin;t;DEBBA;;f;;f;8006403;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7395;Basel Badischer Bahnhof;basel-badischer-bahnhof;8000491;;7.607804;47.567292;5877;f;CH;f;Europe/Berlin;t;DEBBB;;f;;f;8000026;t;;f;;f;;f;;f;;f;;Bâle;;;Basilea;Basilea;Basilej;;Bázel;バーゼル;바젤;Bazel;Bazylea;Basileia;Базель;;;巴塞尔
 7396;Bad Wildbad Bf;bad-wildbad-bf;8029456;;8.551087;48.75572;;f;DE;f;Europe/Berlin;t;DEBBC;;f;;f;8006431;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7397;Wilhelmshaven Hbf;wilhelmshaven-hbf;8021222;;8.115641;53.518717;;f;DE;f;Europe/Berlin;t;DEBBD;;f;;f;8006445;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ヴィルヘルムスハーフェン;빌헬름스하펜;;;;Вильгельмсхафен;;;威廉港
+7397;Wilhelmshaven Hbf;wilhelmshaven-hbf;8021222;;8.115641;53.518717;;f;DE;f;Europe/Berlin;t;DEBBD;;f;;f;8006445;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ヴィルヘルムスハーフェン;빌헬름스하펜;;;;Вильгельмсхафен;;;威廉港
 7398;Bonn-Beuel;bonn-beuel;8015577;;7.127654;50.738479;;f;DE;f;Europe/Berlin;t;DEBBE;;f;;f;8001083;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7399;Willebadessen;willebadessen;8008526;;9.011829;51.621795;;f;DE;f;Europe/Berlin;t;DEBBF;;f;;f;8006449;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7400;Bonn-Bad Godesberg;bonn-bad-godesberg;8015490;;7.159557;50.683924;;f;DE;f;Europe/Berlin;t;DEBBG;;f;;f;8001082;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5989,15 +5989,15 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7402;Winsen (Luhe);winsen-luhe;8001179;;10.207691;53.353837;;f;DE;f;Europe/Berlin;t;DEBBI;;f;;f;8006484;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7403;Wissen (Sieg);wissen-sieg;8019647;;7.73937;50.783066;;f;DE;f;Europe/Berlin;t;DEBBJ;;f;;f;8006501;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7404;Winklarn;winklarn;8026182;;;;;f;DE;f;Europe/Berlin;f;DEBBK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7405;Witten Hbf;witten-hbf;8010091;;7.329444;51.435548;;f;DE;f;Europe/Berlin;t;DEBBL;;f;;f;8000251;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ヴィッテン;비텐;;;;Виттен;;;维滕
+7405;Witten Hbf;witten-hbf;8010091;;7.329444;51.435548;;f;DE;f;Europe/Berlin;t;DEBBL;;f;;f;8000251;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ヴィッテン;비텐;;;;Виттен;;;维滕
 7406;Wittmund;wittmund;8021450;;7.788829;53.579871;;f;DE;f;Europe/Berlin;t;DEBBM;;f;;f;8006520;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7407;Witzenhausen Nord;witzenhausen-nord;8005493;;9.863081;51.351553;;f;DE;f;Europe/Berlin;t;DEBBN;;f;;f;8006524;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7408;Wörth (Rhein);worth-rhein;8019103;;8.27315;49.045676;;f;DE;f;Europe/Berlin;t;DEBBO;;f;;f;8000254;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7409;Wolfenbüttel;wolfenbuttel;8013344;;10.53231;52.159126;;f;DE;f;Europe/Berlin;t;DEBBP;;f;;f;8000255;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Вольфенбюттель;;;沃爾芬比特爾
-7410;Wolfsburg Hbf;wolfsburg-hbf;8013017;;10.788197;52.429494;;f;DE;f;Europe/Berlin;t;DEBBQ;;f;;f;8006552;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Wolfsburgo;;;;ヴォルフスブルク;볼프스부르크;;;;Вольфсбург;;;沃尔夫斯堡
+7410;Wolfsburg Hbf;wolfsburg-hbf;8013017;;10.788197;52.429494;;f;DE;f;Europe/Berlin;t;DEBBQ;;f;;f;8006552;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Wolfsburgo Estación central;;;;ヴォルフスブルク;볼프스부르크;;;;Вольфсбург;;;沃尔夫斯堡
 7411;Bad Breisig;bad-breisig;8019006;;7.304562;50.50422;;f;DE;f;Europe/Berlin;t;DEBBR;;f;;f;8000694;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7412;Wolfsmünster;wolfsmunster;8022560;;9.734895;50.09451;;f;DE;f;Europe/Berlin;t;DEBBS;;f;;f;8006554;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7413;Worms Hbf;worms-hbf;8019066;;8.356633;49.634748;;f;DE;f;Europe/Berlin;t;DEBBT;;f;;f;8000257;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ヴォルムス;보름스;;Wormacja;;Вормс;;;沃尔姆斯
+7413;Worms Hbf;worms-hbf;8019066;;8.356633;49.634748;;f;DE;f;Europe/Berlin;t;DEBBT;;f;;f;8000257;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ヴォルムス;보름스;;Wormacja;;Вормс;;;沃尔姆斯
 7414;Wunstorf;wunstorf;8013565;;9.450979;52.422222;;f;DE;f;Europe/Berlin;t;DEBBU;;f;;f;8000268;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7415;Wesel;wesel;8010274;;6.627135;51.655837;;f;DE;f;Europe/Berlin;t;DEBBV;;f;;f;8000242;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Везель;;;韋塞爾
 7416;Wetzlar;wetzlar;8011423;;8.504217;50.565662;;f;DE;f;Europe/Berlin;t;DEBBW;;f;;f;8000383;t;;f;;f;;f;;f;;f;;;;;;;;;;ヴェッツラー;베츨라어;;;;Вецлар;;;韦茨拉尔
@@ -6017,7 +6017,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7430;Weißenau;weissenau;8029154;;9.594384;47.765971;;f;DE;f;Europe/Berlin;t;DEBCK;;f;;f;8006296;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7431;Werne a d Lippe;werne-a-d-lippe;8021548;;7.622933;51.669249;;f;DE;f;Europe/Berlin;t;DEBCL;;f;;f;8006348;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7432;Werdohl;werdohl;8008284;;7.757573;51.25944;;f;DE;f;Europe/Berlin;t;DEBCM;;f;;f;8006339;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7433;Zweibrücken Hbf;zweibrucken-hbf;8019778;;7.356646;49.2468;;f;DE;f;Europe/Berlin;t;DEBCN;;f;;f;8006680;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Dos Puentes;;;;ツヴァイブリュッケン;;;;;Цвайбрюккен;;;茨魏布吕肯
+7433;Zweibrücken Hbf;zweibrucken-hbf;8019778;;7.356646;49.2468;;f;DE;f;Europe/Berlin;t;DEBCN;;f;;f;8006680;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Dos Puentes Estación central;;;;ツヴァイブリュッケン;;;;;Цвайбрюккен;;;茨魏布吕肯
 7434;Zwiesel (Bay);zwiesel-bay;8026467;;13.226377;49.020937;;f;DE;f;Europe/Berlin;t;DEBCO;;f;;f;8006684;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7435;Zollhaus;zollhaus;8019550;;;;;f;DE;f;Europe/Berlin;f;DEBCP;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7436;Hedemünden;hedemunden;8005491;;9.762141;51.392166;;f;DE;f;Europe/Berlin;t;DEBCQ;;f;;f;8002677;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6035,14 +6035,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7448;Gmund (Tegernsee);gmund-tegernsee;8054102;;11.735291;47.749638;;f;DE;f;Europe/Berlin;t;DEBDC;;f;;f;8007631;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7449;Lenggries;lenggries;8020269;;11.573315;47.679873;;f;DE;f;Europe/Berlin;t;DEBDD;;f;;f;8003643;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7450;Bad Tölz;bad-tolz;8053402;;11.573773;47.760263;;f;DE;f;Europe/Berlin;t;DEBDE;;f;;f;8000758;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бад-Тёльц;;;巴德特尔茨
-7451;Wittlich Hbf;wittlich-hbf;8025135;;6.94298;49.972985;;f;DE;f;Europe/Berlin;t;DEBDF;;f;;f;8000379;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+7451;Wittlich Hbf;wittlich-hbf;8025135;;6.94298;49.972985;;f;DE;f;Europe/Berlin;t;DEBDF;;f;;f;8000379;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 7452;Holzkirchen;holzkirchen;8020276;;11.697231;47.884386;;f;DE;f;Europe/Berlin;t;DEBDG;;f;;f;8002980;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7453;München Harras;munchen-harras;8020283;;11.536315;48.117746;;f;DE;f;Europe/Berlin;t;DEBDH;;f;;f;8004130;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7454;Weizen;weizen;8014545;;8.476513;47.76883;;f;DE;f;Europe/Berlin;t;DEBDI;;f;;f;8070569;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7455;Seeg;seeg;8002389;;10.613977;47.655269;;f;DE;f;Europe/Berlin;t;DEBDJ;;f;;f;8005505;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7456;Lengenwang;lengenwang;8002387;;10.601212;47.697402;;f;DE;f;Europe/Berlin;t;DEBDK;;f;;f;8003639;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7457;Marktoberdorf;marktoberdorf;8002291;;10.614228;47.779212;;f;DE;f;Europe/Berlin;t;DEBDL;;f;;f;8003885;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7458;Pirmasens Hbf;pirmasens-hbf;8019775;;7.598428;49.205648;;f;DE;f;Europe/Berlin;t;DEBDM;;f;;f;8004822;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ピルマゼンス;피르마젠스;;;;Пирмазенс;;;皮尔马森斯
+7458;Pirmasens Hbf;pirmasens-hbf;8019775;;7.598428;49.205648;;f;DE;f;Europe/Berlin;t;DEBDM;;f;;f;8004822;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ピルマゼンス;피르마젠스;;;;Пирмазенс;;;皮尔马森斯
 7459;Pfarrkirchen;pfarrkirchen;8026390;;12.938165;48.429195;;f;DE;f;Europe/Berlin;t;DEBDN;;f;;f;8004786;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7460;Igel;igel;8000580;;6.550682;49.707372;;f;DE;f;Europe/Berlin;t;DEBDO;;f;;f;8003042;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7461;Leutkirch;leutkirch;8029212;;10.015834;47.826163;;f;DE;f;Europe/Berlin;t;DEBDP;;f;;f;8000336;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6056,19 +6056,19 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7469;Rödental;rodental;8022822;;11.03131;50.288362;;f;DE;f;Europe/Berlin;t;DEBDX;;f;;f;8004633;t;;f;;f;;f;;f;;f;;;;;;;;;;レーデンタール;;;;;Рёденталь;;;勒登塔尔
 7470;Bochum;bochum;;;;;;t;DE;f;Europe/Berlin;f;DEBDZ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7471;Bochum-Langendreer;bochum-langendreer;8010114;;7.323727;51.478031;7470;f;DE;f;Europe/Berlin;t;DEBLA;;f;;f;8000358;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7472;Bochum Hbf;bochum-hbf;8010179;;7.224109;51.478651;7470;f;DE;f;Europe/Berlin;t;DEQBO;;f;;f;8000041;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ボーフム;보훔;;;;Бохум;;;波鸿
-7473;Bonn Hbf;bonn-hbf;8015485;;7.097136;50.732007;7545;f;DE;f;Europe/Berlin;t;DEBEA;;f;;f;8000044;t;;f;;f;;f;;f;108000044;t;;Gare centrale;Main station;;Stazione centrale;;;;;ボン;본;;;Bona;Бонн;;;波恩
+7472;Bochum Hbf;bochum-hbf;8010179;;7.224109;51.478651;7470;f;DE;f;Europe/Berlin;t;DEQBO;;f;;f;8000041;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ボーフム;보훔;;;;Бохум;;;波鸿
+7473;Bonn Hbf;bonn-hbf;8015485;;7.097136;50.732007;7545;f;DE;f;Europe/Berlin;t;DEBEA;;f;;f;8000044;t;;f;;f;;f;;f;108000044;t;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ボン;본;;;Bona;Бонн;;;波恩
 7474;Hamburg Hbf;hamburg-hbf;8001071;;10.006908;53.552732;7626;f;DE;f;Europe/Berlin;t;DEBEB;;f;;f;8002549;t;;f;;f;;f;;f;108001071;t;;Hambourg Gare centrale;Main station;;Amburgo Stazione centrale;Hamburgo;Hamburk;Hamborg;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
-7475;Düsseldorf Hbf;dusseldorf-hbf;8008094;;6.794316;51.21996;7578;f;DE;f;Europe/Berlin;t;DEBEC;;t;;f;8000085;t;;f;;f;;f;;f;108008094;t;;Gare centrale;Main station;;Stazione centrale;;;;;デュッセルドルフ;뒤셀도르프;;;;Дюссельдорф;;;
+7475;Düsseldorf Hbf;dusseldorf-hbf;8008094;;6.794316;51.21996;7578;f;DE;f;Europe/Berlin;t;DEBEC;;t;;f;8000085;t;;f;;f;;f;;f;108008094;t;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;デュッセルドルフ;뒤셀도르프;;;;Дюссельдорф;;;
 7476;Lindau reutin;lindau-reutin;8000467;;;;;f;DE;f;Europe/Berlin;f;DEBED;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7477;Mittenwald (Gr);mittenwald-gr;8000464;;11.267439;47.39807;7685;f;DE;f;Europe/Berlin;f;DEBEE;;f;;f;8004044;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7478;Mannheim;mannheim;;;;;;t;DE;f;Europe/Berlin;f;DEBEF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7479;Mannheim Hbf;mannheim-hbf;8014008;;8.469530940055847;49.479295999056305;7478;f;DE;t;Europe/Berlin;t;DEMHG;;t;;f;8000244;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;マンハイム;만하임;;;;Мангейм;;;曼海姆
+7479;Mannheim Hbf;mannheim-hbf;8014008;;8.469530940055847;49.479295999056305;7478;f;DE;t;Europe/Berlin;t;DEMHG;;t;;f;8000244;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;マンハイム;만하임;;;;Мангейм;;;曼海姆
 7480;München Hbf;munchen-hbf;8020347;;11.558338;48.140228;;f;DE;f;Europe/Berlin;t;DEBEG;;t;;f;8000261;t;;f;;f;;f;;f;;f;;Munich Gare centrale;Munich Main station;;Monaco di Baviera Stazione centrale;Múnich;Mnichov;;;ミュンヘン;뮌헨;;Monachium;Munique;Мюнхен;;Münih;慕尼黑
 7481;Neustadt;neustadt;;;;;;t;DE;f;Europe/Berlin;f;DEBEH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7482;Neustadt (Weinstr) Hbf;neustadt-weinstr-hbf;8019403;;8.140379;49.34961;7481;f;DE;f;Europe/Berlin;t;DEQNL;;f;;f;8000275;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ノイシュタット・バイ・コーブルク;;;;;Нойштадт-ам-Ренштайг;;;伦斯泰希地区诺伊斯塔特
+7482;Neustadt (Weinstr) Hbf;neustadt-weinstr-hbf;8019403;;8.140379;49.34961;7481;f;DE;f;Europe/Berlin;t;DEQNL;;f;;f;8000275;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ノイシュタット・バイ・コーブルク;;;;;Нойштадт-ам-Ренштайг;;;伦斯泰希地区诺伊斯塔特
 7483;Wuppertal;wuppertal;;;;;;t;DE;f;Europe/Berlin;f;DEBEI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7484;Wuppertal Hbf;wuppertal-hbf;8008143;;7.149381;51.254334;7483;f;DE;f;Europe/Berlin;t;DEUWP;;f;;f;8000266;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ヴッパータール;부퍼탈;;;;Вупперталь;;;伍珀塔尔
+7484;Wuppertal Hbf;wuppertal-hbf;8008143;;7.149381;51.254334;7483;f;DE;f;Europe/Berlin;t;DEUWP;;f;;f;8000266;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ヴッパータール;부퍼탈;;;;Вупперталь;;;伍珀塔尔
 7485;Buebingen;buebingen;8025413;;;;;f;DE;f;Europe/Berlin;f;DEBEJ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7486;Puttgarden (MS);puttgarden-ms;8000023;;11.227904;54.502047;7696;f;DE;f;Europe/Berlin;f;DEBEK;;f;;f;8000079;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7487;Wengerohr;wengerohr;8080916;;;;;f;DE;f;Europe/Berlin;f;DEBEL;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6081,16 +6081,16 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7494;Marienborn;marienborn;8024036;;11.122299;52.198435;;f;DE;f;Europe/Berlin;t;DEBES;;f;;f;8012302;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7495;Löbau (Sachs);lobau-sachs;8006094;;14.671923;51.099396;;f;DE;f;Europe/Berlin;t;DEBET;;f;;f;8010212;t;;f;;f;;f;;f;;f;;;;;;;Lobava;;;;;;;;Лёбау;;;勒鲍
 7496;Weimar;weimar;8016019;;11.326462;50.99149;;f;DE;f;Europe/Berlin;t;DEBEU;;f;;f;8010366;t;;f;;f;;f;;f;;f;;;;;;;Výmar;;;ヴァイマル;바이마르;;;;Веймар;;;魏玛
-7497;Naumburg (Saale) Hbf;naumburg-saale-hbf;8016011;;11.796984;51.163067;;f;DE;f;Europe/Berlin;t;DEBEW;;f;;f;8010240;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Naumburgo;;;;ナウムブルク;나움부르크;;;;Наумбург;;;瑙姆堡
+7497;Naumburg (Saale) Hbf;naumburg-saale-hbf;8016011;;11.796984;51.163067;;f;DE;f;Europe/Berlin;t;DEBEW;;f;;f;8010240;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Naumburgo Estación central;;;;ナウムブルク;나움부르크;;;;Наумбург;;;瑙姆堡
 7498;Weißenfels;weissenfels;8016008;;11.9708;51.204831;;f;DE;f;Europe/Berlin;t;DEBEY;;f;;f;8010368;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7499;Wurzen;wurzen;8023481;;12.738973;51.364416;;f;DE;f;Europe/Berlin;t;DEBEZ;;f;;f;8013361;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7500;Berlin-Lichtenberg;berlin-lichtenberg;8003231;;13.496925;52.509894;7527;f;DE;f;Europe/Berlin;t;DEBFC;;f;;f;8010036;t;;f;;f;;f;;f;;f;;;;;Berlino;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
-7501;Zwickau (Sachs) Hbf;zwickau-sachs-hbf;8006640;;12.475984;50.714955;;f;DE;f;Europe/Berlin;t;DEBFF;;f;;f;8010397;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ツヴィッカウ;츠비카우;;;;Цвиккау;;;茨维考
+7501;Zwickau (Sachs) Hbf;zwickau-sachs-hbf;8006640;;12.475984;50.714955;;f;DE;f;Europe/Berlin;t;DEBFF;;f;;f;8010397;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ツヴィッカウ;츠비카우;;;;Цвиккау;;;茨维考
 7502;Bad Schandau;bad-schandau;8006006;;14.139861;50.918713;;f;DE;f;Europe/Berlin;t;DEBFH;;f;;f;8010022;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7503;Saalfeld (Saale);saalfeld-saale;8016332;;11.374986;50.650313;;f;DE;f;Europe/Berlin;t;DEBFI;;f;;f;8010309;t;;f;;f;;f;;f;;f;;;;;;;;;;ザールフェルト;;;;;Заальфельд;;;萨尔费尔德
 7504;Ahlhorn;ahlhorn;8021249;;8.209452;52.899513;;f;DE;f;Europe/Berlin;t;DEBFJ;;f;;f;8000442;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гросенкнетен;;;格罗森克内滕
-7505;Arnstadt Hbf;arnstadt-hbf;8016173;;10.948259;50.841936;;f;DE;f;Europe/Berlin;t;DEBFK;;f;;f;8010007;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Арнштадте;;;阿恩施塔特
-7506;Berlin-Schönefeld Flughafen;berlin-schonefeld-flughafen;8003424;;13.513178;52.391641;7527;f;DE;f;Europe/Berlin;t;DEBFL;;f;;f;8010109;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Berlino Aeroporto;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
+7505;Arnstadt Hbf;arnstadt-hbf;8016173;;10.948259;50.841936;;f;DE;f;Europe/Berlin;t;DEBFK;;f;;f;8010007;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Арнштадте;;;阿恩施塔特
+7506;Berlin-Schönefeld Flughafen;berlin-schonefeld-flughafen;8003424;;13.513178;52.391641;7527;f;DE;f;Europe/Berlin;t;DEBFL;;f;;f;8010109;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Berlino Aeroporto;Aeropuerto;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
 7507;Waren (Müritz);waren-muritz;8028087;;12.680678;53.521513;;f;DE;f;Europe/Berlin;t;DEBFO;;f;;f;8010361;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7508;Probstzella;probstzella;8016340;;11.38357;50.528231;;f;DE;f;Europe/Berlin;t;DEBFQ;;f;;f;8010288;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7509;Oebisfelde;oebisfelde;8024052;;10.984899;52.439598;;f;DE;f;Europe/Berlin;t;DEBFR;;f;;f;8010261;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6103,7 +6103,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7516;Bautzen;bautzen;8006099;;14.428738;51.173099;;f;DE;f;Europe/Berlin;t;DEBHA;;f;;f;8010026;t;;f;;f;;f;;f;;f;;;;;;;Budyšín;;;バウツェン;;;Budziszyn;;Баутцен;;;包岑
 7517;Bühl (Baden);buhl-baden;8014281;;8.129295;48.696678;;f;DE;f;Europe/Berlin;t;DEBHB;;f;;f;8001252;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бюль;;;
 7518;Dresde;dresde;;;;;;t;DE;f;Europe/Berlin;f;DEBHD;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7519;Dresden Hbf;dresden-hbf;8006050;;13.732038;51.040562;7518;f;DE;f;Europe/Berlin;t;DEDRS;;f;;f;8010085;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Dresde;Drážďany;;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
+7519;Dresden Hbf;dresden-hbf;8006050;;13.732038;51.040562;7518;f;DE;f;Europe/Berlin;t;DEDRS;;f;;f;8010085;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Dresde Estación central;Drážďany;;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
 7520;Bad Hersfeld;bad-hersfeld;8005647;;9.716179;50.869632;;f;DE;f;Europe/Berlin;t;DEBHF;;f;;f;8000020;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7521;Eisenach;eisenach;8016077;;10.332147;50.977089;;f;DE;f;Europe/Berlin;t;DEBHG;;f;;f;8010097;t;;f;;f;;f;;f;;f;;;;;;;;;;アイゼナハ;아이제나흐;;;;Айзенах;;;艾森纳赫
 7522;Buchholz (Nordheide);buchholz-nordheide;8001233;;9.876592;53.324568;;f;DE;f;Europe/Berlin;t;DEBHH;;f;;f;8000056;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6120,67 +6120,67 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7533;Bad Kreuznach;bad-kreuznach;8019186;;7.866433;49.842399;;f;DE;f;Europe/Berlin;t;DEBKN;;f;;f;8000021;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7534;Bad Krozingen;bad-krozingen;8014408;;7.69784;47.919966;;f;DE;f;Europe/Berlin;t;DEBKR;;f;;f;8000718;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бад-Кроцинген;;;巴德克罗钦根
 7535;Berlin-Charlottenburg;berlin-charlottenburg;8003034;;13.303522;52.504725;7527;f;DE;f;Europe/Berlin;t;DEBLC;;f;;f;8010403;t;;f;;f;;f;;f;;f;;;;;Berlino;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
-7536;Bielefeld Hbf;bielefeld-hbf;8013597;;8.532722;52.029258;;f;DE;f;Europe/Berlin;t;DEBLF;;f;;f;8000036;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ビーレフェルト;빌레펠트;;;;Билефельд;;;比勒费尔德
+7536;Bielefeld Hbf;bielefeld-hbf;8013597;;8.532722;52.029258;;f;DE;f;Europe/Berlin;t;DEBLF;;f;;f;8000036;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ビーレフェルト;빌레펠트;;;;Билефельд;;;比勒费尔德
 7537;Brohl;brohl;8019007;;7.332635;50.481433;;f;DE;f;Europe/Berlin;t;DEBLH;;f;;f;8001186;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7538;Bremerhaven;bremerhaven;;;;;;t;DE;f;Europe/Berlin;f;DEBMH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7539;Bremerhaven Hbf;bremerhaven-hbf;8013786;;8.599557;53.534916;7538;f;DE;f;Europe/Berlin;t;DEBRH;;f;;f;8000051;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ブレーマーハーフェン;브레머하펜;;;;Бремерхафен;;;不来梅哈芬
+7539;Bremerhaven Hbf;bremerhaven-hbf;8013786;;8.599557;53.534916;7538;f;DE;f;Europe/Berlin;t;DEBRH;;f;;f;8000051;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ブレーマーハーフェン;브레머하펜;;;;Бремерхафен;;;不来梅哈芬
 7540;Berlin Ostbahnhof;berlin-ostbahnhof;8003004;;13.434567;52.510972;7527;f;DE;f;Europe/Berlin;t;DEBML;;f;;f;8010255;t;;f;;f;;f;;f;;f;;;;;Berlino;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
 7541;Bad Münster a Stein;bad-munster-a-stein;8019187;;7.846989;49.813426;;f;DE;f;Europe/Berlin;t;DEBMS;;f;;f;8000726;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7542;Bad Honnef (Rhein);bad-honnef-rhein;8015585;;7.219533;50.639769;;f;DE;f;Europe/Berlin;t;DEBNF;;f;;f;8000713;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7543;Bingen (Rhein) Hbf;bingen-rhein-hbf;8019041;;7.884258;49.968724;;f;DE;f;Europe/Berlin;t;DEBNG;;f;;f;8000039;t;;f;;f;;f;;f;108000039;t;;Gare centrale;Main station;;Stazione centrale;;;;;ビンゲン・アム・ライン;;;;;Бинген-на-Рейне;;;莱茵河畔宾根
+7543;Bingen (Rhein) Hbf;bingen-rhein-hbf;8019041;;7.884258;49.968724;;f;DE;f;Europe/Berlin;t;DEBNG;;f;;f;8000039;t;;f;;f;;f;;f;108000039;t;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ビンゲン・アム・ライン;;;;;Бинген-на-Рейне;;;莱茵河畔宾根
 7544;Bad Nauheim;bad-nauheim;8011402;;8.749335;50.367899;;f;DE;f;Europe/Berlin;t;DEBNH;;f;;f;8000728;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7545;Bonn;bonn;;;;;;t;DE;f;Europe/Berlin;f;DEBNJ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7546;Buchloe;buchloe;8002181;;10.71622;48.033724;;f;DE;f;Europe/Berlin;t;DEBOE;;f;;f;8000057;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7547;Boppard Hbf;boppard-hbf;8019029;;7.586104;50.231416;;f;DE;f;Europe/Berlin;t;DEBPP;;f;;f;8000045;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
-7548;Bremen Hbf;bremen-hbf;8013750;;8.813833;53.083477;;f;DE;f;Europe/Berlin;t;DEBRE;;f;;f;8000050;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Brémy;;Bréma;ブレーメン;브레멘;;Brema;;Бремен;;;不来梅
+7547;Boppard Hbf;boppard-hbf;8019029;;7.586104;50.231416;;f;DE;f;Europe/Berlin;t;DEBPP;;f;;f;8000045;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
+7548;Bremen Hbf;bremen-hbf;8013750;;8.813833;53.083477;;f;DE;f;Europe/Berlin;t;DEBRE;;f;;f;8000050;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;Brémy;;Bréma;ブレーメン;브레멘;;Brema;;Бремен;;;不来梅
 7549;Bensheim;bensheim;8011306;;8.616978;49.681231;;f;DE;f;Europe/Berlin;t;DEBSH;;f;;f;8000031;t;;f;;f;;f;;f;;f;;;;;;;;;;ベンスハイム;;;;;Бенсхайм;;;本斯海姆
 7550;Berlin-Spandau;berlin-spandau;8003025;;13.19753;52.53447;7527;f;DE;f;Europe/Berlin;t;DEBSP;;f;;f;8010404;t;;f;;f;;f;;f;;f;;;;;Berlino;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
 7551;Brunswick;brunswick;8013241;;;;;f;DE;f;Europe/Berlin;f;DEBSW;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7552;Bretten;bretten;8014094;;8.693135;49.036947;;f;DE;f;Europe/Berlin;t;DEBTN;;f;;f;8000053;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7553;Bad Oeynhausen;bad-oeynhausen;8013585;;8.796933;52.205465;;f;DE;f;Europe/Berlin;t;DEBYN;;f;;f;8000732;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7554;Bayreuth Hbf;bayreuth-hbf;8022248;;11.579985;49.949613;;f;DE;f;Europe/Berlin;t;DEBYU;;f;;f;8000028;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;バイロイト;바이로이트;;;;Байройт;;;拜罗伊特
+7554;Bayreuth Hbf;bayreuth-hbf;8022248;;11.579985;49.949613;;f;DE;f;Europe/Berlin;t;DEBYU;;f;;f;8000028;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;バイロイト;바이로이트;;;;Байройт;;;拜罗伊特
 7555;Butzbach;butzbach;8011407;;8.66952;50.431156;;f;DE;f;Europe/Berlin;t;DEBZB;;f;;f;8001312;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7556;Bützow;butzow;8027021;;11.997749;53.836809;;f;DE;f;Europe/Berlin;t;DEBZW;;f;;f;8010066;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бютцов;;;比措
 7557;Cottbus;cottbus;8004019;;14.324158;51.750952;;f;DE;f;Europe/Berlin;t;DECBU;;f;;f;8010073;t;;f;;f;;f;;f;;f;;;;;;;Chotěbuz;;;コトブス;콧부스;;Chociebuż;;Котбус;;;科特布斯
 7558;Köln;koln;;;6.967206;50.941312;;t;DE;f;Europe/Berlin;t;DECGN;;t;;f;8096022;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
 7559;Köln-Mülheim;koln-mulheim;8015541;;7.013294;50.957987;7558;f;DE;f;Europe/Berlin;t;DEKOM;;f;;f;8000209;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
 7560;Köln Messe/Deutz;koln-messe-deutz;8015561;;6.975;50.940871;7558;f;DE;f;Europe/Berlin;t;DEKOD;;f;;f;8003368;t;QKU;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
-7561;Köln Hbf;koln-hbf;8015458;80154583;6.958729;50.943029;7558;f;DE;t;Europe/Berlin;t;DEKOH;;t;;f;8000207;t;;f;;f;;f;;f;108015458;t;;Cologne Gare centrale;Cologne Main station;;Colonia Stazione centrale;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
-7562;Celle;celle;8013631;;10.062704;52.621171;;f;DE;f;Europe/Berlin;t;DECLL;;f;;f;8000064;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;;;;;ツェレ;첼레;;;;Целле;;;策勒
+7561;Köln Hbf;koln-hbf;8015458;80154583;6.958729;50.943029;7558;f;DE;t;Europe/Berlin;t;DEKOH;;t;;f;8000207;t;;f;;f;;f;;f;108015458;t;;Cologne Gare centrale;Cologne Main station;;Colonia Stazione centrale;Colonia Estación central;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
+7562;Celle;celle;8013631;;10.062704;52.621171;;f;DE;f;Europe/Berlin;t;DECLL;;f;;f;8000064;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;Alemania;;;;ツェレ;첼레;;;;Целле;;;策勒
 7563;Cochem (Mosel);cochem-mosel;8025107;;7.166739;50.153093;;f;DE;f;Europe/Berlin;t;DECMO;;f;;f;8001340;t;;f;;f;;f;;f;;f;;;;;;;;;;コッヘム;;;;;Кохем;;;科赫姆
 7564;Crailsheim;crailsheim;8029685;;10.064322;49.137869;;f;DE;f;Europe/Berlin;t;DECRH;;f;;f;8000067;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7565;Creußen (Oberfr);creussen-oberfr;8022296;;11.628445;49.849473;;f;DE;f;Europe/Berlin;t;DECSS;;f;;f;8001348;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7566;Cuxhaven;cuxhaven;8001205;;8.703706;53.861008;;f;DE;f;Europe/Berlin;t;DECUX;;f;;f;8001352;t;;f;;f;;f;;f;;f;;;;;;;;;;;쿡스하펜;;;;Куксхафен;;;库克斯港
-7567;Brandenburg Hbf;brandenburg-hbf;8024019;;12.566245;52.400765;;f;DE;f;Europe/Berlin;t;DEDBG;;f;;f;8010060;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Brandeburgo;;;;ブランデンブルク・アン・デア・ハーフェル;브란덴부르크안데어하펠;;;;Бранденбург-на-Хафеле;;;哈弗尔河畔勃兰登堡
+7567;Brandenburg Hbf;brandenburg-hbf;8024019;;12.566245;52.400765;;f;DE;f;Europe/Berlin;t;DEDBG;;f;;f;8010060;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Brandeburgo Estación central;;;;ブランデンブルク・アン・デア・ハーフェル;브란덴부르크안데어하펠;;;;Бранденбург-на-Хафеле;;;哈弗尔河畔勃兰登堡
 7568;Dombühl;dombuhl;8022742;;10.298518;49.252113;;f;DE;f;Europe/Berlin;t;DEDMB;;f;;f;8000365;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7569;Delmenhorst;delmenhorst;8013828;;8.629761;53.052788;;f;DE;f;Europe/Berlin;t;DEDMH;;f;;f;8000070;t;;f;;f;;f;;f;;f;;;;;;;;;;デルメンホルスト;;;;;Дельменхорст;;;代尔门霍斯特
 7570;Donaueschingen;donaueschingen;8014529;;8.498923;47.947787;;f;DE;f;Europe/Berlin;t;DEDNE;;f;;f;8000077;t;;f;;f;;f;;f;;f;;;;;;;;;;ドナウエッシンゲン;;;;;Донауэшинген;;;多瑙艾辛根
 7571;Dillingen (Donau);dillingen-donau;8002078;;10.48917;48.581257;;f;DE;f;Europe/Berlin;t;DEDON;;f;;f;8001463;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7572;Darmstadt Hbf;darmstadt-hbf;8011336;;8.629635;49.872503;;f;DE;f;Europe/Berlin;t;DEDST;;f;;f;8000068;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ダルムシュタット;다름슈타트;;;;Дармштадт;;;达姆施塔特
-7573;Dortmund Hbf;dortmund-hbf;8010053;;7.459293;51.517898;;f;DE;f;Europe/Berlin;t;DEDTM;;f;;f;8000080;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ドルトムント;도르트문트;;;;Дортмунд;;;多特蒙德
+7572;Darmstadt Hbf;darmstadt-hbf;8011336;;8.629635;49.872503;;f;DE;f;Europe/Berlin;t;DEDST;;f;;f;8000068;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ダルムシュタット;다름슈타트;;;;Дармштадт;;;达姆施塔特
+7573;Dortmund Hbf;dortmund-hbf;8010053;;7.459293;51.517898;;f;DE;f;Europe/Berlin;t;DEDTM;;f;;f;8000080;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ドルトムント;도르트문트;;;;Дортмунд;;;多特蒙德
 7574;Düsseldorf-Benrath;dusseldorf-benrath;8008117;;6.87904;51.162375;7578;f;DE;f;Europe/Berlin;t;DEDUB;;f;;f;8001584;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Дюссельдорф-Бенрат;;;
-7575;Düsseldorf Flughafen;dusseldorf-flughafen;8039904;;6.786837;51.292008;7578;f;DE;f;Europe/Berlin;t;DEDUF;;t;;f;8000082;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;デュッセルドルフ;뒤셀도르프;;;;Дюссельдорф;;;
-7576;Duisburg Hbf;duisburg-hbf;8010316;;6.775906;51.429786;;f;DE;f;Europe/Berlin;t;DEDUI;;t;;f;8000086;t;;f;;f;;f;;f;108010316;t;;Duisbourg Gare centrale;Main station;;Stazione centrale;Duisburgo;;;;デュイスブルク;뒤스부르크;;;Duisburgo;Дуйсбург;;;杜伊斯堡
+7575;Düsseldorf Flughafen;dusseldorf-flughafen;8039904;;6.786837;51.292008;7578;f;DE;f;Europe/Berlin;t;DEDUF;;t;;f;8000082;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;デュッセルドルフ;뒤셀도르프;;;;Дюссельдорф;;;
+7576;Duisburg Hbf;duisburg-hbf;8010316;;6.775906;51.429786;;f;DE;f;Europe/Berlin;t;DEDUI;;t;;f;8000086;t;;f;;f;;f;;f;108010316;t;;Duisbourg Gare centrale;Main station;;Stazione centrale;Duisburgo Estación central;;;;デュイスブルク;뒤스부르크;;;Duisburgo;Дуйсбург;;;杜伊斯堡
 7577;Düren;duren;8015330;;6.482031;50.809395;;f;DE;f;Europe/Berlin;t;DEDUR;;f;;f;8000084;t;;f;;f;;f;;f;;f;;;;;;;;;;;뒤렌;;;;Дюрен;;;迪伦
 7578;Düsseldorf;dusseldorf;8080260;;;;;t;DE;f;Europe/Berlin;f;DEDUS;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7579;Eberbach;eberbach;8014121;;8.984152;49.465769;;f;DE;f;Europe/Berlin;t;DEEBB;;f;;f;8000369;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7580;Eberswalde Hbf;eberswalde-hbf;8028227;;13.797057;52.834018;;f;DE;f;Europe/Berlin;t;DEEBW;;f;;f;8010093;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;エーベルスヴァルデ;에베르스발데;;;;Эберсвальде;;;埃贝尔斯瓦尔德
+7580;Eberswalde Hbf;eberswalde-hbf;8028227;;13.797057;52.834018;;f;DE;f;Europe/Berlin;t;DEEBW;;f;;f;8010093;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;エーベルスヴァルデ;에베르스발데;;;;Эберсвальде;;;埃贝尔斯瓦尔德
 7581;Elze (Han);elze-han;8013420;;9.746895;52.120148;;f;DE;f;Europe/Berlin;t;DEEHA;;f;;f;8000093;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Эльце;;;埃尔策
 7582;Ehrang;ehrang;8025142;;6.685808;49.802028;;f;DE;f;Europe/Berlin;t;DEEHR;;f;;f;8000370;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7583;Eichenberg;eichenberg;8013046;;9.921484;51.374826;;f;DE;f;Europe/Berlin;t;DEEIC;;f;;f;8000090;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7584;Eltville;eltville;8011011;;8.121529;50.027558;;f;DE;f;Europe/Berlin;t;DEELT;;f;;f;8001763;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7585;Ellwangen;ellwangen;8029693;;10.129683;48.964117;;f;DE;f;Europe/Berlin;t;DEELW;;f;;f;8001751;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7586;Emden Hbf;emden-hbf;8021099;;7.19501;53.369011;;f;DE;f;Europe/Berlin;t;DEEME;;f;;f;8001768;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;エムデン;엠덴;;;;Эмден;;;埃姆登
+7586;Emden Hbf;emden-hbf;8021099;;7.19501;53.369011;;f;DE;f;Europe/Berlin;t;DEEME;;f;;f;8001768;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;エムデン;엠덴;;;;Эмден;;;埃姆登
 7587;Engen;engen;8014554;;8.772788;47.856349;;f;DE;f;Europe/Berlin;t;DEENG;;f;;f;8001790;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7588;Erfurt Hbf;erfurt-hbf;8016043;;11.038501;50.972549;;f;DE;f;Europe/Berlin;t;DEERF;;f;;f;8010101;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Érfurt;;;;エアフルト;에르푸르트;;;;Эрфурт;;;埃尔福特
+7588;Erfurt Hbf;erfurt-hbf;8016043;;11.038501;50.972549;;f;DE;f;Europe/Berlin;t;DEERF;;f;;f;8010101;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Érfurt Estación central;;;;エアフルト;에르푸르트;;;;Эрфурт;;;埃尔福特
 7589;Erkelenz;erkelenz;8015183;;6.321717;51.076564;;f;DE;f;Europe/Berlin;t;DEERK;;f;;f;8001839;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7590;Esslingen-am-Neckar;esslingen-am-neckar;8029054;;;;;f;DE;f;Europe/Berlin;f;DEESN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7591;Essen Hbf;essen-hbf;8010184;;7.014795;51.451351;;f;DE;f;Europe/Berlin;t;DEESS;;t;;f;8000098;t;ESX;t;;f;;f;;f;108010184;t;;Gare centrale;Main station;;Stazione centrale;;;;;エッセン;에센;;;;Эссен;;;埃森
-7592;Fürth (Bay) Hbf;furth-bay-hbf;8022187;;10.989987;49.469706;;f;DE;f;Europe/Berlin;t;DEFBH;;f;;f;8000114;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;フュルト;퓌르트;;;;Фюрт;;;菲尔特
+7591;Essen Hbf;essen-hbf;8010184;;7.014795;51.451351;;f;DE;f;Europe/Berlin;t;DEESS;;t;;f;8000098;t;ESX;t;;f;;f;;f;108010184;t;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;エッセン;에센;;;;Эссен;;;埃森
+7592;Fürth (Bay) Hbf;furth-bay-hbf;8022187;;10.989987;49.469706;;f;DE;f;Europe/Berlin;t;DEFBH;;f;;f;8000114;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;フュルト;퓌르트;;;;Фюрт;;;菲尔特
 7593;Plauen (Vogtl) ob Bf;plauen-vogtl-ob-bf;8006712;;12.12954;50.505937;;f;DE;f;Europe/Berlin;t;DEFBS;;f;;f;8010275;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7594;Friedrichshafen Stadt;friedrichshafen-stadt;8029162;;9.473902;47.65322;;f;DE;f;Europe/Berlin;t;DEFDH;;f;;f;8000112;t;;f;;f;;f;;f;;f;;;;;;;;;;フリードリヒスハーフェン;;;;;Фридрихсхафен;;;腓特烈港
 7596;Frankfurt (M) Flughafen Fernbf;frankfurt-m-flughafen-fernbf;8061676;;8.569872379302979;50.05290581298199;;f;DE;f;Europe/Berlin;t;DEFFF;;t;;f;8070003;t;;f;;f;;f;;f;;f;;Francfort Aéroport;Airport;;Francoforte Aeroporto;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-7597;Freiburg (Breisgau) Hbf;freiburg-breisgau-hbf;8014350;80143503;7.841593623161316;47.997690269936264;7692;f;DE;t;Europe/Berlin;t;DEFGB;;t;;f;8000107;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Freiberg;;;;フライベルク;;Freiberg;Freiberg;Freiberga;Фрайбург;Freiberg;;弗莱贝格
+7597;Freiburg (Breisgau) Hbf;freiburg-breisgau-hbf;8014350;80143503;7.841593623161316;47.997690269936264;7692;f;DE;t;Europe/Berlin;t;DEFGB;;t;;f;8000107;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Freiberg Estación central;;;;フライベルク;;Freiberg;Freiberg;Freiberga;Фрайбург;Freiberg;;弗莱贝格
 7598;Bergen auf Rügen;bergen-auf-rugen;8028496;;13.41782;54.420497;;f;DE;f;Europe/Berlin;t;DEFGV;;f;;f;8010033;t;;f;;f;;f;;f;;f;;;;;;;;;;;베르겐아우프뤼겐;;;;Берген-на-Рюгене;;;贝尔根奥夫吕根
 7599;Binz LB;binz-lb;8028951;;13.609947;54.392783;;f;DE;f;Europe/Berlin;t;DEFHA;;f;;f;8011193;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7600;Freilassing;freilassing;8000462;;12.977196;47.836914;;f;DE;f;Europe/Berlin;t;DEFLS;;f;;f;8000108;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6194,14 +6194,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7608;Gießen;giessen;8011033;;8.661466;50.579056;;f;DE;f;Europe/Berlin;t;DEGIE;;f;;f;8000124;t;;f;;f;;f;;f;;f;;;;;;;;;;ギーセン;기센;;;;Гиссен;;;吉森
 7609;Geilenkirchen;geilenkirchen;8015188;;6.124368;50.961097;;f;DE;f;Europe/Berlin;t;DEGLK;;f;;f;8002206;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7610;Gelnhausen;gelnhausen;8011044;;9.189276;50.19634;;f;DE;f;Europe/Berlin;t;DEGLN;;f;;f;8000117;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7611;Gelsenkirchen Hbf;gelsenkirchen-hbf;8010143;;7.102583;51.505016;;f;DE;f;Europe/Berlin;t;DEGLS;;f;;f;8000118;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ゲルゼンキルヒェン;겔젠키르헨;;;;Гельзенкирхен;;;盖尔森基兴
+7611;Gelsenkirchen Hbf;gelsenkirchen-hbf;8010143;;7.102583;51.505016;;f;DE;f;Europe/Berlin;t;DEGLS;;f;;f;8000118;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ゲルゼンキルヒェン;겔젠키르헨;;;;Гельзенкирхен;;;盖尔森基兴
 7612;Gemünden (Main);gemunden-main;8022549;;9.699891;50.050013;;f;DE;f;Europe/Berlin;t;DEGMM;;f;;f;8000120;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7613;Göttingen;gottingen;8013050;;9.925682;51.536614;;f;DE;f;Europe/Berlin;t;DEGOE;;f;;f;8000128;t;;f;;f;;f;;f;;f;;Gœttingue;;;Gottinga;Gotinga;;;;ゲッティンゲン;괴팅겐;;Getynga;Gotinga;Гёттинген;;;哥廷根
 7614;Göppingen;goppingen;8029065;;9.651969;48.700022;;f;DE;f;Europe/Berlin;t;DEGPG;;f;;f;8000127;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гёппинген;;;格平根
 7615;Graben-Neudorf;graben-neudorf;8014068;;8.490545;49.162284;;f;DE;f;Europe/Berlin;t;DEGRN;;f;;f;8000131;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7616;Großkorbetha;grosskorbetha;8023011;;12.022173;51.267315;;f;DE;f;Europe/Berlin;t;DEGRO;;f;;f;8010146;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7617;Geisenheim;geisenheim;8011007;;7.968802;49.985974;;f;DE;f;Europe/Berlin;t;DEGSH;;f;;f;8002212;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7618;Gütersloh Hbf;gutersloh-hbf;8013606;;8.385632;51.90732;;f;DE;f;Europe/Berlin;t;DEGSL;;f;;f;8002461;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;귀터슬로;;;;Гютерсло;;;居特斯洛
+7618;Gütersloh Hbf;gutersloh-hbf;8013606;;8.385632;51.90732;;f;DE;f;Europe/Berlin;t;DEGSL;;f;;f;8002461;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;귀터슬로;;;;Гютерсло;;;居特斯洛
 7619;Geislingen (Steige);geislingen-steige;8029086;;9.841821;48.61947;;f;DE;f;Europe/Berlin;t;DEGSS;;f;;f;8002218;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7620;Gutach schwarzwaldb;gutach-schwarzwaldb;8014510;;;;;f;DE;f;Europe/Berlin;f;DEGTC;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7621;Baunatal-Guntershausen;baunatal-guntershausen;8005369;;9.466998;51.22992;;f;DE;f;Europe/Berlin;t;DEGTH;;f;;f;8000140;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6212,11 +6212,11 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7626;Hamburg;hamburg;8001083;;9.965836;53.563816;;t;DE;f;Europe/Berlin;t;DEHAM;;f;;f;8096009;t;;f;;f;;f;;f;;f;;Hambourg;;;Amburgo;Hamburgo;Hamburk;Hamborg;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
 7627;Hamburg Dammtor;hamburg-dammtor;8001089;;9.989568;53.560751;7626;f;DE;f;Europe/Berlin;t;DEHDA;;f;;f;8002548;t;;f;;f;;f;;f;;f;;Hambourg;;;Amburgo;Hamburgo;Hamburk;Hamborg;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
 7628;Hamburg-Harburg;hamburg-harburg;8001134;;9.991591;53.456296;7626;f;DE;f;Europe/Berlin;t;DEHHA;;f;;f;8000147;t;;f;;f;;f;;f;108001134;t;;Hambourg;;;Amburgo;Hamburgo;Hamburk;Hamborg;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
-7629;Hanau Hbf;hanau-hbf;8011051;;8.929165;50.12128;;f;DE;f;Europe/Berlin;t;DEHAU;;f;;f;8000150;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ハーナウ;;;;;;;;
-7630;Berlin Hbf;berlin-hbf;8033452;80334524;13.369548;52.525589;7527;f;DE;t;Europe/Berlin;t;DEHBF;;f;;f;8011160;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Berlino Stazione centrale;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
-7631;Heilbronn Hbf;heilbronn-hbf;8029629;;9.207713;49.143308;;f;DE;f;Europe/Berlin;t;DEHBN;;f;;f;8000157;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ハイルブロン;하일브론;;;;Хайльбронн;;;海尔布隆
+7629;Hanau Hbf;hanau-hbf;8011051;;8.929165;50.12128;;f;DE;f;Europe/Berlin;t;DEHAU;;f;;f;8000150;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ハーナウ;;;;;;;;
+7630;Berlin Hbf;berlin-hbf;8033452;80334524;13.369548;52.525589;7527;f;DE;t;Europe/Berlin;t;DEHBF;;f;;f;8011160;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Berlino Stazione centrale;Estación central;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
+7631;Heilbronn Hbf;heilbronn-hbf;8029629;;9.207713;49.143308;;f;DE;f;Europe/Berlin;t;DEHBN;;f;;f;8000157;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ハイルブロン;하일브론;;;;Хайльбронн;;;海尔布隆
 7632;Heidelberg;heidelberg;;;;;;t;DE;f;Europe/Berlin;f;DEHEI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7633;Heidelberg Hbf;heidelberg-hbf;8014021;;8.675741;49.403779;7632;f;DE;f;Europe/Berlin;t;DEQHD;;f;;f;8000156;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ハイデルベルク;하이델베르크;;;;Гейдельберг;;;海德堡
+7633;Heidelberg Hbf;heidelberg-hbf;8014021;;8.675741;49.403779;7632;f;DE;f;Europe/Berlin;t;DEQHD;;f;;f;8000156;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ハイデルベルク;하이델베르크;;;;Гейдельберг;;;海德堡
 7634;Hersbruck (Pegnitz);hersbruck-pegnitz;8002712;;11.426611;49.503928;;t;DE;f;Europe/Berlin;f;DEHER;;f;;f;8096017;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7635;Hersbruck (r Pegnitz);hersbruck-r-pegnitz;8022309;;11.423824;49.510076;7634;f;DE;f;Europe/Berlin;t;DEHRP;;f;;f;8002794;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7636;Herford;herford;8013593;;8.663641;52.119609;;f;DE;f;Europe/Berlin;t;DEHFD;;f;;f;8000162;t;;f;;f;;f;;f;;f;;;;;;;;;;ヘルフォルト;;;;;Херфорд;;;黑爾福德
@@ -6226,51 +6226,51 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7640;Helmstedt;helmstedt;8013227;;11.010734;52.222221;;f;DE;f;Europe/Berlin;t;DEHMT;;f;;f;8000159;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Хельмштедт;;;黑尔姆斯特
 7641;Hornberg (Schwarzw);hornberg-schwarzw;8014511;;8.232941;48.21189;;f;DE;f;Europe/Berlin;t;DEHNB;;f;;f;8003001;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7642;Wunsiedel-Holenbrunn;wunsiedel-holenbrunn;8026059;;12.033931;50.05111;;f;DE;f;Europe/Berlin;t;DEHNN;;f;;f;8000173;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7643;Herne;herne;8010038;;7.217825;51.543652;;f;DE;f;Europe/Berlin;t;DEHNR;;f;;f;8000164;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;;;;;ヘルネ;헤르네;;;;Херне;;;黑尔讷
+7643;Herne;herne;8010038;;7.217825;51.543652;;f;DE;f;Europe/Berlin;t;DEHNR;;f;;f;8000164;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;Alemania;;;;ヘルネ;헤르네;;;;Херне;;;黑尔讷
 7644;Holzminden;holzminden;8013330;;9.454314;51.820834;;f;DE;f;Europe/Berlin;t;DEHOL;;f;;f;8000391;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7645;Hof Hbf;hof-hbf;8000637;;11.923067;50.307743;;f;DE;f;Europe/Berlin;t;DEHOQ;;f;;f;8002924;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ヘッシシュ・オルデンドルフ;호프;;;;Хессиш-Ольдендорф;;;黑西施奥尔登多夫
+7645;Hof Hbf;hof-hbf;8000637;;11.923067;50.307743;;f;DE;f;Europe/Berlin;t;DEHOQ;;f;;f;8002924;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ヘッシシュ・オルデンドルフ;호프;;;;Хессиш-Ольдендорф;;;黑西施奥尔登多夫
 7646;Heppenheim (Bergstr);heppenheim-bergstr;8011307;;8.633213;49.641535;;f;DE;f;Europe/Berlin;t;DEHPP;;f;;f;8002757;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7647;Horrem;horrem;8015327;;6.713494;50.91625;;f;DE;f;Europe/Berlin;t;DEHRR;;f;;f;8000178;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7648;Homburg (Saar) Hbf;homburg-saar-hbf;8025459;;7.337031;49.328081;;f;DE;f;Europe/Berlin;t;DEHSA;;f;;f;8000176;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+7648;Homburg (Saar) Hbf;homburg-saar-hbf;8025459;;7.337031;49.328081;;f;DE;f;Europe/Berlin;t;DEHSA;;f;;f;8000176;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 7649;Hausach;hausach;8014502;;8.181666;48.284928;;f;DE;f;Europe/Berlin;t;DEHSH;;f;;f;8000333;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7650;Haslach;haslach;8014501;;8.087972;48.280037;;f;DE;f;Europe/Berlin;t;DEHSL;;f;;f;8002621;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7651;Ingelheim;ingelheim;8019046;;8.053175;49.976176;;f;DE;f;Europe/Berlin;t;DEIGH;;f;;f;8003075;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7652;Immendingen;immendingen;8014534;;8.729532;47.936002;;f;DE;f;Europe/Berlin;t;DEIMI;;f;;f;8000182;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7653;Immenstadt;immenstadt;8002342;;10.214002;47.559201;;f;DE;f;Europe/Berlin;t;DEIMM;;f;;f;8003065;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7654;Idar-Oberstein;idar-oberstein;8025279;;7.321228;49.699371;;f;DE;f;Europe/Berlin;t;DEIOB;;f;;f;8003040;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7655;Köln/Bonn Flughafen;koln-bonn-flughafen;8032003;;7.119303;50.8789;;f;DE;f;Europe/Berlin;t;DEKAB;;f;;f;8003330;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
-7656;Kempten (Allgäu) Hbf;kempten-allgau-hbf;8002307;;10.317611;47.711748;;f;DE;f;Europe/Berlin;t;DEKAL;;f;;f;8000197;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+7655;Köln/Bonn Flughafen;koln-bonn-flughafen;8032003;;7.119303;50.8789;;f;DE;f;Europe/Berlin;t;DEKAB;;f;;f;8003330;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
+7656;Kempten (Allgäu) Hbf;kempten-allgau-hbf;8002307;;10.317611;47.711748;;f;DE;f;Europe/Berlin;t;DEKAL;;f;;f;8000197;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 7657;Kaufbeuren;kaufbeuren;8002278;;10.629492;47.875433;;f;DE;f;Europe/Berlin;t;DEKBR;;f;;f;8000194;t;;f;;f;;f;;f;;f;;;;;;;;;;カウフボイレン;;;;;Кауфбойрен;;;考夫博伊伦
 7658;Karlsruhe-Durlach;karlsruhe-durlach;8014043;;8.462364;49.001961;7665;f;DE;f;Europe/Berlin;t;DEKDR;;f;;f;8003184;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7659;Kehl;kehl;;;;;;t;DE;f;Europe/Berlin;f;DEKEH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7660;Krefeld;krefeld;;;;;;t;DE;f;Europe/Berlin;f;DEKFL;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7661;Krefeld Hbf;krefeld-hbf;8015035;;6.570224;51.325772;7660;f;DE;f;Europe/Berlin;t;DEKRF;;f;;f;8000211;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;クレフェルト;크레펠트;;;;Крефельд;;;
+7661;Krefeld Hbf;krefeld-hbf;8015035;;6.570224;51.325772;7660;f;DE;f;Europe/Berlin;t;DEKRF;;f;;f;8000211;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;クレフェルト;크레펠트;;;;Крефельд;;;
 7662;Kirchhain (Bz Kassel);kirchhain-bz-kassel;8005383;;8.921398;50.823778;;f;DE;f;Europe/Berlin;t;DEKHN;;f;;f;8000435;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7663;Kiel Hbf;kiel-hbf;8001304;;10.131975;54.314982;;f;DE;f;Europe/Berlin;t;DEKIE;;f;;f;8000199;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ケール;킬;Kehl;Kilonia;Kehl;Кель;;;凱爾
+7663;Kiel Hbf;kiel-hbf;8001304;;10.131975;54.314982;;f;DE;f;Europe/Berlin;t;DEKIE;;f;;f;8000199;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ケール;킬;Kehl;Kilonia;Kehl;Кель;;;凱爾
 7664;Kirchenlaibach;kirchenlaibach;8026089;;11.776327;49.869906;;f;DE;f;Europe/Berlin;t;DEKLB;;f;;f;8000201;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7665;Karlsruhe;karlsruhe;;;;;;t;DE;f;Europe/Berlin;f;DEKLS;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7666;Karlsruhe Hbf;karlsruhe-hbf;8014228;;8.401848077774048;48.993509649554724;7665;f;DE;t;Europe/Berlin;t;DEQKA;;t;;f;8000191;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;カールスルーエ;카를스루에;;;;Карлсруэ;;;卡尔斯鲁厄
-7667;Kaiserslautern Hbf;kaiserslautern-hbf;8019698;;7.768711;49.43614;;f;DE;f;Europe/Berlin;t;DEKLT;;t;;f;8000189;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;カイザースラウテルン;카이저슬라우테른;;;;Кайзерслаутерн;;;
+7666;Karlsruhe Hbf;karlsruhe-hbf;8014228;;8.401848077774048;48.993509649554724;7665;f;DE;t;Europe/Berlin;t;DEQKA;;t;;f;8000191;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;カールスルーエ;카를스루에;;;;Карлсруэ;;;卡尔斯鲁厄
+7667;Kaiserslautern Hbf;kaiserslautern-hbf;8019698;;7.768711;49.43614;;f;DE;f;Europe/Berlin;t;DEKLT;;t;;f;8000189;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;カイザースラウテルン;카이저슬라우테른;;;;Кайзерслаутерн;;;
 7668;Kornwestheim Pbf;kornwestheim-pbf;8029026;;9.179964;48.862215;;f;DE;f;Europe/Berlin;t;DEKOR;;f;;f;8003411;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7669;Konstanz-Petershausen;konstanz-petershausen;8014584;;9.171514;47.674839;;f;DE;f;Europe/Berlin;t;DEKPT;;f;;f;8003401;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7670;Kreiensen;kreiensen;8013060;;9.967796;51.851425;;f;DE;f;Europe/Berlin;t;DEKRS;;f;;f;8000213;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7671;Kassel Hbf;kassel-hbf;8005361;;9.489498;51.318257;16766;f;DE;f;Europe/Berlin;t;DEKSF;;f;;f;8000193;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;カッセル;카셀;;;;Кассель;;;卡塞尔
+7671;Kassel Hbf;kassel-hbf;8005361;;9.489498;51.318257;16766;f;DE;f;Europe/Berlin;t;DEKSF;;f;;f;8000193;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;カッセル;카셀;;;;Кассель;;;卡塞尔
 7672;Karlstadt (Main);karlstadt-main;8022546;;9.768146;49.962899;;f;DE;f;Europe/Berlin;t;DEKST;;f;;f;8003189;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7673;Konstanz;konstanz;8014586;;;;;t;DE;f;Europe/Berlin;f;DEKSZ;;f;;f;;f;;f;;f;;f;;f;;f;7674;;;;;;;;;;;;;;;;;
 7674;Konstanz;konstanz;8000495;;9.177312;47.658757;7673;f;DE;f;Europe/Berlin;t;DEQKZ;;f;;f;8003400;t;;f;;f;;f;;f;;f;;Constance;;;Costanza;Constanza;Kostnice;;;コンスタンツ;콘스탄츠;;Konstancja;Constança;Констанц;;;康斯坦茨
 7675;Kitzingen;kitzingen;8022525;;10.155212;49.732497;;f;DE;f;Europe/Berlin;t;DEKTZ;;f;;f;8000479;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7676;Lübeck Hbf;lubeck-hbf;8000630;;10.670348;53.867768;;f;DE;f;Europe/Berlin;t;DELBC;;f;;f;8000237;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Lubeca;;;;リューベック;뤼베크;;Lubeka;;Любек;;;吕贝克
+7676;Lübeck Hbf;lubeck-hbf;8000630;;10.670348;53.867768;;f;DE;f;Europe/Berlin;t;DELBC;;f;;f;8000237;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Lubeca Estación central;;;;リューベック;뤼베크;;Lubeka;;Любек;;;吕贝克
 7677;Lubeck;lubeck;;;;;;t;DE;f;Europe/Berlin;f;DELBK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7678;Leipzig Hbf;leipzig-hbf;8023179;;12.383333;51.346546;16756;f;DE;t;Europe/Berlin;t;DELEJ;;f;;f;8010205;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Lipsko;;Lipcse;ライプツィヒ;라이프치히;;Lipsk;Lípsia;Лейпциг;;;莱比锡
-7679;Lindau Hbf;lindau-hbf;8002371;;9.680303;47.544738;;f;DE;f;Europe/Berlin;t;DELIN;;f;;f;8000230;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;リンダウ;;;;;Линдау;;;林道
+7678;Leipzig Hbf;leipzig-hbf;8023179;;12.383333;51.346546;16756;f;DE;t;Europe/Berlin;t;DELEJ;;f;;f;8010205;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;Lipsko;;Lipcse;ライプツィヒ;라이프치히;;Lipsk;Lípsia;Лейпциг;;;莱比锡
+7679;Lindau Hbf;lindau-hbf;8002371;;9.680303;47.544738;;f;DE;f;Europe/Berlin;t;DELIN;;f;;f;8000230;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;リンダウ;;;;;Линдау;;;林道
 7680;Leverkusen;leverkusen;;;;;;t;DE;f;Europe/Berlin;f;DELVK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7681;München Flughafen Terminal;munchen-flughafen-terminal;8020658;;11.785972;48.353731;;f;DE;f;Europe/Berlin;t;DEMIG;;f;;f;8004168;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+7681;München Flughafen Terminal;munchen-flughafen-terminal;8020658;;11.785972;48.353731;;f;DE;f;Europe/Berlin;t;DEMIG;;f;;f;8004168;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 7682;Marktredwitz;marktredwitz;8026071;;12.08258;50.0046;;f;DE;f;Europe/Berlin;t;DEMKZ;;f;;f;8000247;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7683;München Ost;munchen-ost;8020234;;11.604975;48.127437;;f;DE;f;Europe/Berlin;t;DEMOS;;f;;f;8000262;t;;f;;f;;f;;f;;f;;Munich;Munich;;Monaco di Baviera;Múnich;Mnichov;;;ミュンヘン;뮌헨;;Monachium;Munique;Мюнхен;;Münih;慕尼黑
 7684;München-Pasing;munchen-pasing;8020286;;11.461489;48.149892;;f;DE;f;Europe/Berlin;t;DEMPS;;f;;f;8004158;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7685;Mittenwald;mittenwald;8103332;;;;;t;DE;f;Europe/Berlin;f;DEMTW;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7686;München;munchen;;;;;;t;DE;f;Europe/Berlin;f;DEMUC;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7687;Münster (Westf) Hbf;munster-westf-hbf;8021011;;7.635716;51.956563;;f;DE;f;Europe/Berlin;t;DEMUN;;f;;f;8000263;t;;f;;f;;f;;f;108013643;t;;Gare centrale;Main station;;Stazione centrale;;;;;ミュンスター;뮌스터;;;;Мюнстер;;;明斯特
+7687;Münster (Westf) Hbf;munster-westf-hbf;8021011;;7.635716;51.956563;;f;DE;f;Europe/Berlin;t;DEMUN;;f;;f;8000263;t;;f;;f;;f;;f;108013643;t;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ミュンスター;뮌스터;;;;Мюнстер;;;明斯特
 7688;Neuburg (Donau);neuburg-donau;8002047;;11.178373;48.727215;;f;DE;f;Europe/Berlin;t;DENBG;;f;;f;8004254;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7689;Neu Isenburg;neu-isenburg;8011092;;8.66561;50.053052;;f;DE;f;Europe/Berlin;t;DENEI;;f;;f;8004246;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7690;Neuenmarkt-Wirsberg;neuenmarkt-wirsberg;8022006;;11.581306;50.093746;;f;DE;f;Europe/Berlin;t;DENEM;;f;;f;8000267;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6283,17 +6283,17 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7697;Puttgarden;puttgarden;8001669;;11.227832;54.500941;7696;f;DE;f;Europe/Berlin;t;DEPUT;;f;;f;8004903;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7698;Pegnitz;pegnitz;8022298;;11.547542;49.75834;;f;DE;f;Europe/Berlin;t;DEPGN;;f;;f;8004759;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7699;Mayen Ost;mayen-ost;8025074;;7.238968;50.329263;;f;DE;f;Europe/Berlin;t;DEQMZ;;f;;f;8000248;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7700;Ulm Hbf;ulm-hbf;8029103;;9.982224;48.399432;;f;DE;f;Europe/Berlin;t;DEQUL;;t;;f;8000170;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ウルム;울름;;;;Ульм;;;乌尔姆
-7701;Würzburg Hbf;wurzburg-hbf;8022534;;9.935777;49.801794;;f;DE;f;Europe/Berlin;t;DEQWU;;f;;f;8000260;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Wurzburgo;;;;ヴュルツブルク;뷔르츠부르크;;;Wurtzburgo;Вюрцбург;;;维尔茨堡
+7700;Ulm Hbf;ulm-hbf;8029103;;9.982224;48.399432;;f;DE;f;Europe/Berlin;t;DEQUL;;t;;f;8000170;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ウルム;울름;;;;Ульм;;;乌尔姆
+7701;Würzburg Hbf;wurzburg-hbf;8022534;;9.935777;49.801794;;f;DE;f;Europe/Berlin;t;DEQWU;;f;;f;8000260;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Wurzburgo Estación central;;;;ヴュルツブルク;뷔르츠부르크;;;Wurtzburgo;Вюрцбург;;;维尔茨堡
 7702;Radolfzell;radolfzell;8014571;;8.968987;47.735875;;f;DE;f;Europe/Berlin;t;DERAD;;f;;f;8000880;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7703;Rastatt;rastatt;8014245;;8.215745;48.860579;;f;DE;f;Europe/Berlin;t;DERAS;;f;;f;8000306;t;;f;;f;;f;;f;;f;;;;;;;;;;ラシュタット;;;;;Раштатт;;;拉施塔特
 7704;Bad-Reichenhall;bad-reichenhall;;;;;;t;DE;f;Europe/Berlin;f;DEREI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7705;Remscheid;remscheid;;;;;;t;DE;f;Europe/Berlin;f;DEREM;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7706;Ribnitz-Damgarten West;ribnitz-damgarten-west;8027064;;12.436962;54.239175;;f;DE;f;Europe/Berlin;t;DERIB;;f;;f;8012763;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7707;Salzgitter;salzgitter;8033859;;10.390649;52.106134;;t;DE;f;Europe/Berlin;t;DESAL;;f;;f;8096006;t;;f;;f;;f;;f;;f;;;;;;;;;;ザルツギッター;잘츠기터;;;;Зальцгиттер;;;薩爾茨吉特
-7708;Saarbrücken Hbf;saarbrucken-hbf;8025391;80253914;6.990984678268433;49.24115221039208;;f;DE;f;Europe/Berlin;t;DESBK;;t;;f;8000323;t;;f;;f;;f;;f;;f;;Sarrebruck Gare centrale;Main station;;Stazione centrale;Sarrebruck;;;;ザールブリュッケン;자르브뤼켄;;;;Саарбрюккен;;;萨尔布吕肯
+7708;Saarbrücken Hbf;saarbrucken-hbf;8025391;80253914;6.990984678268433;49.24115221039208;;f;DE;f;Europe/Berlin;t;DESBK;;t;;f;8000323;t;;f;;f;;f;;f;;f;;Sarrebruck Gare centrale;Main station;;Stazione centrale;Sarrebruck Estación central;;;;ザールブリュッケン;자르브뤼켄;;;;Саарбрюккен;;;萨尔布吕肯
 7709;Schirnding;schirnding;8000644;;12.228745;50.077296;;f;DE;f;Europe/Berlin;t;DESCH;;f;;f;8005352;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7710;Stuttgart Hbf;stuttgart-hbf;8029034;80290346;9.181636;48.784081;7714;f;DE;f;Europe/Berlin;t;DESGT;;t;;f;8000096;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;シュトゥットガルト;슈투트가르트;;;Estugarda;Штутгарт;;;斯图加特
+7710;Stuttgart Hbf;stuttgart-hbf;8029034;80290346;9.181636;48.784081;7714;f;DE;f;Europe/Berlin;t;DESGT;;t;;f;8000096;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;シュトゥットガルト;슈투트가르트;;;Estugarda;Штутгарт;;;斯图加特
 7711;Solingen;solingen;;;;;;t;DE;f;Europe/Berlin;f;DESLG;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7712;Schnabelwaid;schnabelwaid;8022297;;11.595662;49.810451;;f;DE;f;Europe/Berlin;t;DESNW;;f;;f;8000328;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7713;Sulzbach rosenberg;sulzbach-rosenberg;;;;;;t;DE;f;Europe/Berlin;f;DESRB;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6301,45 +6301,45 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7715;Schweinfurt;schweinfurt;;;;;;t;DE;f;Europe/Berlin;f;DESWF;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7716;Tantow;tantow;8028359;;14.347925;53.269275;;f;DE;f;Europe/Berlin;t;DETTW;;f;;f;8013090;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7717;Unna;unna;8010381;;7.693381;51.538906;;f;DE;f;Europe/Berlin;t;DEUNN;;f;;f;8000171;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Унна;;;
-7718;Wiesbaden Hbf;wiesbaden-hbf;8011018;;8.243728;50.070788;;f;DE;f;Europe/Berlin;t;DEUWE;;f;;f;8000250;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ヴィースバーデン;비스바덴;;;;Висбаден;;;威斯巴登
+7718;Wiesbaden Hbf;wiesbaden-hbf;8011018;;8.243728;50.070788;;f;DE;f;Europe/Berlin;t;DEUWE;;f;;f;8000250;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ヴィースバーデン;비스바덴;;;;Висбаден;;;威斯巴登
 7719;Velgast;velgast;8028518;;12.803138;54.277317;;f;DE;f;Europe/Berlin;t;DEVLG;;f;;f;8010355;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7720;Berlin Wannsee;berlin-wannsee;8003037;;13.179336;52.421053;7527;f;DE;f;Europe/Berlin;t;DEWAN;;f;;f;8010405;t;;f;;f;;f;;f;;f;;;;;Berlino;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
 7721;Wiesbaden;wiesbaden;;;;;;t;DE;f;Europe/Berlin;f;DEWBD;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7722;Potsdam;potsdam;;;;;;t;DE;f;Europe/Berlin;f;DEXXN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7723;Potsdam stadt;potsdam-stadt;;;;;7722;f;DE;f;Europe/Berlin;f;DEXXO;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7724;Potsdam Hbf;potsdam-hbf;8003479;;13.066782;52.391703;7722;f;DE;f;Europe/Berlin;t;DEXXP;;f;;f;8012666;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Postupim;;;ポツダム;포츠담;;Poczdam;;Потсдам;;;波茨坦
+7724;Potsdam Hbf;potsdam-hbf;8003479;;13.066782;52.391703;7722;f;DE;f;Europe/Berlin;t;DEXXP;;f;;f;8012666;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;Postupim;;;ポツダム;포츠담;;Poczdam;;Потсдам;;;波茨坦
 7725;Arenshausen;arenshausen;8016543;;9.968641;51.375167;;f;DE;f;Europe/Berlin;t;DEZAS;;f;;f;8011054;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7726;Baden-Baden;baden-baden;8014277;;8.190467;48.790085;;f;DE;f;Europe/Berlin;t;DEZCC;;t;;f;8000774;t;;f;;f;;f;;f;;f;;;;;;;;;;バーデン＝バーデン;바덴바덴;;;;Баден-Баден;;;巴登-巴登
 7727;Fulda;fulda;8005637;;9.68398;50.554722;;f;DE;f;Europe/Berlin;t;DEZEE;;f;;f;8000115;t;;f;;f;;f;;f;;f;;;;;;;;;;フルダ;풀다;;;;Фульда;;;富尔达
 7728;Garmisch-Partenkirchen;garmisch-partenkirchen;8020295;;11.097012;47.49145;;f;DE;f;Europe/Berlin;t;DEZEI;;f;;f;8002187;t;;f;;f;;f;;f;;f;;;;;;;;;;ガルミッシュ＝パルテンキルヒェン;가르미슈파르텐키르헨;;;;Гармиш-Партенкирхен;;;加爾米施-帕滕基興
-7729;Hagen Hbf;hagen-hbf;8008073;;7.460246;51.362744;;f;DE;f;Europe/Berlin;t;DEZEY;;f;;f;8000142;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ハーゲン;;;;;Хаген;;;哈根伊姆布雷米申
+7729;Hagen Hbf;hagen-hbf;8008073;;7.460246;51.362744;;f;DE;f;Europe/Berlin;t;DEZEY;;f;;f;8000142;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ハーゲン;;;;;Хаген;;;哈根伊姆布雷米申
 7730;Frankfurt (Oder);frankfurt-oder;8053610;;14.546506;52.336159;;f;DE;f;Europe/Berlin;t;DEZFR;;f;;f;8010113;t;;f;;f;;f;;f;;f;;Francfort-sur-l’Oder;;;Francoforte sull’Oder;Fráncfort del Óder;Frankfurt nad Mohanem;;Frankfurt an der Oder;フランクフルト・アン・デア・オーダー;프랑크푸르트;Frankfurt an der Oder;Frankfurt nad Odrą;Frankfurt an der Oder;Франкфурт-на-Одере;;;
-7731;Gera Hbf;gera-hbf;8016705;;12.077088;50.883421;;f;DE;f;Europe/Berlin;t;DEZGA;;f;;f;8010125;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ゲーラ;게라;;;;Гера;;;格拉
+7731;Gera Hbf;gera-hbf;8016705;;12.077088;50.883421;;f;DE;f;Europe/Berlin;t;DEZGA;;f;;f;8010125;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ゲーラ;게라;;;;Гера;;;格拉
 7732;Görlitz;gorlitz;8006085;;14.979076;51.146769;;f;DE;f;Europe/Berlin;t;DEZGE;;f;;f;8010131;t;;f;;f;;f;;f;;f;;;;;;;;;;ゲルリッツ;괴를리츠;;;;Гёрлиц;;;格尔利茨
 7733;Gutenfürst;gutenfurst;8006718;;11.96075;50.41912;;f;DE;f;Europe/Berlin;t;DEZGN;;f;;f;8011790;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7734;Gotha;gotha;8016051;;10.712849;50.939029;;f;DE;f;Europe/Berlin;t;DEZGO;;f;;f;8010136;t;;f;;f;;f;;f;;f;;;;;;;;;;ゴータ;고타;;;Gota;Гота;;;哥達
 7735;Gerstungen;gerstungen;8016084;;10.065041;50.964666;;f;DE;f;Europe/Berlin;t;DEZGT;;f;;f;8011629;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7736;Halle (Saale) Hbf;halle-saale-hbf;8023002;;11.987088;51.477509;;f;DE;f;Europe/Berlin;t;DEZHZ;;f;;f;8010159;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ハレ;;;;Halle an der Saale;Галле;;;
+7736;Halle (Saale) Hbf;halle-saale-hbf;8023002;;11.987088;51.477509;;f;DE;f;Europe/Berlin;t;DEZHZ;;f;;f;8010159;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ハレ;;;;Halle an der Saale;Галле;;;
 7737;Zittau;zittau;8006113;;14.8058;50.904348;;f;DE;f;Europe/Berlin;t;DEZIT;;f;;f;8010393;t;;f;;f;;f;;f;;f;;;;;;;Žitava;;;ツィッタウの;;;Żytawa;;Циттау;;;齐陶
 7738;Jena Saalbf;jena-saalbf;8016319;;11.593918;50.937096;;f;DE;f;Europe/Berlin;t;DEZJS;;f;;f;8011058;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7739;Ludwigslust;ludwigslust;8027327;;11.494488;53.334672;;f;DE;f;Europe/Berlin;t;DEZLU;;f;;f;8010216;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7740;Magdeburg Hbf;magdeburg-hbf;8024001;;11.62689;52.130351;;f;DE;f;Europe/Berlin;t;DEZMG;;f;;f;8010224;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Magdeburgo;Magdeburk;;;マクデブルク;마그데부르크;Maagdenburg;;Magdeburgo;Магдебург;;;马格德堡
+7740;Magdeburg Hbf;magdeburg-hbf;8024001;;11.62689;52.130351;;f;DE;f;Europe/Berlin;t;DEZMG;;f;;f;8010224;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Magdeburgo Estación central;Magdeburk;;;マクデブルク;마그데부르크;Maagdenburg;;Magdeburgo;Магдебург;;;马格德堡
 7741;Hamm (Westf);hamm-westf;8010002;;7.807823;51.678077;;f;DE;f;Europe/Berlin;t;DEZNB;;f;;f;8000149;t;;f;;f;;f;;f;;f;;;;;;;;;;ハム;함;;;;Хамм;;;哈姆
-7742;Koblenz Hbf;koblenz-hbf;8019021;;7.588648;50.35108;;f;DE;f;Europe/Berlin;t;DEZNV;;f;;f;8000206;t;;f;;f;;f;;f;108000206;t;;Coblence Gare centrale;Main station;;Coblenza Stazione centrale;Coblenza;;;;コブレンツ;코블렌츠;;Koblencja;Coblença;Кобленц;;;科布倫茨
-7743;Ludwigshafen (Rh) Hbf;ludwigshafen-rh-hbf;8019082;;8.4334;49.477985;;f;DE;f;Europe/Berlin;t;DEZOE;;f;;f;8000236;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ルートヴィヒスハーフェン;루트비히스하펜;;;;Людвигсхафен-на-Рейне;;;路德维希港
+7742;Koblenz Hbf;koblenz-hbf;8019021;;7.588648;50.35108;;f;DE;f;Europe/Berlin;t;DEZNV;;f;;f;8000206;t;;f;;f;;f;;f;108000206;t;;Coblence Gare centrale;Main station;;Coblenza Stazione centrale;Coblenza Estación central;;;;コブレンツ;코블렌츠;;Koblencja;Coblença;Кобленц;;;科布倫茨
+7743;Ludwigshafen (Rh) Hbf;ludwigshafen-rh-hbf;8019082;;8.4334;49.477985;;f;DE;f;Europe/Berlin;t;DEZOE;;f;;f;8000236;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ルートヴィヒスハーフェン;루트비히스하펜;;;;Людвигсхафен-на-Рейне;;;路德维希港
 7744;Minden (Westf);minden-westf;8013577;;8.934729;52.290134;;f;DE;f;Europe/Berlin;t;DEZOM;;f;;f;8000252;t;;f;;f;;f;;f;;f;;;;;;;;;;ミンデン;;;;;Минден;;;明登
-7745;Mülheim (Ruhr) Hbf;mulheim-ruhr-hbf;8010217;;6.88668;51.431323;;f;DE;f;Europe/Berlin;t;DEZOO;;f;;f;8000259;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Мюльхайм-на-Руре;;;
+7745;Mülheim (Ruhr) Hbf;mulheim-ruhr-hbf;8010217;;6.88668;51.431323;;f;DE;f;Europe/Berlin;t;DEZOO;;f;;f;8000259;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Мюльхайм-на-Руре;;;
 7746;Offenburg;offenburg;8014309;;7.946724;48.476479;;f;DE;f;Europe/Berlin;t;DEZPA;;f;;f;8000290;t;;f;;f;;f;;f;;f;;Offenbourg;;;;;;;;オッフェンブルク;;;;;Оффенбург;;;奥芬堡
 7747;;;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7748;Villingen (Schwarzw);villingen-schwarzw;8014521;;8.465258;48.058022;;f;DE;f;Europe/Berlin;t;DEZQL;;f;;f;8000366;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7749;Rostock Hbf;rostock-hbf;8027089;;12.131706;54.078323;;f;DE;f;Europe/Berlin;t;DEZRO;;f;;f;8010304;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ロストック;로스토크;;;;Росток;;;罗斯托克
+7749;Rostock Hbf;rostock-hbf;8027089;;12.131706;54.078323;;f;DE;f;Europe/Berlin;t;DEZRO;;f;;f;8010304;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ロストック;로스토크;;;;Росток;;;罗斯托克
 7750;Riesa;riesa;8006233;;13.287396;51.309726;;f;DE;f;Europe/Berlin;t;DEZRX;;f;;f;8010297;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Риза;;;里薩
 7751;Sassnitz;sassnitz;8028491;;13.637912;54.516286;;f;DE;f;Europe/Berlin;t;DEZSI;;f;;f;8012843;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7752;Stendal;stendal;8024062;;11.854407;52.594725;;f;DE;f;Europe/Berlin;t;DEZSN;;f;;f;8010334;t;;f;;f;;f;;f;;f;;;;;;;;;;;슈텐달;;;;Штендаль;;;施滕达尔
-7753;Schwerin Hbf;schwerin-hbf;8027359;;11.407553;53.63466;;f;DE;f;Europe/Berlin;t;DEZSR;;f;;f;8010324;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;シュヴェリーン;슈베린;;;;Шверин;;;什未林
-7754;Dessau Hbf;dessau-hbf;8023723;;12.234948;51.839865;;f;DE;f;Europe/Berlin;t;DEZSU;;f;;f;8010077;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;デッサウ;데사우;;;;Дессау;;;德绍
-7755;Stralsund Hbf;stralsund-hbf;8028504;;13.077318;54.308626;;f;DE;f;Europe/Berlin;t;DEZSX;;f;;f;8010338;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;シュトラールズント;슈트랄준트;;;;Штральзунд;;;施特拉爾松德
-7756;Chemnitz Hbf;chemnitz-hbf;8006377;;12.930299;50.839266;;f;DE;f;Europe/Berlin;t;DEZTZ;;f;;f;8010184;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Saská Kamenice;;;ケムニッツ;켐니츠;;;;Хемниц;;;开姆尼茨
+7753;Schwerin Hbf;schwerin-hbf;8027359;;11.407553;53.63466;;f;DE;f;Europe/Berlin;t;DEZSR;;f;;f;8010324;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;シュヴェリーン;슈베린;;;;Шверин;;;什未林
+7754;Dessau Hbf;dessau-hbf;8023723;;12.234948;51.839865;;f;DE;f;Europe/Berlin;t;DEZSU;;f;;f;8010077;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;デッサウ;데사우;;;;Дессау;;;德绍
+7755;Stralsund Hbf;stralsund-hbf;8028504;;13.077318;54.308626;;f;DE;f;Europe/Berlin;t;DEZSX;;f;;f;8010338;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;シュトラールズント;슈트랄준트;;;;Штральзунд;;;施特拉爾松德
+7756;Chemnitz Hbf;chemnitz-hbf;8006377;;12.930299;50.839266;;f;DE;f;Europe/Berlin;t;DEZTZ;;f;;f;8010184;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;Saská Kamenice;;;ケムニッツ;켐니츠;;;;Хемниц;;;开姆尼茨
 7757;Warnemünde;warnemunde;8027098;;12.091273;54.176853;;f;DE;f;Europe/Berlin;t;DEZWD;;f;;f;8013236;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7758;Wittenberge;wittenberge;8027316;;11.763023;53.002233;;f;DE;f;Europe/Berlin;t;DEZWN;;f;;f;8010382;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7759;Southampton;southampton;7059320;;;;;f;GB;f;Europe/London;f;GBAAA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7209,7 +7209,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8624;Hilversum;hilversum;8400322;;5.1801950000;52.2263470000;;f;NL;f;Europe/Amsterdam;t;NLAAR;;f;;f;8400322;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Хилверсюм;;;希爾弗瑟姆
 8625;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8626;Hoofddorp;hoofddorp;8400332;;4.7023740000;52.2950060000;;f;NL;f;Europe/Amsterdam;t;NLAAT;;f;;f;8400332;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8627;Leiden Centraal;leiden-centraal;8400390;;4.4929970000;52.1750720000;;f;NL;f;Europe/Amsterdam;t;NLAAU;;f;;f;8400390;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;;;;;ライデン;레이던;;Lejda;Leida;Лейден;;;莱顿
+8627;Leiden Centraal;leiden-centraal;8400390;;4.4929970000;52.1750720000;;f;NL;f;Europe/Amsterdam;t;NLAAU;;f;;f;8400390;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;Estación central;;;;ライデン;레이던;;Lejda;Leida;Лейден;;;莱顿
 8628;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8629;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8630;Nieuwe schans;nieuwe-schans;8400457;;;;;f;NL;f;Europe/Amsterdam;f;NLAAX;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7246,16 +7246,16 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8661;Breda;breda;8400131;;4.7764000000;51.5944590000;;f;NL;f;Europe/Amsterdam;t;NLBDA;;f;;f;8400131;t;;f;;f;;f;;f;;f;;;;;;;;;;ブレダ;브레다;;;;Бреда;;;布雷达
 8662;Dordrecht;dordrecht;8400180;;4.6668210000;51.8077820000;;f;NL;f;Europe/Amsterdam;t;NLDDT;;f;;f;8400180;t;;f;;f;;f;;f;;f;;;;;;;;;;ドルトレヒト;;;;;;;;
 8663;La Haye;la-haye;;;;;;t;NL;f;Europe/Amsterdam;f;NLDHC;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8664;Den Haag Centraal;den-haag-centraal;8400282;;4.3239910000;52.0805060000;8663;f;NL;f;Europe/Amsterdam;t;NLDHH;;f;;f;8400282;t;;f;;f;;f;;f;;f;;La Haye Gare centrale;The Hague Main station;Hauptbahnhof;L’Aia Stazione centrale;La Haya;;;Hága;ハーグ;헤이그;;Haga;A Haia;Гаага;;Lahey;海牙
+8664;Den Haag Centraal;den-haag-centraal;8400282;;4.3239910000;52.0805060000;8663;f;NL;f;Europe/Amsterdam;t;NLDHH;;f;;f;8400282;t;;f;;f;;f;;f;;f;;La Haye Gare centrale;The Hague Main station;Hauptbahnhof;L’Aia Stazione centrale;La Haya Estación central;;;Hága;ハーグ;헤이그;;Haga;A Haia;Гаага;;Lahey;海牙
 8665;Eijsden maastricht grens;eijsden-maastricht-grens;8400220;;;;;f;NL;f;Europe/Amsterdam;f;NLEIJ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8666;Eindhoven;eindhoven;8400206;;5.4799500000;51.4430630000;;f;NL;f;Europe/Amsterdam;t;NLEIN;;f;;f;8400206;t;;f;;f;;f;;f;;f;;;;;;;;;;アイントホーフェン;에인트호번;;;;Эйндховен;;;埃因霍温
 8667;Haarlem;haarlem;8400285;;4.6364650000;52.3871100000;;f;NL;f;Europe/Amsterdam;t;NLGRZ;;f;;f;8400285;t;;f;;f;;f;;f;;f;;;;;;;;;;ハールレム;하를럼;;;;Харлем;;;哈勒姆
 8668;Maastricht;maastricht;8400424;;5.705875;50.849811;;f;NL;f;Europe/Amsterdam;f;NLMST;;f;;f;8400424;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8669;Roosendaal;roosendaal;8400526;;4.4566360000;51.5398590000;;f;NL;f;Europe/Amsterdam;t;NLROO;;f;;f;8400526;t;;f;;f;;f;;f;;f;;Rosendael;;;;;;;;ローゼンダール;;;;;Розендал;;;罗森达尔
-8670;Rotterdam Centraal;rotterdam-centraal;8400530;84005306;4.468839168548584;51.925068244603146;;f;NL;f;Europe/Amsterdam;t;NLRTA;;t;;f;8400530;f;QRH;t;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;Róterdam;;;;ロッテルダム;로테르담;;;Roterdão;Роттердам;;;鹿特丹
+8670;Rotterdam Centraal;rotterdam-centraal;8400530;84005306;4.468839168548584;51.925068244603146;;f;NL;f;Europe/Amsterdam;t;NLRTA;;t;;f;8400530;f;QRH;t;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;Róterdam Estación central;;;;ロッテルダム;로테르담;;;Roterdão;Роттердам;;;鹿特丹
 8671;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8672;Amsterdam-Schiphol;amsterdam-schiphol;8400561;;4.7614870000;52.3087870000;;f;NL;f;Europe/Amsterdam;t;NLSPH;;t;;f;8400561;t;;f;;f;;f;;f;;f;;Aéroport;Airport;Flughafen;Aeroporto;;;;;;;;;;;;;
-8673;Utrecht Centraal;utrecht-centraal;8400621;;5.1111670000;52.0875800000;;f;NL;f;Europe/Amsterdam;t;NLUTC;;f;;f;8400621;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;;;;;ユトレヒト;;;;;Утрехт;;;
+8672;Amsterdam-Schiphol;amsterdam-schiphol;8400561;;4.7614870000;52.3087870000;;f;NL;f;Europe/Amsterdam;t;NLSPH;;t;;f;8400561;t;;f;;f;;f;;f;;f;;Aéroport;Airport;Flughafen;Aeroporto;Aeropuerto;;;;;;;;;;;;
+8673;Utrecht Centraal;utrecht-centraal;8400621;;5.1111670000;52.0875800000;;f;NL;f;Europe/Amsterdam;t;NLUTC;;f;;f;8400621;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;Estación central;;;;ユトレヒト;;;;;Утрехт;;;
 8674;Pinhel;pinhel;9448595;;;;;f;PT;f;Europe/Lisbon;f;PTAAA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8675;Vila franca das naves;vila-franca-das-naves;9448546;;;;;f;PT;f;Europe/Lisbon;f;PTAAB;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8676;Mangualde;mangualde;9448009;;;;;f;PT;f;Europe/Lisbon;f;PTAAC;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7315,7 +7315,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8731;Luxembourg;luxembourg;;;;;;t;LU;f;Europe/Luxembourg;f;LUXAA;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8732;Auxon RN;auxon-rn;8742976;87429761;;;9587;f;FR;f;Europe/Paris;f;FRXAU;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8735;St-Lyé Libération;st-lye-liberation;8734412;87344127;3.996271;48.351277;;f;FR;f;Europe/Paris;f;FRLYO;;f;;f;8705313;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8737;Aéroport de Beauvais-Tillé;aeroport-de-beauvais-tille;8744895;;2.113044261932373;49.46054452648477;;f;FR;f;Europe/Paris;t;FRBQR;;t;;f;;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;;;;;;;;;;;;;
+8737;Aéroport de Beauvais-Tillé;aeroport-de-beauvais-tille;8744895;;2.113044261932373;49.46054452648477;;f;FR;f;Europe/Paris;t;FRBQR;;t;;f;;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;Aeropuerto;;;;;;;;;;;;
 8738;Breteuil RN;breteuil-rn;8745127;87451278;2.293687;49.631952;;f;FR;f;Europe/Paris;t;FRBQS;;t;;f;8705998;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8740;Breteuil Place Laffitte;breteuil-place-laffitte;8730797;;;;;f;FR;f;Europe/Paris;f;FRBDL;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8745;St-Dizier St-Amand;st-dizier-st-amand;8733814;87338145;4.967097;48.6297;5167;f;FR;f;Europe/Paris;t;FRSDA;;t;;f;8705275;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7606,7 +7606,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 9099;Besse-sur-Braye;besse-sur-braye;;;0.7500000000;47.8333330000;;f;FR;f;Europe/Paris;f;FRDMR;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 9100;Dompierre-sur-Mer;dompierre-sur-mer;;;;;;t;FR;f;Europe/Paris;f;FRDMS;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 9101;Courtalain;courtalain;8739930;;;;;f;FR;f;Europe/Paris;f;FRDMW;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-9102;Vitrolles Aéroport Marseille-Provence TER;vitrolles-aeroport-marseille-provence-ter;8743955;87439554;5.237111;43.441917;;f;FR;f;Europe/Paris;t;FRHBO;AYD;t;;f;8706207;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;;;;;;;;;;;;;
+9102;Vitrolles Aéroport Marseille-Provence TER;vitrolles-aeroport-marseille-provence-ter;8743955;87439554;5.237111;43.441917;;f;FR;f;Europe/Paris;t;FRHBO;AYD;t;;f;8706207;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;Aeropuerto;;;;;;;;;;;;
 9103;St-Agil;st-agil;;;0.9333330000;48.0333330000;;f;FR;f;Europe/Paris;f;FRDMX;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 9104;Chatelay;chatelay;8771885;;5.7000000000;47.0333330000;;f;FR;f;Europe/Paris;f;FRHBP;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 9105;Deutschland db dr 80;deutschland-db-dr-80;;;;;;f;DE;f;Europe/Berlin;f;DEARK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -8968,7 +8968,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10461;Innsbruck;innsbruck;;;;;;t;AT;f;Europe/Vienna;f;ATINN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10462;Novara;novara;8300248;83002485;8.625104;45.451258;;f;IT;f;Europe/Rome;t;ITAAB;;t;;f;8300007;f;;f;;f;8300248;t;;f;;f;;Novare;;;;;;;;ノヴァーラ;;;;;Новара;;;
 10463;Vercelli;vercelli;8300245;83002451;8.416501;45.330137;;f;IT;f;Europe/Rome;t;ITAAC;;t;;f;8300008;f;;f;;f;8300245;t;;f;;f;;Verceil;;;;;;;;ヴェルチェッリ;;;;;Верчелли;;;
-10464;Innsbruck Hbf;innsbruck-hbf;8101187;;11.4010000000;47.2632770000;10461;f;AT;f;Europe/Vienna;t;ATALA;;f;;f;8100108;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;インスブルック;인스브루크;;;;Инсбрук;;İnnsbruck;因斯布鲁克
+10464;Innsbruck Hbf;innsbruck-hbf;8101187;;11.4010000000;47.2632770000;10461;f;AT;f;Europe/Vienna;t;ATALA;;f;;f;8100108;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;インスブルック;인스브루크;;;;Инсбрук;;İnnsbruck;因斯布鲁克
 10465;Figueras (Figueres);figueras-figueres;;;;;;t;ES;f;Europe/Madrid;f;ESFRS;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10466;Autun St-Jean;autun-st-jean;8747850;87478503;;;;f;FR;f;Europe/Paris;f;FRSDY;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10467;Frontenaud Mairie;frontenaud-mairie;8753647;;5.2934789657592765;46.55271471039897;;f;FR;f;Europe/Paris;t;FRJGA;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9027,7 +9027,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10520;La Guérinière;la-gueriniere;8746302;87463026;-2.238655;46.969878;;f;FR;f;Europe/Paris;t;FRKBD;;t;;f;8706482;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10521;;;8740564;;;;;f;FR;f;Europe/Paris;f;FRZAI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10522;Wien (Vienne) Westbahnhof;wien-vienne-westbahnhof;;;;;;f;AT;f;Europe/Vienna;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10523;Villach Hbf;villach-hbf;8103654;;13.8485380000;46.6186240000;;f;AT;f;Europe/Vienna;t;ATVIC;;f;;f;8100147;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;フィラッハ;필라흐;;;;Филлах;;;菲拉赫
+10523;Villach Hbf;villach-hbf;8103654;;13.8485380000;46.6186240000;;f;AT;f;Europe/Vienna;t;ATVIC;;f;;f;8100147;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;フィラッハ;필라흐;;;;Филлах;;;菲拉赫
 10524;;;8103656;;;;;f;AT;f;Europe/Vienna;f;ATAHD;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10525;Zaragoza Delicias;zaragoza-delicias;7171000;;-0.9099876880645752;41.658384928939746;;f;ES;f;Europe/Madrid;t;ESZAZ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10526;Cloyes Centre;cloyes-centre;8734315;;1.23014688491821;47.9975107867748;10708;f;FR;f;Europe/Paris;f;FREUU;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9106,7 +9106,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10599;Aix-en-Provence Gare routière;aix-en-provence-gare-routiere;8754179;;;;5047;f;FR;f;Europe/Paris;f;FRQXC;;f;;f;;f;QXB;t;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10600;Amiens Gare routière;amiens-gare-routiere;8752242;87522425;2.308762;49.891965;5022;f;FR;f;Europe/Paris;f;FRQBU;;f;;f;8706635;f;XAS;t;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10601;;;;;;;;t;FR;f;Europe/Paris;f;FRXSO;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10602;Aulnat Aéroport;aulnat-aeroport;8756242;87562421;3.161547;45.792058;;f;FR;f;Europe/Paris;t;FRTKN;AUL;t;;f;;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;;;;;;;;;;;;;
+10602;Aulnat Aéroport;aulnat-aeroport;8756242;87562421;3.161547;45.792058;;f;FR;f;Europe/Paris;t;FRTKN;AUL;t;;f;;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;Aeropuerto;;;;;;;;;;;;
 10603;Auch ZA de Lamothe;auch-za-de-lamothe;8716819;;0.5941468477249146;43.6656946799256;;f;FR;f;Europe/Paris;t;FRUDD;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10604;;;;;;;;t;FR;f;Europe/Paris;f;FRWCR;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10605;Amiens;amiens;;;2.296565;49.894144;;t;FR;f;Europe/Paris;f;FRZHK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9311,9 +9311,9 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10804;Babenhausen (Hess);babenhausen-hess;8011346;;8.957184;49.957964;;f;DE;f;Europe/Berlin;t;;;f;;f;8000015;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10805;Bad Nenndorf;bad-nenndorf;8013529;;9.377996;52.344627;;f;DE;f;Europe/Berlin;t;;;f;;f;8000022;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10806;Bedburg (Erft);bedburg-erft;8015283;;6.572615;50.987481;;f;DE;f;Europe/Berlin;t;;;f;;f;8000030;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10807;Bottrop Hbf;bottrop-hbf;8010021;;6.936921;51.509538;;f;DE;f;Europe/Berlin;t;;;f;;f;8000047;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ボトロップ;보트로프;;;;Ботроп;;;博特罗普
+10807;Bottrop Hbf;bottrop-hbf;8010021;;6.936921;51.509538;;f;DE;f;Europe/Berlin;t;;;f;;f;8000047;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;ボトロップ;보트로프;;;;Ботроп;;;博特罗普
 10808;Brackwede;brackwede;8013603;;8.498428;51.997374;;f;DE;f;Europe/Berlin;t;;;f;;f;8000048;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10809;Braunschweig Hbf;braunschweig-hbf;8013240;;10.539699;52.252236;;f;DE;f;Europe/Berlin;t;;;f;;f;8000049;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Brunswick;;;;ブラウンシュヴァイク;브라운슈바이크;;Brunszwik;;Брауншвейг;;;不伦瑞克
+10809;Braunschweig Hbf;braunschweig-hbf;8013240;;10.539699;52.252236;;f;DE;f;Europe/Berlin;t;;;f;;f;8000049;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Brunswick Estación central;;;;ブラウンシュヴァイク;브라운슈바이크;;Brunszwik;;Брауншвейг;;;不伦瑞克
 10810;Bünde (Westf);bunde-westf;8021173;;8.573875;52.202076;;f;DE;f;Europe/Berlin;t;DEAFG;;f;;f;8000059;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бюнде;;;
 10811;Siershahn;siershahn;8019581;;7.771561;50.485388;;f;DE;f;Europe/Berlin;t;;;f;;f;8000060;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10812;Burg-u. Nieder Gemünden;burg-u-nieder-gemunden;8005610;;9.047606;50.691115;;f;DE;f;Europe/Berlin;t;;;f;;f;8000061;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9330,7 +9330,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10823;Gladbeck West;gladbeck-west;8010019;;6.97677;51.575357;;f;DE;f;Europe/Berlin;t;;;f;;f;8000125;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гладбек;;;格拉德貝克
 10824;Riedstadt-Goddelau;riedstadt-goddelau;8011246;;8.489187;49.83323;;f;DE;f;Europe/Berlin;t;;;f;;f;8000126;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10825;Grävenwiesbach;gravenwiesbach;8011554;;8.458552;50.382237;;f;DE;f;Europe/Berlin;t;;;f;;f;8000132;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гревенвисбах;;;格雷芬维斯巴赫
-10826;Trier Hbf;trier-hbf;8025181;;6.652449;49.756848;;f;DE;f;Europe/Berlin;t;DEZQF;;f;;f;8000134;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Tréveris;Trevír;;;トリーア;트리어;;Trewir;Tréveris;Трир;;;特里尔
+10826;Trier Hbf;trier-hbf;8025181;;6.652449;49.756848;;f;DE;f;Europe/Berlin;t;DEZQF;;f;;f;8000134;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Tréveris Estación central;Trevír;;;トリーア;트리어;;Trewir;Tréveris;Трир;;;特里尔
 10827;Groß Gerau;gross-gerau;8011236;;8.486212;49.924938;;f;DE;f;Europe/Berlin;t;;;f;;f;8000136;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10828;Grünstadt;grunstadt;8019350;;8.167958;49.56438;;f;DE;f;Europe/Berlin;t;;;f;;f;8000137;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Грюнштадт;;;格林斯塔特
 10829;Gruiten;gruiten;8008083;;7.011145;51.214611;;f;DE;f;Europe/Berlin;t;;;f;;f;8000138;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9350,10 +9350,10 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10843;Jülich;julich;8088407;;6.367976;50.919378;;f;DE;f;Europe/Berlin;t;;;f;;f;8000188;t;;f;;f;;f;;f;;f;;Juliers;;;;;;;;;;;;;Юлих;;;于利希
 10844;Kettwig;kettwig;8010234;;6.954028;51.363616;;f;DE;f;Europe/Berlin;t;;;f;;f;8000198;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10845;Krefeld-Oppum;krefeld-oppum;8015044;;6.611107;51.329736;;f;DE;f;Europe/Berlin;t;;;f;;f;8000212;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10846;Landau (Pfalz) Hbf;landau-pfalz-hbf;8019426;;8.126167;49.198178;;f;DE;f;Europe/Berlin;t;;;f;;f;8000216;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Ландау-на-Изаре;;;伊萨尔河畔兰道
+10846;Landau (Pfalz) Hbf;landau-pfalz-hbf;8019426;;8.126167;49.198178;;f;DE;f;Europe/Berlin;t;;;f;;f;8000216;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Ландау-на-Изаре;;;伊萨尔河畔兰道
 10847;Lauterbach (Hess) Nord;lauterbach-hess-nord;8005617;;9.408056;50.643607;;f;DE;f;Europe/Berlin;t;;;f;;f;8000222;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10848;Lollar;lollar;8011686;;8.701737;50.64794;;f;DE;f;Europe/Berlin;t;;;f;;f;8000234;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10849;Mainz Hbf;mainz-hbf;8019051;;8.258722;50.001112;;f;DE;f;Europe/Berlin;t;;;f;;f;8000240;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Maguncia;Mohuč;;;マインツ;마인츠;;Moguncja;Mogúncia;Майнц;;;美因茨
+10849;Mainz Hbf;mainz-hbf;8019051;;8.258722;50.001112;;f;DE;f;Europe/Berlin;t;;;f;;f;8000240;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Maguncia Estación central;Mohuč;;;マインツ;마인츠;;Moguncja;Mogúncia;Майнц;;;美因茨
 10850;Mainz-Bischofsheim;mainz-bischofsheim;8011231;;8.358116;49.992815;;f;DE;f;Europe/Berlin;t;;;f;;f;8000241;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10851;Westerburg;westerburg;8019565;;7.966977;50.557643;;f;DE;f;Europe/Berlin;t;;;f;;f;8000245;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10852;Rohrbach (Ilm);rohrbach-ilm;8020428;;11.57318;48.605851;;f;DE;f;Europe/Berlin;t;;;f;;f;8000256;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9847,7 +9847,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 11340;Burgau (Schwab);burgau-schwab;8002102;;10.42701;48.4248;;f;DE;f;Europe/Berlin;t;;;f;;f;8001276;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11341;Burgbernheim;burgbernheim;8022517;;10.320218;49.454325;;f;DE;f;Europe/Berlin;t;;;f;;f;8001277;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11342;Burgbernheim-Wildbad;burgbernheim-wildbad;8022708;;10.312317;49.443296;;f;DE;f;Europe/Berlin;t;;;f;;f;8001278;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-11343;Burgdorf Bahnhof;burgdorf-bahnhof;8013637;;10.00289;52.449001;;f;DE;f;Europe/Berlin;t;;;f;;f;8001279;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;;;;;;;;;;Бургдорф (Ганновер);;;
+11343;Burgdorf Bahnhof;burgdorf-bahnhof;8013637;;10.00289;52.449001;;f;DE;f;Europe/Berlin;t;;;f;;f;8001279;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;Alemania;;;;;;;;;Бургдорф (Ганновер);;;
 11344;Burghaun (Hünfeld);burghaun-hunfeld;8005644;;9.727955;50.700554;;f;DE;f;Europe/Berlin;t;;;f;;f;8001283;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11345;Burghausen (Oberbay);burghausen-oberbay;8020045;;12.828182;48.174198;;f;DE;f;Europe/Berlin;t;;;f;;f;8001284;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11346;Burgheim;burgheim;8002050;;11.026986;48.701047;;f;DE;f;Europe/Berlin;t;;;f;;f;8001285;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10007,7 +10007,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 11500;Dürrenbüchig;durrenbuchig;8014102;;8.64818;49.023949;;f;DE;f;Europe/Berlin;t;;;f;;f;8001576;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11501;Dürrnhaar;durrnhaar;8020243;;11.736729;47.99356;;f;DE;f;Europe/Berlin;t;;;f;;f;8001578;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11502;Düsseldorf Friedrichstadt;dusseldorf-friedrichstadt;8008328;;6.788986;51.212112;7578;f;DE;f;Europe/Berlin;t;;;f;;f;8001579;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-11503;Düsseldorf Flughafen Terminal;dusseldorf-flughafen-terminal;8015653;;6.767043;51.276538;7578;f;DE;f;Europe/Berlin;t;;;f;;f;8001580;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+11503;Düsseldorf Flughafen Terminal;dusseldorf-flughafen-terminal;8015653;;6.767043;51.276538;7578;f;DE;f;Europe/Berlin;t;;;f;;f;8001580;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 11504;Düsseldorf Volksgarten;dusseldorf-volksgarten;8008113;;6.791979;51.210134;7578;f;DE;f;Europe/Berlin;t;;;f;;f;8001581;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11505;Düsseldorf Wehrhahn;dusseldorf-wehrhahn;8008109;;6.797301;51.229335;7578;f;DE;f;Europe/Berlin;t;;;f;;f;8001582;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11506;Düsseldorf-Zoo;dusseldorf-zoo;8015651;;6.797067;51.236958;7578;f;DE;f;Europe/Berlin;t;;;f;;f;8001583;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10245,7 +10245,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 11738;Förbau;forbau;8026026;;11.910689;50.207522;;f;DE;f;Europe/Berlin;t;;;f;;f;8002019;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11739;Förtschendorf;fortschendorf;8022026;;11.35013;50.392898;;f;DE;f;Europe/Berlin;t;;;f;;f;8002020;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11740;Forbach (fr);forbach-fr;8025396;;6.94431;49.214089;;f;DE;f;Europe/Berlin;f;;;f;;f;8002021;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-11741;Forbach;forbach;8014261;;8.361487;48.680399;;f;DE;f;Europe/Berlin;t;;;f;;f;8002022;t;;f;;f;;f;;f;;f;;Forêt Noire;Black Forest;Schwarzwald;Foresta Nera;;;;;;;;;;;;;
+11741;Forbach;forbach;8014261;;8.361487;48.680399;;f;DE;f;Europe/Berlin;t;;;f;;f;8002022;t;;f;;f;;f;;f;;f;;Forêt Noire;Black Forest;Schwarzwald;Foresta Nera;Selva Negra;;;;;;;;;;;;
 11742;Forchheim (b Karlsruhe);forchheim-b-karlsruhe;8014234;;8.338933;48.964782;;f;DE;f;Europe/Berlin;t;;;f;;f;8002023;t;;f;;f;;f;;f;;f;;;;;;;;;;フォルヒハイム;;;;;Форххайм;;;福希海姆
 11743;Fornsbach;fornsbach;8029584;;9.638944;48.97538;;f;DE;f;Europe/Berlin;t;;;f;;f;8002026;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11744;Forsthaus;forsthaus;8015116;;6.503075;51.303245;;f;DE;f;Europe/Berlin;t;;;f;;f;8002027;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10311,7 +10311,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 11804;Friedrichstal (Baden);friedrichstal-baden;8014069;;8.476701;49.11011;;f;DE;f;Europe/Berlin;t;;;f;;f;8002116;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11805;Friedrichsthal (Saar);friedrichsthal-saar;8025424;;7.089127;49.320062;;f;DE;f;Europe/Berlin;t;;;f;;f;8002117;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11806;Friedrichsthal (b Bayreuth);friedrichsthal-b-bayreuth;8022254;;11.627834;49.962593;;f;DE;f;Europe/Berlin;t;;;f;;f;8002118;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-11807;Friedrichshafen Flughafen;friedrichshafen-flughafen;8037288;;9.523711;47.672214;;f;DE;f;Europe/Berlin;t;;;f;;f;8002120;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;フリードリヒスハーフェン;;;;;Фридрихсхафен;;;腓特烈港
+11807;Friedrichshafen Flughafen;friedrichshafen-flughafen;8037288;;9.523711;47.672214;;f;DE;f;Europe/Berlin;t;;;f;;f;8002120;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;フリードリヒスハーフェン;;;;;Фридрихсхафен;;;腓特烈港
 11808;Friedrichshafen Landratsamt;friedrichshafen-landratsamt;8064618;;9.451986;47.657148;;f;DE;f;Europe/Berlin;t;;;f;;f;8002122;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11809;Friesenheim (Baden);friesenheim-baden;8014318;;7.862945;48.381589;;f;DE;f;Europe/Berlin;t;;;f;;f;8002123;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11810;Friedrichstal b Freudenstadt;friedrichstal-b-freudenstadt;8066082;;8.376921;48.4818;;f;DE;f;Europe/Berlin;t;;;f;;f;8002126;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10389,7 +10389,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 11882;Gessertshausen;gessertshausen;8002113;;10.732383;48.333712;;f;DE;f;Europe/Berlin;t;;;f;;f;8002263;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11883;Gettenau-Bingenheim;gettenau-bingenheim;8011398;;8.885792;50.379189;;f;DE;f;Europe/Berlin;t;;;f;;f;8002265;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11884;Gettorf;gettorf;8001389;;9.978673;54.40989;;f;DE;f;Europe/Berlin;t;;;f;;f;8002266;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-11885;Gevelsberg Hbf;gevelsberg-hbf;8008043;;7.339935;51.324432;;f;DE;f;Europe/Berlin;t;;;f;;f;8002267;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+11885;Gevelsberg Hbf;gevelsberg-hbf;8008043;;7.339935;51.324432;;f;DE;f;Europe/Berlin;t;;;f;;f;8002267;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 11886;Gevelsberg West;gevelsberg-west;8008497;;7.31356;51.317178;;f;DE;f;Europe/Berlin;t;;;f;;f;8002268;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11887;Gießen Oswaldsgarten;giessen-oswaldsgarten;8079952;;8.669134;50.58835;;f;DE;f;Europe/Berlin;t;;;f;;f;8002269;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11888;Gifhorn Stadt;gifhorn-stadt;8013173;;10.542791;52.479789;;f;DE;f;Europe/Berlin;t;;;f;;f;8002274;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10530,7 +10530,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12023;Hannover-Leinhausen;hannover-leinhausen;8013558;;9.676177;52.396791;;f;DE;f;Europe/Berlin;t;;;f;;f;8002585;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12024;Hannover-Linden/Fischerhof;hannover-linden-fischerhof;8013507;;9.72311;52.352636;;f;DE;f;Europe/Berlin;t;;;f;;f;8002586;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12025;Hanweiler (Gr);hanweiler-gr;8025418;;7.057637;49.1118;;f;DE;f;Europe/Berlin;f;;;f;;f;8002587;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12026;Hannover Flughafen;hannover-flughafen;8033118;;9.700817;52.459302;;f;DE;f;Europe/Berlin;t;;;f;;f;8002589;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Hanóver;;;;ハノーファー;하노버;;Hanower;Hanôver;Ганновер;;;汉诺威
+12026;Hannover Flughafen;hannover-flughafen;8033118;;9.700817;52.459302;;f;DE;f;Europe/Berlin;t;;;f;;f;8002589;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Hanóver Aeropuerto;;;;ハノーファー;하노버;;Hanower;Hanôver;Ганновер;;;汉诺威
 12027;Harblek;harblek;8001558;;8.961445;54.36115;;f;DE;f;Europe/Berlin;t;;;f;;f;8002592;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12028;Harburg (Schwab);harburg-schwab;8002040;;10.698457;48.778894;;f;DE;f;Europe/Berlin;t;;;f;;f;8002593;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12029;Hardegsen;hardegsen;8013288;;9.825218;51.659002;;f;DE;f;Europe/Berlin;t;;;f;;f;8002594;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -11101,7 +11101,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12594;Lübeck St Jürgen;lubeck-st-jurgen;8004930;;10.700866;53.842374;;f;DE;f;Europe/Berlin;t;;;f;;f;8003774;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12595;Lübeck-Kücknitz;lubeck-kucknitz;8004935;;10.818886;53.924949;;f;DE;f;Europe/Berlin;t;;;f;;f;8003776;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12596;Lüchtringen;luchtringen;8013328;;9.426511;51.790559;;f;DE;f;Europe/Berlin;t;;;f;;f;8003780;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12597;Lübeck Flughafen;lubeck-flughafen;8001682;;10.69772;53.803181;;f;DE;f;Europe/Berlin;t;;;f;;f;8003781;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Lubeca;;;;リューベック;뤼베크;;Lubeka;;Любек;;;吕贝克
+12597;Lübeck Flughafen;lubeck-flughafen;8001682;;10.69772;53.803181;;f;DE;f;Europe/Berlin;t;;;f;;f;8003781;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Lubeca Aeropuerto;;;;リューベック;뤼베크;;Lubeka;;Любек;;;吕贝克
 12598;Lüdenscheid;ludenscheid;8008378;;7.628857;51.220849;;f;DE;f;Europe/Berlin;t;;;f;;f;8003782;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Люденшайд;;;吕登沙伊德
 12599;Lüdinghausen;ludinghausen;8021113;;7.431652;51.761838;;f;DE;f;Europe/Berlin;t;;;f;;f;8003783;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Людингхаузен;;;吕丁格豪森
 12600;Lügde;lugde;8013447;;9.250826;51.959295;;f;DE;f;Europe/Berlin;t;;;f;;f;8003784;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Люгде;;;吕格德
@@ -11302,7 +11302,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12795;Münchhausen Bahnhof;munchhausen-bahnhof;8005314;;8.718673;50.964198;;f;DE;f;Europe/Berlin;t;;;f;;f;8004164;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12796;Münchsmünster;munchsmunster;8026325;;11.687406;48.758344;;f;DE;f;Europe/Berlin;t;;;f;;f;8004165;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12797;Münchweiler (Rodalb);munchweiler-rodalb;8019719;;7.70042;49.221352;;f;DE;f;Europe/Berlin;t;;;f;;f;8004166;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12798;München Flughafen Besucherpark;munchen-flughafen-besucherpark;8020657;;11.764488;48.352023;;f;DE;f;Europe/Berlin;t;;;f;;f;8004167;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+12798;München Flughafen Besucherpark;munchen-flughafen-besucherpark;8020657;;11.764488;48.352023;;f;DE;f;Europe/Berlin;t;;;f;;f;8004167;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 12799;Münnerstadt;munnerstadt;8022461;;10.188634;50.250077;;f;DE;f;Europe/Berlin;t;;;f;;f;8004169;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Мюннерштадт;;;米内尔斯塔特
 12800;Münster (b Dieburg);munster-b-dieburg;8011171;;8.853889;49.923679;;f;DE;f;Europe/Berlin;t;;;f;;f;8004171;t;;f;;f;;f;;f;;f;;;;;;;;;;ミュンスター;뮌스터;;;;Мюнстер;;;明斯特
 12801;Münster-Sarmsheim;munster-sarmsheim;8019181;;7.89803;49.947384;;f;DE;f;Europe/Berlin;t;;;f;;f;8004172;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -11519,7 +11519,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 13012;Ochtrup;ochtrup;8021152;;7.184035;52.201618;;f;DE;f;Europe/Berlin;t;;;f;;f;8004613;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13013;Ockenheim;ockenheim;8019228;;7.96544;49.950548;;f;DE;f;Europe/Berlin;t;;;f;;f;8004614;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13014;Odendorf;odendorf;8015452;;6.879768;50.651158;;f;DE;f;Europe/Berlin;t;;;f;;f;8004616;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-13015;Öhringen Hbf;ohringen-hbf;8029661;;9.502703;49.203212;;f;DE;f;Europe/Berlin;t;;;f;;f;8004623;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;エーリンゲン;;;;;Эринген;;;厄赫林根
+13015;Öhringen Hbf;ohringen-hbf;8029661;;9.502703;49.203212;;f;DE;f;Europe/Berlin;t;;;f;;f;8004623;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;エーリンゲン;;;;;Эринген;;;厄赫林根
 13016;Öhringen West;ohringen-west;8085221;;9.485804;49.200137;;f;DE;f;Europe/Berlin;t;;;f;;f;8004624;t;;f;;f;;f;;f;;f;;;;;;;;;;エーリンゲン;;;;;Эринген;;;厄赫林根
 13017;Oelde;oelde;8013610;;8.142599;51.829114;;f;DE;f;Europe/Berlin;t;;;f;;f;8004626;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13018;Kloster Oesede;kloster-oesede;8021479;;8.111272;52.200665;;f;DE;f;Europe/Berlin;t;;;f;;f;8004627;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -11986,7 +11986,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 13479;Münster-Sprakel;munster-sprakel;8021058;;7.619985;52.041511;;f;DE;f;Europe/Berlin;t;;;f;;f;8005635;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13480;Dreieich-Sprendlingen;dreieich-sprendlingen;8011287;;8.688739;50.015198;;f;DE;f;Europe/Berlin;t;;;f;;f;8005636;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13481;Sprendlingen (Rheinh);sprendlingen-rheinh;8019223;;7.981791;49.858948;;f;DE;f;Europe/Berlin;t;;;f;;f;8005637;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-13482;Sankt Alban;sankt-alban;8084423;;11.1053540000;47.9641300000;;f;DE;f;Europe/Berlin;t;;;f;;f;8005639;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;;;;;;;;;;;;;
+13482;Sankt Alban;sankt-alban;8084423;;11.1053540000;47.9641300000;;f;DE;f;Europe/Berlin;t;;;f;;f;8005639;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;Alemania;;;;;;;;;;;;
 13483;Sprötze;sprotze;8001234;;9.812247;53.30943;;f;DE;f;Europe/Berlin;t;;;f;;f;8005640;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13484;St Ilgen-Sandhausen;st-ilgen-sandhausen;8014033;;8.668711;49.341268;;f;DE;f;Europe/Berlin;t;;;f;;f;8005648;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13485;St Koloman;st-koloman;8020075;;11.882966;48.243748;;f;DE;f;Europe/Berlin;t;;;f;;f;8005652;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12050,7 +12050,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 13543;Stühlingen;stuhlingen;8014546;;8.45137;47.747031;;f;DE;f;Europe/Berlin;t;;;f;;f;8005764;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Штюлинген;;;施蒂赫林根
 13544;Stuttgart Ebitzweg;stuttgart-ebitzweg;8029029;;9.231696;48.803938;;f;DE;f;Europe/Berlin;t;;;f;;f;8005766;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13545;Stuttgart Nord;stuttgart-nord;8029033;;9.18773;48.803956;;f;DE;f;Europe/Berlin;t;;;f;;f;8005767;t;;f;;f;;f;;f;;f;;;;;Stoccarda;;;;;シュトゥットガルト;슈투트가르트;;;Estugarda;Штутгарт;;;斯图加特
-13546;Stuttgart Flughafen/Messe;stuttgart-flughafen-messe;8029725;;9.192629;48.690647;;f;DE;f;Europe/Berlin;t;;;f;;f;8005768;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+13546;Stuttgart Flughafen/Messe;stuttgart-flughafen-messe;8029725;;9.192629;48.690647;;f;DE;f;Europe/Berlin;t;;;f;;f;8005768;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 13547;Stuttgart-Feuerbach;stuttgart-feuerbach;8029031;;9.169383;48.813673;;f;DE;f;Europe/Berlin;t;;;f;;f;8005770;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13548;Stuttgart-Münster;stuttgart-munster;8029028;;9.215857;48.820721;;f;DE;f;Europe/Berlin;t;;;f;;f;8005771;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13549;Stuttgart-Obertürkheim;stuttgart-oberturkheim;8029052;;9.267887;48.762012;;f;DE;f;Europe/Berlin;t;;;f;;f;8005772;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12784,7 +12784,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14277;Delitzsch unt Bf;delitzsch-unt-bf;8023172;;12.34574;51.524487;;f;DE;f;Europe/Berlin;t;;;f;;f;8010076;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14278;Deuben (Zeitz);deuben-zeitz;8023666;;12.068917;51.110534;;f;DE;f;Europe/Berlin;t;;;f;;f;8010078;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14279;Doberlug-Kirchhain;doberlug-kirchhain;8004326;;13.564236;51.620573;;f;DE;f;Europe/Berlin;t;;;f;;f;8010079;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14280;Döbeln Hbf;dobeln-hbf;8006264;;13.095026;51.126822;;f;DE;f;Europe/Berlin;t;;;f;;f;8010080;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Дебельн;;;德伯爾恩
+14280;Döbeln Hbf;dobeln-hbf;8006264;;13.095026;51.126822;;f;DE;f;Europe/Berlin;t;;;f;;f;8010080;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Дебельн;;;德伯爾恩
 14281;Döllstädt;dollstadt;8016682;;10.812584;51.08496;;f;DE;f;Europe/Berlin;t;;;f;;f;8010081;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14282;Gnadau;gnadau;8024132;;11.781424;51.979296;;f;DE;f;Europe/Berlin;t;;;f;;f;8010084;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14283;Magdeburg-Rothensee;magdeburg-rothensee;8024003;;11.648114;52.18612;;f;DE;f;Europe/Berlin;t;;;f;;f;8010086;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12898,7 +12898,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14391;Neuruppin West;neuruppin-west;8027231;;12.793888;52.926247;;f;DE;f;Europe/Berlin;t;;;f;;f;8010246;t;;f;;f;;f;;f;;f;;;;;;;;;;;노이루핀;;;;Нойруппин;;;诺伊鲁平
 14392;Neustadt (Dosse);neustadt-dosse;8027307;;12.450671;52.852679;;f;DE;f;Europe/Berlin;t;;;f;;f;8010248;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14393;Neustadt (Sachs);neustadt-sachs;8006064;;14.213536;51.021244;;f;DE;f;Europe/Berlin;t;;;f;;f;8010249;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14394;Neustrelitz Hbf;neustrelitz-hbf;8028121;;13.074603;53.359257;;f;DE;f;Europe/Berlin;t;;;f;;f;8010250;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Нойштрелиц;;;诺伊斯特雷利茨
+14394;Neustrelitz Hbf;neustrelitz-hbf;8028121;;13.074603;53.359257;;f;DE;f;Europe/Berlin;t;;;f;;f;8010250;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Нойштрелиц;;;诺伊斯特雷利茨
 14395;Niederwiesa;niederwiesa;8006375;;13.022843;50.862701;;f;DE;f;Europe/Berlin;t;;;f;;f;8010253;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14396;Nienhagen (Halberst);nienhagen-halberst;8024152;;11.169942;51.951034;;f;DE;f;Europe/Berlin;t;;;f;;f;8010254;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14397;Nordhausen;nordhausen;8016453;;10.789248;51.492917;;f;DE;f;Europe/Berlin;t;;;f;;f;8010256;t;;f;;f;;f;;f;;f;;;;;;;;;;ノルトハウゼン;노르트하우젠;;;;Нордхаузен;;;北豪森
@@ -13203,7 +13203,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14696;Döberitz;doberitz;8024284;;12.368464;52.52433;;f;DE;f;Europe/Berlin;t;;;f;;f;8011390;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14697;Dörrberg;dorrberg;8016187;;10.798669;50.735351;;f;DE;f;Europe/Berlin;t;;;f;;f;8011397;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14698;Dohna (Sachs);dohna-sachs;8006029;;13.855415;50.960953;;f;DE;f;Europe/Berlin;t;;;f;;f;8011398;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14699;Dresden Flughafen;dresden-flughafen;8065112;;13.766224;51.124854;;f;DE;f;Europe/Berlin;t;;;f;;f;8011399;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Dresde;Drážďany;;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
+14699;Dresden Flughafen;dresden-flughafen;8065112;;13.766224;51.124854;;f;DE;f;Europe/Berlin;t;;;f;;f;8011399;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Dresde Aeropuerto;Drážďany;;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
 14700;Domnitz (Saalkr);domnitz-saalkr;8023115;;11.835044;51.636906;;f;DE;f;Europe/Berlin;t;;;f;;f;8011402;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14701;Domsühl;domsuhl;8058191;;11.765872;53.485367;;f;DE;f;Europe/Berlin;t;;;f;;f;8011403;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14702;Dorfchemnitz;dorfchemnitz;8006589;;12.839652;50.665397;;f;DE;f;Europe/Berlin;t;;;f;;f;8011405;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13608,7 +13608,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15101;Lauterbach-Steinbach;lauterbach-steinbach;8047980;;12.619407;51.174879;;f;DE;f;Europe/Berlin;t;;;f;;f;8012178;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15102;Legefeld;legefeld;8016026;;11.288545;50.926884;;f;DE;f;Europe/Berlin;t;;;f;;f;8012180;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15103;Leipzig Olbrichtstraße;leipzig-olbrichtstrasse;8032903;;12.354297;51.369828;;f;DE;f;Europe/Berlin;t;;;f;;f;8012181;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15104;Leipzig/Halle Flughafen;leipzig-halle-flughafen;8027504;;12.223423;51.42334;;f;DE;f;Europe/Berlin;t;;;f;;f;8012183;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+15104;Leipzig/Halle Flughafen;leipzig-halle-flughafen;8027504;;12.223423;51.42334;;f;DE;f;Europe/Berlin;t;;;f;;f;8012183;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 15105;Leipzig Ost;leipzig-ost;8023542;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;8012185;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15106;Leipzig-Gohlis;leipzig-gohlis;8023675;;12.374577;51.362924;;f;DE;f;Europe/Berlin;t;;;f;;f;8012188;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15107;Leipzig-Heiterblick;leipzig-heiterblick;8023442;;12.459759;51.369243;;f;DE;f;Europe/Berlin;t;;;f;;f;8012190;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14062,7 +14062,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15555;Sohland;sohland;8006127;;14.43192;51.05392;;f;DE;f;Europe/Berlin;t;;;f;;f;8013003;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15556;Sollstedt;sollstedt;8016525;;10.529847;51.413668;;f;DE;f;Europe/Berlin;t;;;f;;f;8013004;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15557;Solpke;solpke;8024056;;11.294181;52.500419;;f;DE;f;Europe/Berlin;t;;;f;;f;8013005;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15558;Sonneberg (Thür) Hbf;sonneberg-thur-hbf;8016243;;11.168845;50.35508;;f;DE;f;Europe/Berlin;t;;;f;;f;8013008;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+15558;Sonneberg (Thür) Hbf;sonneberg-thur-hbf;8016243;;11.168845;50.35508;;f;DE;f;Europe/Berlin;t;;;f;;f;8013008;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 15559;Sonneberg (Thür) Nord;sonneberg-thur-nord;8016360;;11.207552;50.365481;;f;DE;f;Europe/Berlin;t;;;f;;f;8013009;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15560;Sonneberg (Thür) Ost;sonneberg-thur-ost;8016244;;11.201395;50.352303;;f;DE;f;Europe/Berlin;t;;;f;;f;8013010;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15561;Sonneberg (Thür) West;sonneberg-thur-west;8016240;;11.159244;50.368088;;f;DE;f;Europe/Berlin;t;;;f;;f;8013011;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14111,7 +14111,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15604;Groß Köris;gross-koris;8004004;;13.650803;52.159611;;f;DE;f;Europe/Berlin;t;;;f;;f;8013109;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15605;Teutschenthal;teutschenthal;8023046;;11.785721;51.46488;;f;DE;f;Europe/Berlin;t;;;f;;f;8013110;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15606;Teutschenthal Ost;teutschenthal-ost;8023045;;11.820149;51.465788;;f;DE;f;Europe/Berlin;t;;;f;;f;8013111;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15607;Thale Hbf;thale-hbf;8024161;;11.030995;51.746197;;f;DE;f;Europe/Berlin;t;;;f;;f;8013112;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+15607;Thale Hbf;thale-hbf;8024161;;11.030995;51.746197;;f;DE;f;Europe/Berlin;t;;;f;;f;8013112;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 15608;Thalheim (Erzgeb);thalheim-erzgeb;8006588;;12.849531;50.696823;;f;DE;f;Europe/Berlin;t;;;f;;f;8013113;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15609;Tharandt;tharandt;8006343;;13.591905;50.982932;;f;DE;f;Europe/Berlin;t;;;f;;f;8013114;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15610;Theißen;theissen;8023668;;12.106627;51.090425;;f;DE;f;Europe/Berlin;t;;;f;;f;8013115;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14287,7 +14287,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15780;Freital-Potschappel;freital-potschappel;8006340;;13.661679;51.013423;;f;DE;f;Europe/Berlin;t;;;f;;f;8013445;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15781;Groß Dalzig;gross-dalzig;8023601;;12.271354;51.208292;;f;DE;f;Europe/Berlin;t;;;f;;f;8013447;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15782;Halle-Silberhöhe;halle-silberhohe;8023090;;11.967006;51.445391;;f;DE;f;Europe/Berlin;t;;;f;;f;8013448;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15783;Dresden Hbf Strehlener Str.;dresden-hbf-strehlener-str;;;13.735849;51.038126;;f;DE;f;Europe/Berlin;f;;;f;;f;8013449;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+15783;Dresden Hbf Strehlener Str.;dresden-hbf-strehlener-str;;;13.735849;51.038126;;f;DE;f;Europe/Berlin;f;;;f;;f;8013449;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 15784;Chemnitz-Hilbersdorf;chemnitz-hilbersdorf;8006376;;12.953878;50.861937;;f;DE;f;Europe/Berlin;t;;;f;;f;8013450;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15785;Bad Lobenstein;bad-lobenstein;8016382;;11.642172;50.452119;;f;DE;f;Europe/Berlin;t;;;f;;f;8013452;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бад-Лобенштайн;;;巴德洛本斯泰因
 15786;Magdeburg Herrenkrug;magdeburg-herrenkrug;8037444;;11.675576;52.145705;;f;DE;f;Europe/Berlin;t;;;f;;f;8013455;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14455,7 +14455,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15948;Husum Bahnhof;husum-bahnhof;8001552;;9.055193;54.472724;;f;DE;f;Europe/Berlin;t;;;f;;f;8070180;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Хузум;;;胡苏姆
 15949;Nordstrand (b Husum);nordstrand-b-husum;;;8.807388;54.496869;;f;DE;f;Europe/Berlin;f;;;f;;f;8070182;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15950;Alveslohe;alveslohe;8040431;;9.913501;53.791818;;f;DE;f;Europe/Berlin;t;;;f;;f;8070185;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15951;München Hbf Arnulfstraße;munchen-hbf-arnulfstrasse;;;11.559085;48.141415;;f;DE;f;Europe/Berlin;f;;;f;;f;8070193;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+15951;München Hbf Arnulfstraße;munchen-hbf-arnulfstrasse;;;11.559085;48.141415;;f;DE;f;Europe/Berlin;f;;;f;;f;8070193;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 15952;Bonn Bertha-von-Suttner-Platz;bonn-bertha-von-suttner-platz;;;7.102646;50.737437;;f;DE;f;Europe/Berlin;t;;;f;;f;8070195;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15953;Bonn Juridicum;bonn-juridicum;;;7.108696;50.729742;;f;DE;f;Europe/Berlin;f;;;f;;f;8070196;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15954;Glossen (b Oschatz);glossen-b-oschatz;8087435;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;8070199;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14578,14 +14578,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 16071;Nebitzschen;nebitzschen;8045178;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;8070698;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16072;Aachen Schanz;aachen-schanz;8031372;;6.07384;50.769861;;f;DE;f;Europe/Berlin;t;;;f;;f;8070704;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16073;Wedel-Schulau Wilkomm Höft;wedel-schulau-wilkomm-hoft;;;9.703414;53.568077;;f;DE;f;Europe/Berlin;f;;;f;;f;8070715;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-16074;Nürnberg Flughafen;nurnberg-flughafen;;;11.078629;49.493392;;f;DE;f;Europe/Berlin;f;;;f;;f;8070716;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+16074;Nürnberg Flughafen;nurnberg-flughafen;;;11.078629;49.493392;;f;DE;f;Europe/Berlin;f;;;f;;f;8070716;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 16075;Nürnberg Hohe Marter;nurnberg-hohe-marter;;;11.044147;49.429443;;f;DE;f;Europe/Berlin;f;;;f;;f;8070717;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16076;Nürnberg Opernhaus;nurnberg-opernhaus;;;11.074899;49.446756;;f;DE;f;Europe/Berlin;f;;;f;;f;8070718;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16077;Nürnberg Rennweg;nurnberg-rennweg;;;11.093291;49.461121;;f;DE;f;Europe/Berlin;f;;;f;;f;8070719;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16078;Nürnberg Schoppershof;nurnberg-schoppershof;;;11.100698;49.465283;;f;DE;f;Europe/Berlin;f;;;f;;f;8070720;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16079;Nürnberg St.Leonhard;nurnberg-st-leonhard;;;11.051635;49.439502;;f;DE;f;Europe/Berlin;f;;;f;;f;8070721;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16080;Nürnberg Wöhrder Wiese;nurnberg-wohrder-wiese;;;11.086594;49.452384;;f;DE;f;Europe/Berlin;f;;;f;;f;8070722;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-16081;Nürnberg Plärrer Richtung Hbf;nurnberg-plarrer-richtung-hbf;;;11.064318;49.44824;;f;DE;f;Europe/Berlin;f;;;f;;f;8070723;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+16081;Nürnberg Plärrer Richtung Hbf;nurnberg-plarrer-richtung-hbf;;;11.064318;49.44824;;f;DE;f;Europe/Berlin;f;;;f;;f;8070723;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 16082;Nürnberg Plärrer;nurnberg-plarrer;;;11.064318;49.448249;;f;DE;f;Europe/Berlin;f;;;f;;f;8070724;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16083;Nürnberg Hbf (U-Bahn);nurnberg-hbf-u-bahn;;;11.082539;49.447134;;f;DE;f;Europe/Berlin;f;;;f;;f;8070725;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16084;Nürnberg Nordostbf. (U-Bahn);nurnberg-nordostbf-u-bahn;;;11.104545;49.47225;;f;DE;f;Europe/Berlin;f;;;f;;f;8070726;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14633,8 +14633,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 16126;Bonn-Ramersdorf Schießbergweg;bonn-ramersdorf-schiessbergweg;;;7.14681;50.725616;;f;DE;f;Europe/Berlin;f;;;f;;f;8070772;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16127;Ilfeld Neanderklinik;ilfeld-neanderklinik;8059895;;10.788529;51.583411;;f;DE;f;Europe/Berlin;t;;;f;;f;8070776;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16128;Nordhausen Bahnhofsplatz;nordhausen-bahnhofsplatz;;;10.78932;51.493951;;f;DE;f;Europe/Berlin;f;;;f;;f;8070777;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-16129;München Flughafen Terminal 1;munchen-flughafen-terminal-1;;;11.786152;48.353362;;f;DE;f;Europe/Berlin;f;;;f;;f;8070786;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
-16130;München Flughafen Terminal 2;munchen-flughafen-terminal-2;;;11.790116;48.355682;;f;DE;f;Europe/Berlin;f;;;f;;f;8070787;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+16129;München Flughafen Terminal 1;munchen-flughafen-terminal-1;;;11.786152;48.353362;;f;DE;f;Europe/Berlin;f;;;f;;f;8070786;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
+16130;München Flughafen Terminal 2;munchen-flughafen-terminal-2;;;11.790116;48.355682;;f;DE;f;Europe/Berlin;f;;;f;;f;8070787;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 16131;Heilbronn Finanzamt;heilbronn-finanzamt;;;9.235013;49.14053;;f;DE;f;Europe/Berlin;t;;;f;;f;8070791;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16132;Heilbronn Friedensplatz;heilbronn-friedensplatz;;;9.228775;49.141312;;f;DE;f;Europe/Berlin;t;;;f;;f;8070792;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16133;Heilbronn Pfühlpark;heilbronn-pfuhlpark;;;9.241378;49.139955;;f;DE;f;Europe/Berlin;t;;;f;;f;8070793;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14690,7 +14690,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 16183;Bonn-Beuel Bahnhof;bonn-beuel-bahnhof;;;7.127115;50.738515;;f;DE;f;Europe/Berlin;f;;;f;;f;8071083;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16184;Bredstedt Bahnhof;bredstedt-bahnhof;;;8.969706;54.621136;;f;DE;f;Europe/Berlin;f;;;f;;f;8071139;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16185;Reicholzheim Ort;reicholzheim-ort;;;9.533887;49.726528;;f;DE;f;Europe/Berlin;f;;;f;;f;8071142;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-16186;München Flughafen Terminal2 Ankunftebene Halt22;munchen-flughafen-terminal2-ankunftebene-halt22;8095587;;11.786125;48.353327;;f;DE;f;Europe/Berlin;f;;;f;;f;8071168;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+16186;München Flughafen Terminal2 Ankunftebene Halt22;munchen-flughafen-terminal2-ankunftebene-halt22;8095587;;11.786125;48.353327;;f;DE;f;Europe/Berlin;f;;;f;;f;8071168;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 16187;Chemnitz Friedrichstraße;chemnitz-friedrichstrasse;8090531;;12.919368;50.772854;;f;DE;f;Europe/Berlin;t;;;f;;f;8071174;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16188;Heidelsheim Marktplatz;heidelsheim-marktplatz;;;8.643577;49.10158;;f;DE;f;Europe/Berlin;f;;;f;;f;8071186;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16189;Rastatt Bahnhof Ost;rastatt-bahnhof-ost;;;8.216257;48.860048;;f;DE;f;Europe/Berlin;f;;;f;;f;8071189;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14698,7 +14698,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 16191;Binsfeld;binsfeld;;;6.535814;50.792855;;f;DE;f;Europe/Berlin;f;;;f;;f;8071257;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16192;Büsum (Hafen);busum-hafen;;;8.86082;54.124599;;f;DE;f;Europe/Berlin;f;;;f;;f;8071259;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16193;Konstanz Sternenplatz;konstanz-sternenplatz;;;9.179487;47.667405;;f;DE;f;Europe/Berlin;f;;;f;;f;8071261;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-16194;Nürnberg Hbf (Bahnhofvorplatz Hauptausgang);nurnberg-hbf-bahnhofvorplatz-hauptausgang;;;11.081694;49.446568;;f;DE;f;Europe/Berlin;f;;;f;;f;8071284;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+16194;Nürnberg Hbf (Bahnhofvorplatz Hauptausgang);nurnberg-hbf-bahnhofvorplatz-hauptausgang;;;11.081694;49.446568;;f;DE;f;Europe/Berlin;f;;;f;;f;8071284;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 16195;Markneukirchen Sächsischer Hof;markneukirchen-sachsischer-hof;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;8071301;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16196;Siebenbrunn Steinknock;siebenbrunn-steinknock;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;8071305;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16197;Muldenhütten Hilbersdorf Gasthof;muldenhutten-hilbersdorf-gasthof;;;13.39043;50.911198;;f;DE;f;Europe/Berlin;f;;;f;;f;8071312;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -15271,7 +15271,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 16764;Eschweiller;eschweiller;8085199;;6.258523;50.813917;;f;DE;f;Europe/Berlin;t;;;f;;f;8096020;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16765;;;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16766;Kassel;kassel;8002748;;9.470378;51.315946;;f;DE;f;Europe/Berlin;t;;;f;;f;8096023;t;;f;;f;;f;;f;;f;;Cassel;;;;;;;;カッセル;카셀;;;;Кассель;;;卡塞尔
-16767;Berlin Flughafen Tegel;berlin-flughafen-tegel;;;13.292403;52.554085;;f;DE;f;Europe/Berlin;t;;;f;;f;8096030;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+16767;Berlin Flughafen Tegel;berlin-flughafen-tegel;;;13.292403;52.554085;;f;DE;f;Europe/Berlin;t;;;f;;f;8096030;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 16768;Bad Abbach Ort;bad-abbach-ort;;;12.04265;48.934551;;f;DE;f;Europe/Berlin;f;;;f;;f;8096031;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16769;Dettelbach Ort;dettelbach-ort;;;10.160345;49.802415;;f;DE;f;Europe/Berlin;f;;;f;;f;8096032;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16770;Bonn Hbf (tief);bonn-hbf-tief;;;7.098026;50.73216;;f;DE;f;Europe/Berlin;f;;;f;;f;8098044;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -15284,7 +15284,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 16777;München Hbf Gl.27-36;munchen-hbf-gl-dot-27-36;8020348;;11.556711;48.141532;;f;DE;f;Europe/Berlin;f;;;f;;f;8098261;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16778;München Hbf Gl.5-10;munchen-hbf-gl-dot-5-10;8069685;;11.555372;48.140093;;f;DE;f;Europe/Berlin;f;;;f;;f;8098262;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16779;München Hbf (tief);munchen-hbf-tief;;;11.560496;48.141172;;f;DE;f;Europe/Berlin;f;;;f;;f;8098263;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-16780;Stolberg (Rheinl) Hbf Gl.27;stolberg-rheinl-hbf-gl-27;8087216;;6.219007;50.794527;;f;DE;f;Europe/Berlin;f;;;f;;f;8098348;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+16780;Stolberg (Rheinl) Hbf Gl.27;stolberg-rheinl-hbf-gl-27;8087216;;6.219007;50.794527;;f;DE;f;Europe/Berlin;f;;;f;;f;8098348;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 16781;Nürnberg Frankenstadion Sonderbahnsteig;nurnberg-frankenstadion-sonderbahnsteig;;;11.128654;49.43161;;f;DE;f;Europe/Berlin;t;;;f;;f;8098493;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16782;Hamburg Hbf (S-Bahn);hamburg-hbf-s-bahn;;;10.007924;53.552804;;f;DE;f;Europe/Berlin;f;;;f;;f;8098549;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16783;Hamburg-Altona (S);hamburg-altona-s;8006900;;9.934482;53.55195;;f;DE;f;Europe/Berlin;f;;;f;;f;8098553;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -15315,7 +15315,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 16808;Villiers-sur-Marne Beauséjour;villiers-sur-marne-beausejour;8798692;;;;;f;FR;f;Europe/Paris;f;FRBSU;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16809;Bettembourg Frontière;bettembourg-frontiere;8719199;;;;8600;f;FR;f;Europe/Paris;f;FRBTG;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16810;Bretenoux—Biars Croisement;bretenoux-biars-croisement;8740755;;;;10702;f;FR;f;Europe/Paris;f;FRBWB;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-16811;Bourges Aéroport;bourges-aeroport;8746569;;2.316807;47.036299;10690;f;FR;f;Europe/Paris;t;FRBWW;;t;;f;8706356;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;;;;;ブールジュ;부르주;;;;Бурж;;;布尔日
+16811;Bourges Aéroport;bourges-aeroport;8746569;;2.316807;47.036299;10690;f;FR;f;Europe/Paris;t;FRBWW;;t;;f;8706356;f;;f;;f;;f;;f;;f;;;Airport;Flughafen;Aeroporto;Aeropuerto;;;;ブールジュ;부르주;;;;Бурж;;;布尔日
 16812;Balazuc RD;balazuc-rd;8742082;;4.381719;44.504164;;f;FR;f;Europe/Paris;t;FRBZX;;t;;f;8705639;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16813;Chomérac;chomerac;8776466;;4.660070;44.703499;;f;FR;f;Europe/Paris;t;FRCKB;;t;;f;8700637;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16814;Calais Terminal;calais-terminal;8731728;;;;1417;f;FR;f;Europe/Paris;f;FRCMM;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -15961,7 +15961,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17455;Mazancourt;mazancourt;;;;;;f;FR;f;Europe/Paris;f;FRZIU;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17456;Boucly;boucly;8758851;;3.014244;49.935365;;f;FR;f;Europe/Paris;t;FRZIV;;t;;f;8706677;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17457;Reichshoffen Usines;reichshoffen-usines;8721323;;7.652436;48.919431;10638;f;FR;f;Europe/Paris;t;FRZMB;;t;;f;8701866;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17458;Salzburg Hbf;salzburg-hbf;8101114;;13.045819401741028;47.813046443088425;;f;AT;f;Europe/Vienna;t;ATSZG;;f;;f;8100002;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Salzburgo;Salcburk;;;ザルツブルク;잘츠부르크;;;Salzburgo;Зальцбург;;;萨尔斯堡
+17458;Salzburg Hbf;salzburg-hbf;8101114;;13.045819401741028;47.813046443088425;;f;AT;f;Europe/Vienna;t;ATSZG;;f;;f;8100002;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Salzburgo Estación central;Salcburk;;;ザルツブルク;잘츠부르크;;;Salzburgo;Зальцбург;;;萨尔斯堡
 17459;Duivendrecht;duivendrecht;8400194;;4.936552;52.323556;;f;NL;f;Europe/Amsterdam;t;NLDAA;;t;;f;8400194;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17476;Montdidier;montdidier;;;;;;f;FR;f;Europe/Paris;f;FRZKG;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17478;Roye;roye;;;;;;t;FR;f;Europe/Paris;f;FRRIY;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -15972,12 +15972,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17494;Kampen;kampen;8400353;;5.9245740000;52.5606020000;;f;NL;t;Europe/Amsterdam;t;NLKAF;;f;;f;8400353;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17495;Bratislava hl.st.;bratislava-hl-st;5613206;;17.106463;48.158908;;f;SK;t;Europe/Bratislava;t;SKABI;;f;;f;5600207;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17496;Zagreb Glavni Kolod.;zagreb-glavni-kolod;7872480;;15.978478;45.804453;;f;HR;t;Europe/Zagreb;t;HRZAG;;f;;f;7800020;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17497;Graz Hbf;graz-hbf;8103171;;15.4156640000;47.0678420000;;f;AT;f;Europe/Vienna;t;ATGRZ;;f;;f;8100173;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Štýrský Hradec;;Grác;グラーツ;그라츠;;;;Грац;;;格拉茨
+17497;Graz Hbf;graz-hbf;8103171;;15.4156640000;47.0678420000;;f;AT;f;Europe/Vienna;t;ATGRZ;;f;;f;8100173;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;Štýrský Hradec;;Grác;グラーツ;그라츠;;;;Грац;;;格拉茨
 17498;Judenburg;judenburg;8103615;;14.6657480000;47.1737260000;;f;AT;f;Europe/Vienna;t;ATJUD;;f;;f;8100073;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17499;Klagenfurt Hbf;klagenfurt-hbf;8103642;;14.3123910000;46.6158020000;;f;AT;f;Europe/Vienna;t;ATKLG;;f;;f;8100085;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;クラーゲンフルト;;;;;Клагенфурт;;;
-17500;Linz/Donau Hbf;linz-donau-hbf;8101591;;14.291122;48.291526;;f;AT;f;Europe/Vienna;f;ATLNZ;;f;;f;8183231;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
+17499;Klagenfurt Hbf;klagenfurt-hbf;8103642;;14.3123910000;46.6158020000;;f;AT;f;Europe/Vienna;t;ATKLG;;f;;f;8100085;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;クラーゲンフルト;;;;;Клагенфурт;;;
+17500;Linz/Donau Hbf;linz-donau-hbf;8101591;;14.291122;48.291526;;f;AT;f;Europe/Vienna;f;ATLNZ;;f;;f;8183231;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;;;;
 17501;Steyr;steyr;8101530;;14.4249450000;48.0394050000;;f;AT;f;Europe/Vienna;t;ATAAL;;f;;f;8100010;t;;f;;f;;f;;f;;f;;;;;;;;;;シュタイアー;슈타이어;;;;Штайр;;;施泰爾
-17502;Wels Hbf;wels-hbf;8101081;;14.0265610000;48.1658740000;;f;AT;f;Europe/Vienna;t;ATAAO;;f;;f;8100014;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Вельс;;;
+17502;Wels Hbf;wels-hbf;8101081;;14.0265610000;48.1658740000;;f;AT;f;Europe/Vienna;t;ATAAO;;f;;f;8100014;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;;;;;;Вельс;;;
 17503;Brno hl.n.;brno-hl-n;5433295;;16.612775;49.190537;;f;CZ;f;Europe/Prague;t;CSABJ;;f;;f;5400001;t;;f;;f;;f;;f;;f;;;;Brünn;;;;;Brünn;ブルノ;브르노;;;;Брно;;;布爾諾
 17505;Děčín hl.n.;decin-hl-n;5455659;;14.201248;50.773411;;f;CZ;f;Europe/Prague;t;CSADJ;;f;;f;5400003;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17506;Karlovy Vary;karlovy-vary;5475875;;12.866853;50.235668;;f;CZ;f;Europe/Prague;t;CSAHA;;f;;f;5400006;t;;f;;f;;f;;f;;f;;;;Karlsbad;;;;;;カルロヴィ・ヴァリ;카를로비바리;Karlsbad;Karlowe Wary;;Карловы Вары;;Karlsbad;卡罗维发利
@@ -15992,7 +15992,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17515;København;kobenhavn;8600626;;12.564618;55.672721;;f;DK;f;Europe/Copenhagen;t;DKCPH;;f;;f;8601309;t;;f;;f;;f;;f;;f;;Copenhague;Copenhagen;Kopenhagen;Copenaghen;Copenhague;Kodaň;;Koppenhága;コペンハーゲン;코펜하겐;Kopenhagen;Kopenhaga;Copenhaga;Копенгаген;Köpenhamn;Kopenhag;哥本哈根
 17516;Odense St.;odense-st;8600512;;10.386001;55.401777;;f;DK;f;Europe/Copenhagen;t;DKACT;;f;;f;8601770;t;;f;;f;;f;;f;;f;;;;;;;;;;オーデンセ;오덴세;;;;Оденсе;;;欧登塞
 17517;Roskilde St.;roskilde-st;8600617;;12.088855;55.639012;;f;DK;f;Europe/Copenhagen;t;DKADC;;f;;f;8602026;t;;f;;f;;f;;f;;f;;;;;;;;;;ロスキレ;로스킬레;;;;Роскилле;;;罗斯基勒
-17518;Gdańsk Główny;gdansk-glowny;5100750;;18.643807;54.355523;;f;PL;f;Europe/Warsaw;t;PLGAW;;f;;f;5100009;t;;f;;f;;f;;f;;f;;Dantzig;Danzig;Danzig;Danzica;;Gdaňsk;;;グダニスク;그단스크;;;Gdańsk;Гданьск;;;格但斯克
+17518;Gdańsk Główny;gdansk-glowny;5100750;;18.643807;54.355523;;f;PL;f;Europe/Warsaw;t;PLGAW;;f;;f;5100009;t;;f;;f;;f;;f;;f;;Dantzig;Danzig;Danzig;Danzica;Danzig;Gdaňsk;;;グダニスク;그단스크;;;Gdańsk;Гданьск;;;格但斯克
 17519;Lodź Kaliska;lodz-kaliska;5104670;;19.430884;51.757416;;f;PL;f;Europe/Warsaw;t;PLABQ;;f;;f;5100039;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17520;Göteborg Central;goteborg-central;7401318;;11.973424;57.709308;;f;SE;f;Europe/Stockholm;t;SEGOT;;f;;f;7400003;t;;f;;f;;f;;f;;f;;;Gothenburg;;;Gotemburgo;;;;ヨーテボリ;예테보리;Gotenburg;;Gotemburgo;Гётеборг;;;哥德堡
 17521;Halmstad Central;halmstad-central;7401380;;12.8643;56.669211;;f;SE;f;Europe/Stockholm;t;SEACM;;f;;f;7400014;t;;f;;f;;f;;f;;f;;;;;;;;;;ハルムスタッド;할름스타드;;;;Хальмстад;;;哈尔姆斯塔德
@@ -16001,7 +16001,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17524;Chalon-sur-Saône Gare Routière;chalon-sur-saone-gare-routiere;8760625;;4.8433969237;46.7817429085;5765;f;FR;f;Europe/Paris;f;FRNDR;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17525;Amsterdam Stadionplein;amsterdam-stadionplein;;;4.8574810000;52.3441030000;8657;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17526;Milano Autostazione;milano-autostazione;;;9.1276310000;45.4894410000;8483;f;IT;f;Europe/Rome;t;;;f;;f;;f;XLM;t;;f;;f;;f;;f;;Milan;Milan;Mailand;;Milán;Milán;;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
-17527;Nice Aéroport Côte d’Azur;nice-aeroport-cote-dazur;;;7.2109370000;43.6651400000;4836;f;FR;f;Europe/Paris;t;;;f;;f;;f;NCE;t;;f;;f;;f;;f;;;Airport;Flughafen;Nizza Aeroporto;Niza;;;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
+17527;Nice Aéroport Côte d’Azur;nice-aeroport-cote-dazur;;;7.2109370000;43.6651400000;4836;f;FR;f;Europe/Paris;t;;;f;;f;;f;NCE;t;;f;;f;;f;;f;;;Airport;Flughafen;Nizza Aeroporto;Niza Aeropuerto;;;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
 17528;Torino Autostazione;torino-autostazione;;;7.6561150000;45.0708540000;8565;f;IT;f;Europe/Rome;t;;;f;;f;;f;XUT;t;;f;;f;;f;;f;;Turin;Turin;Turin;;Turín;Turín;;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
 17529;Wilderswil;wilderswil;8507388;;7.8694710000;46.6657010000;;f;CH;f;Europe/Zurich;t;;;f;;f;8507388;t;;f;;f;;f;;f;;f;;;;;;;;;;ヴィルダースヴィル;;;;;Вильдерсвиль;;;維爾德斯維爾
 17530;Stäfa;stafa;8503107;;8.7216310000;47.2405160000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503107;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16022,13 +16022,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17548;Hopfgarten im Brixental;hopfgarten-im-brixental;8101168;;12.1491810000;47.4553490000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100059;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17549;Kitzbühel;kitzbuhel;8101160;;12.3913780000;47.4537760000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100055;t;;f;;f;;f;;f;;f;;;;;;;;;;キッツビュール;키츠뷜;;;;Кицбюэль;;;基茨比厄爾
 17550;Klosters Platz;klosters-platz;8509068;;9.8809420000;46.8691980000;;f;AT;f;Europe/Vienna;t;CHKST;;f;;f;8509068;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17555;Leoben Hbf;leoben-hbf;8103603;;15.0896070000;47.3866000000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100070;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;レオーベン;레오벤;;;;Леобен;;;萊奧本
+17555;Leoben Hbf;leoben-hbf;8103603;;15.0896070000;47.3866000000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100070;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Estación central;;;;レオーベン;레오벤;;;;Леобен;;;萊奧本
 17556;Liezen;liezen;8101459;;14.2417980000;47.5626620000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100131;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17557;Linz;linz;8101073;;14.2915180000;48.2902490000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100013;t;;f;;f;;f;;f;;f;;;;;;;Linec;;;リンツ;린츠;;;;Линц;;;林茨
 17558;Lustenau;lustenau;8102352;;9.6671160000;47.4503330000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100123;t;;f;;f;;f;;f;;f;;;;;;;;;;ルステナウ;루스테나우;;;;Лустенау;;;盧斯特瑙
 17559;Saalfelden;saalfelden;8101148;;12.8294220000;47.4268440000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100049;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17560;St. Pölten Hbf;st-polten-hbf;8101032;;15.6259120000;48.2076830000;;f;AT;f;Europe/Vienna;t;ATAAH;;f;;f;8100008;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Pölten;Stazione centrale;;;;;ザンクト・ペルテン;장크트푈텐;;;;Санкт-Пёльтен;;;聖帕爾滕
-17561;Wien Westbahnhof;wien-westbahnhof;8101001;;16.3370670000;48.1975970000;;f;AT;f;Europe/Vienna;t;ATWIW;;f;;f;8100003;t;;f;;f;;f;;f;;f;;Vienne;Vienna;;Vienna;;;;;;;;;;;;;
+17560;St. Pölten Hbf;st-polten-hbf;8101032;;15.6259120000;48.2076830000;;f;AT;f;Europe/Vienna;t;ATAAH;;f;;f;8100008;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Pölten;Stazione centrale;Estación central;;;;ザンクト・ペルテン;장크트푈텐;;;;Санкт-Пёльтен;;;聖帕爾滕
+17561;Wien Westbahnhof;wien-westbahnhof;8101001;;16.3370670000;48.1975970000;;f;AT;f;Europe/Vienna;t;ATWIW;;f;;f;8100003;t;;f;;f;;f;;f;;f;;Vienne;Vienna;;Vienna;Viena;;;;;;;;;;;;
 17562;Barcelona Nord;barcelona-nord;;;2.1825720000;41.3940670000;6617;f;ES;f;Europe/Madrid;t;;;f;;f;;f;XBC;t;;f;;f;;f;;f;;Barcelone;;;Barcellona;;;;;バルセロナ;바르셀로나;;;;Барселона;;Barselona;巴薩隆拿
 17564;Alphen aan den Rijn;alphen-aan-den-rijn;8400053;;4.6715590000;52.1159590000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400053;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17565;Boskoop;boskoop;8400125;;4.6477370000;52.0766760000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400125;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16203,11 +16203,11 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17736;Schaarbeek;schaarbeek;8811007;;4.3786540000;50.8784050000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800001;t;;f;;f;;f;;f;;f;;;;;;;;;;スカールベーク;;;;;Схарбек;;;斯哈尔贝克
 17737;Bruxelles-Central;bruxelles-central;8813003;;4.3570620000;50.8454960000;;f;BE;f;Europe/Brussels;t;BEBCE;;f;;f;8800003;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 17738;Bruxelles-Luxembourg;bruxelles-luxembourg;8811304;;4.3739980000;50.8388080000;5974;f;BE;f;Europe/Brussels;t;BEBQL;;f;;f;8800005;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
-17739;Halle;halle;8814308;;4.2400850000;50.7333730000;;f;BE;f;Europe/Brussels;t;BEHAB;;f;;f;8800006;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17739;Halle;halle;8814308;;4.2400850000;50.7333730000;;f;BE;f;Europe/Brussels;t;BEHAB;;f;;f;8800006;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17740;Antwerpen-Berchem;antwerpen-berchem;8821121;;4.4324640000;51.1995270000;;f;BE;f;Europe/Brussels;t;BEBHM;;f;;f;8800008;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17741;Essen;essen;8821402;;4.4509990000;51.4626410000;;f;BE;f;Europe/Brussels;t;BEESS;;f;;f;8800009;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17741;Essen;essen;8821402;;4.4509990000;51.4626410000;;f;BE;f;Europe/Brussels;t;BEESS;;f;;f;8800009;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17742;Mechelen;mechelen;8822004;;4.4834680000;51.0175040000;;f;BE;f;Europe/Brussels;t;BEAAH;;f;;f;8800010;t;;f;;f;;f;;f;;f;;Malines;;Mecheln;Malines;Malinas;;;;メヘレン;메헬렌;;;;Мехелен;;;梅赫伦
-17743;Ans;ans;8841202;;5.5096860000;50.6610280000;;f;BE;f;Europe/Brussels;t;BEAAK;;f;;f;8800013;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;アンス;;;;;Анс;;;昂斯
+17743;Ans;ans;8841202;;5.5096860000;50.6610280000;;f;BE;f;Europe/Brussels;t;BEAAK;;f;;f;8800013;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;アンス;;;;;Анс;;;昂斯
 17744;Rivage;rivage;8842705;;5.5859680000;50.4850370000;;f;BE;f;Europe/Brussels;t;BEAAL;;f;;f;8800014;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17745;Flemalle-Haute;flemalle-haute;8843208;;5.4562270000;50.5947150000;;f;BE;f;Europe/Brussels;t;BEAAM;;f;;f;8800015;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17746;Andenne;andenne;8863404;;5.0946630000;50.4968400000;;f;BE;f;Europe/Brussels;t;BEAAS;;f;;f;8800019;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Анден;;;昂代讷
@@ -16251,7 +16251,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17784;Jemeppe-sur-Sambre;jemeppe-sur-sambre;8874724;;4.6641520000;50.4516520000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800069;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17785;Jette;jette;8812047;;4.3285930000;50.8808860000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800070;t;;f;;f;;f;;f;;f;;;;;;;;;;ジェット;;;;;Жет;;;热特
 17786;Jurbise;jurbise;8881166;;3.9101180000;50.5302350000;;f;BE;f;Europe/Brussels;t;BEJBS;;f;;f;8800071;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17787;Kapellen;kapellen;8821535;;4.4326520000;51.3133750000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800072;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17787;Kapellen;kapellen;8821535;;4.4326520000;51.3133750000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800072;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17788;Knokke;knokke;8891660;;3.2848830000;51.3398310000;;f;BE;f;Europe/Brussels;t;BEKKK;;f;;f;8800074;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17789;Koksijde;koksijde;8892320;;2.6530850000;51.0790900000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800075;t;;f;;f;;f;;f;;f;;Coxyde;;;;;;;;;;;;;Коксейде;;;科克赛德
 17790;Kortemark;kortemark;8892403;;3.0431900000;51.0250550000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800076;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16298,7 +16298,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17831;Poulseur;poulseur;8842689;;5.5784800000;50.5090480000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800177;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17832;Couvin;couvin;8875127;;4.4920620000;50.0565940000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800182;t;;f;;f;;f;;f;;f;;;;;;;;;;クーヴァン;;;;;Кувен;;;库万
 17833;Kalmthout;kalmthout;8821444;;4.4665060000;51.3913750000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800183;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17834;Huy;huy;8843307;;5.2334560000;50.5270260000;;f;BE;f;Europe/Brussels;t;BEHUY;;f;;f;8800185;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;ユイ;;Hoei;;;Юи;;;于伊
+17834;Huy;huy;8843307;;5.2334560000;50.5270260000;;f;BE;f;Europe/Brussels;t;BEHUY;;f;;f;8800185;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;ユイ;;Hoei;;;Юи;;;于伊
 17835;Luchtbal;luchtbal;8821063;;4.4248320000;51.2447340000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800187;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17836;Antwerpen-Noorderdokken;antwerpen-noorderdokken;8821089;;4.4278340000;51.2616160000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800188;t;;f;;f;;f;;f;;f;;Anvers;Antwerp;;Anversa;;;;;;;;;;;;;
 17837;Ekeren;ekeren;8821071;;4.4342610000;51.2815180000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800189;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16317,15 +16317,15 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17850;Bokrijk;bokrijk;8831781;;5.4084400000;50.9556680000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800210;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17851;Bruxelles-Chapelle;bruxelles-chapelle;8813037;;4.3486300000;50.8412260000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800211;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 17852;Bruxelles-Congres;bruxelles-congres;8813045;;4.3622040000;50.8515190000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800212;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
-17853;Buda;buda;8811148;;4.4178830000;50.9084200000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800213;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17853;Buda;buda;8811148;;4.4178830000;50.9084200000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800213;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17854;Weerde;weerde;8822251;;4.4708380000;50.9775110000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800216;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17855;Duffel;duffel;8822210;;4.4928080000;51.0916300000;;f;BE;f;Europe/Brussels;t;BEDUF;;f;;f;8800218;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17856;Kontich;kontich;8821311;;4.4766010000;51.1342380000;;f;BE;f;Europe/Brussels;t;BEKTK;;f;;f;8800219;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17857;Hove;hove;8821337;;4.4657330000;51.1531070000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800220;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17857;Hove;hove;8821337;;4.4657330000;51.1531070000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800220;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17858;Mortsel-Oude-God;mortsel-oude-god;8821238;;4.4557640000;51.1711840000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800221;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17859;Mortsel-Deurnesteenweg;mortsel-deurnesteenweg;8821154;;4.4472330000;51.1823400000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800222;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17860;Melkouwen;melkouwen;8821824;;4.6720260000;51.0948120000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800223;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17861;Alken;alken;8831039;;5.2925330000;50.8868190000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800225;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17861;Alken;alken;8831039;;5.2925330000;50.8868190000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800225;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17862;Etterbeek;etterbeek;8811411;;4.3905380000;50.8213600000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800227;t;;f;;f;;f;;f;;f;;;;;;;;;;エテルベーク;;;;;Эттербек;;;埃特尔贝克
 17863;Delta;delta;8811205;;4.4039140000;50.8184560000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800228;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17864;Merode;merode;8811197;;4.3999770000;50.8388620000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800229;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16363,13 +16363,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17896;Fraipont;fraipont;8844255;;5.7241860000;50.5650590000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800266;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17897;Nessonvaux;nessonvaux;8844230;;5.7420840000;50.5719630000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800267;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17898;Tilff;tilff;8842630;;5.5841530000;50.5705880000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800270;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17899;Mery;mery;8842648;;5.5872990000;50.5475390000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800271;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17899;Mery;mery;8842648;;5.5872990000;50.5475390000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800271;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17900;Hony;hony;8842655;;5.5735180000;50.5397640000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800272;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17901;Esneux;esneux;8842663;;5.5727810000;50.5305770000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800273;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17902;Vielsalm;vielsalm;8845146;;5.9091310000;50.2788250000;;f;BE;f;Europe/Brussels;t;BEAAP;;f;;f;8800274;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Вьельсальм;;;维尔萨姆
 17903;Comblain-la-Tour;comblain-la-tour;8842838;;5.5671180000;50.4567660000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800276;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17904;Hamoir;hamoir;8842846;;5.5337410000;50.4282260000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800277;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17905;Sy;sy;8842853;;5.5238080000;50.4030650000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800278;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17905;Sy;sy;8842853;;5.5238080000;50.4030650000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800278;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17906;Bomal;bomal;8864469;;5.5194030000;50.3769420000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800279;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17907;Melreux-Hotton;melreux-hotton;8864436;;5.4404510000;50.2839310000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800280;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17908;Marche-en-Famenne;marche-en-famenne;8864410;;5.3458480000;50.2223370000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800281;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16406,14 +16406,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17939;Wespelaar-Tildonk;wespelaar-tildonk;8822525;;4.6388290000;50.9579240000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800324;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17940;Haacht;haacht;8822517;;4.6131920000;50.9661310000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800325;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17941;Boortmeerbeek;boortmeerbeek;8822475;;4.5733960000;50.9821500000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800326;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17942;Hever;hever;8822459;;4.5379520000;50.9975390000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800327;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17942;Hever;hever;8822459;;4.5379520000;50.9975390000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800327;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17943;Gentbrugge;gentbrugge;8893179;;3.7560880000;51.0388090000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800328;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17944;Wondelgem;wondelgem;8893211;;3.7196550000;51.0891930000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800329;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17945;Sleidinge;sleidinge;8893260;;3.6678590000;51.1261750000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800330;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17946;Waarschoot;waarschoot;8893815;;3.6152180000;51.1544190000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800331;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17947;Eeklo;eeklo;8893708;;3.5748840000;51.1809910000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800332;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17948;Nieuwkerken-Waas;nieuwkerken-waas;8894714;;4.1853140000;51.1853420000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800334;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17949;Zwijndrecht;zwijndrecht;8894821;;4.3299600000;51.2141080000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800336;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17949;Zwijndrecht;zwijndrecht;8894821;;4.3299600000;51.2141080000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800336;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17950;Zellik;zellik;8812062;;4.2754400000;50.8896150000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800337;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17951;Asse;asse;8812070;;4.2083350000;50.9064970000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800338;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17952;Mollem;mollem;8812112;;4.2164620000;50.9328530000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800339;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16435,7 +16435,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17968;Gavere-Asper;gavere-asper;8892643;;3.6399660000;50.9290960000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800362;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17969;Eine;eine;8892627;;3.6237580000;50.8703870000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800364;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17970;Haaltert;haaltert;8895869;;4.0238320000;50.9068470000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800366;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17971;Ede;ede;8895877;;3.9875420000;50.9111440000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800367;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17971;Ede;ede;8895877;;3.9875420000;50.9111440000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800367;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17972;Terhagen;terhagen;8895448;;3.8964910000;50.9016520000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800368;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17973;Herzele;herzele;8895430;;3.8798340000;50.8971210000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800369;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17974;Hillegem;hillegem;8895422;;3.8581610000;50.8915390000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800370;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16453,7 +16453,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17986;Mevergnies-Attre;mevergnies-attre;8886058;;3.8344560000;50.5997850000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800389;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17987;Brugelette;brugelette;8886066;;3.8520300000;50.5942560000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800390;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17988;Cambron-Casteau;cambron-casteau;8886074;;3.8748990000;50.5865440000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800391;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17989;Lens Gare;lens-gare;8881190;;3.9033580000;50.5588750000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800392;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+17989;Lens Gare;lens-gare;8881190;;3.9033580000;50.5588750000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800392;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 17990;Erbisoeul;erbisoeul;8881158;;3.8881310000;50.5073760000;;f;BE;f;Europe/Brussels;t;BEERB;;f;;f;8800393;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17991;Ghlin;ghlin;8881125;;3.9068910000;50.4874470000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800394;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17992;Vorst-Zuid;vorst-zuid;8814373;;4.3097880000;50.8090810000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800397;t;;f;;f;;f;;f;;f;;Forest-Midi;;;;;;;;;;;;;;;;
@@ -16470,7 +16470,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18003;Ecaussinnes;ecaussinnes;8883212;;4.1571870000;50.5619130000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800413;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18004;Marche-lez-Ecaussinnes;marche-lez-ecaussinnes;8883220;;4.1770080000;50.5462090000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800414;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18005;Familleureux;familleureux;8883238;;4.2102050000;50.5202300000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800415;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18006;Leval Gare;leval-gare;8882339;;4.2105650000;50.4296370000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800417;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+18006;Leval Gare;leval-gare;8882339;;4.2105650000;50.4296370000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800417;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 18007;Binche;binche;8882362;;4.1730170000;50.4088990000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800418;t;;f;;f;;f;;f;;f;;;;;;;;;;バンシュ;;;;;Бенш;;;
 18008;Godarville;godarville;8871381;;4.2903980000;50.4929750000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800419;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18009;Gouy-lez-Pieton;gouy-lez-pieton;8871373;;4.3252580000;50.4967140000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800420;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16488,7 +16488,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18021;Balegem-Dorp;balegem-dorp;8895257;;3.7915420000;50.9194320000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800440;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18022;Balegem-Zuid;balegem-zuid;8895240;;3.8060500000;50.8996830000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800441;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18023;Lierde;lierde;8895570;;3.8273370000;50.8158050000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800442;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18024;Herne Station;herne-station;8895646;;4.0135210000;50.7243660000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800443;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+18024;Herne Station;herne-station;8895646;;4.0135210000;50.7243660000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800443;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 18025;Galmaarden;galmaarden;8895620;;3.9664090000;50.7435940000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800445;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18026;Vorst-Oost;vorst-oost;8814118;;4.3210420000;50.8099170000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800447;t;;f;;f;;f;;f;;f;;Forest-Est;;;;;;;;;;;;;;;;
 18027;Ukkel-Stalle;ukkel-stalle;8814126;;4.3238200000;50.8024650000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800448;t;;f;;f;;f;;f;;f;;Uccle;;;;;;;;;;;;;;;;
@@ -16613,7 +16613,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18146;Geel;geel;8832433;;4.9888780000;51.1688560000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800056;t;;f;;f;;f;;f;;f;;;;;;;;;;ヘール;;;;;Геел;;;赫尔
 18147;Herentals;herentals;8821717;;4.8285730000;51.1811170000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800063;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18148;Kortrijk;kortrijk;8896008;;3.2642970000;50.8244610000;;f;BE;f;Europe/Brussels;t;BEQKT;;f;;f;8800077;t;;f;;f;;f;;f;;f;;Courtrai;;;Courtrai;Courtrai;;;;コルトレイク;코르트레이크;;;Courtrai;Кортрейк;;;科特赖克
-18149;Lier;lier;8821600;;4.5599760000;51.1358560000;;f;BE;f;Europe/Brussels;t;BELIR;;f;;f;8800083;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;リール;;;;;Льер;;;利尔
+18149;Lier;lier;8821600;;4.5599760000;51.1358560000;;f;BE;f;Europe/Brussels;t;BELIR;;f;;f;8800083;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;リール;;;;;Льер;;;利尔
 18150;Zottegem;zottegem;8895208;;3.8146620000;50.8689580000;;f;BE;f;Europe/Brussels;t;BEAAG;;f;;f;8800098;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18151;Hasselt;hasselt;8831005;;5.3270610000;50.9308750000;;f;BE;f;Europe/Brussels;t;BEHST;;f;;f;8800114;t;;f;;f;;f;;f;;f;;;;;;;;;;ハッセルト;하셀트;;;;Хасселт;;;哈瑟尔特
 18152;Mol;mol;8832409;;5.1151040000;51.1907720000;;f;BE;f;Europe/Brussels;t;BEMOL;;f;;f;8800124;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Мол;;;莫尔
@@ -16626,18 +16626,18 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18159;Tielen;tielen;8821964;;4.8942210000;51.2417130000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800200;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18160;Overpelt;overpelt;8832573;;5.4237130000;51.2156180000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800201;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18161;Eppegem;eppegem;8822269;;4.4577320000;50.9586430000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800215;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18162;Haren;haren;8811155;;4.4198880000;50.8886440000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800233;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+18162;Haren;haren;8811155;;4.4198880000;50.8886440000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800233;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 18163;Liedekerke;liedekerke;8895836;;4.0951250000;50.8824870000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800289;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18164;Melle Station;melle-station;8893039;;3.7974480000;51.0025370000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800295;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
+18164;Melle Station;melle-station;8893039;;3.7974480000;51.0025370000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800295;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;Bélgica;;;;;;;;;;;;
 18165;Burst;burst;8895455;;3.9211480000;50.9070540000;;f;BE;f;Europe/Brussels;t;BEAAZ;;f;;f;8800360;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18166;Luttre;luttre;8871308;;4.3836880000;50.5061800000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800422;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18167;Olen;olen;8832458;;4.9029680000;51.1738900000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800605;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18168;Haren-Zuid;haren-zuid;8811130;;4.4164180000;50.8898580000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800587;t;;f;;f;;f;;f;;f;;Sud;South;Süd;;;;;;;;;;;;;;
+18168;Haren-Zuid;haren-zuid;8811130;;4.4164180000;50.8898580000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800587;t;;f;;f;;f;;f;;f;;Sud;South;Süd;;Sur;;;;;;;;;;;;
 18169;Liestal;liestal;8500023;;7.7313520000;47.4843750000;;f;CH;f;Europe/Zurich;t;CHAFC;;f;;f;8500023;t;;f;;f;8500023;t;;f;;f;;;;;;;;;;リースタル;리스탈;;;;Листаль;;;利斯塔爾
 18170;Sissach;sissach;8500026;;7.8120210000;47.4627470000;;f;CH;f;Europe/Zurich;t;CHAIY;;f;;f;8500026;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18171;Dornach (CH);dornach-ch;;;7.6110130000;47.4896340000;;f;CH;f;Europe/Zurich;f;;;f;;f;8500078;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18172;Tavannes;tavannes;8500100;;7.2011410000;47.2202990000;;f;CH;f;Europe/Zurich;t;CHAIC;;f;;f;8500100;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18173;Laufen;laufen;8500113;;7.5026300000;47.4193380000;;f;CH;f;Europe/Zurich;t;CHAFV;;f;;f;8500113;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18173;Laufen;laufen;8500113;;7.5026300000;47.4193380000;;f;CH;f;Europe/Zurich;t;CHAFV;;f;;f;8500113;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18174;Andermatt (Gemsstockbahn);andermatt-gemsstockbahn;;;8.5917900000;46.6325480000;;f;CH;f;Europe/Zurich;f;;;f;;f;8500137;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18175;Grindelwald BGF;grindelwald-bgf;;;8.0417760000;46.6251140000;;f;CH;f;Europe/Zurich;f;;;f;;f;8500145;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18176;Tramelan;tramelan;8500170;;7.1055500000;47.2227980000;;f;CH;f;Europe/Zurich;t;;;f;;f;8500170;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16646,8 +16646,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18179;Balsthal;balsthal;8500294;;7.6943160000;47.3132390000;;f;CH;f;Europe/Zurich;t;;;f;;f;8500294;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бальсталь;;;巴爾斯塔爾
 18180;Frick;frick;8500305;;8.0131280000;47.5072980000;;f;CH;f;Europe/Zurich;t;CHAIU;;f;;f;8500305;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18181;Stein-Säckingen;stein-sackingen;8500320;;7.9488190000;47.5415830000;;f;CH;f;Europe/Zurich;t;CHAGI;;f;;f;8500320;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18182;Laufenburg;laufenburg;8500322;;8.0612920000;47.5597680000;;f;CH;f;Europe/Zurich;t;;;f;;f;8500322;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
-18183;Koblenz Bahnhof;koblenz-bahnhof;8500329;;8.2270530000;47.6003270000;;f;CH;f;Europe/Zurich;t;CHAHD;;f;;f;8500329;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18182;Laufenburg;laufenburg;8500322;;8.0612920000;47.5597680000;;f;CH;f;Europe/Zurich;t;;;f;;f;8500322;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
+18183;Koblenz Bahnhof;koblenz-bahnhof;8500329;;8.2270530000;47.6003270000;;f;CH;f;Europe/Zurich;t;CHAHD;;f;;f;8500329;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18184;Kreuzlingen Bernrain Bahnhof;kreuzlingen-bernrain-bahnhof;;;9.1618230000;47.6421900000;;f;CH;f;Europe/Zurich;f;;;f;;f;8500521;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18185;Frick Bahnhof;frick-bahnhof;;;8.0129480000;47.5067760000;;f;CH;f;Europe/Zurich;f;;;f;;f;8500583;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18186;Visp Bahnhof Nord;visp-bahnhof-nord;;;7.8815980000;46.2951020000;;f;CH;f;Europe/Zurich;f;;;f;;f;8500602;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16670,7 +16670,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18203;Gstaad;gstaad;8501399;;7.2843900000;46.4747790000;;f;CH;f;Europe/Zurich;t;CHZHK;;f;;f;8501399;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18204;Aigle;aigle;8501400;85014001;6.9636550000;46.3168560000;;f;CH;f;Europe/Zurich;t;CHZDC;;t;;f;8501400;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18205;Bex;bex;8501402;;7.0006730000;46.2514600000;;f;CH;f;Europe/Zurich;t;CHBEX;;f;;f;8501402;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18206;St-Maurice;st-maurice;8501403;;7.0020390000;46.2163570000;;f;CH;f;Europe/Zurich;t;CHAGD;;f;;f;8501403;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18206;St-Maurice;st-maurice;8501403;;7.0020390000;46.2163570000;;f;CH;f;Europe/Zurich;t;CHAGD;;f;;f;8501403;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18207;Leysin TLSA;leysin-tlsa;;;7.0173840000;46.3475090000;;f;CH;f;Europe/Zurich;f;;;f;;f;8501467;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18208;Sion;sion;8501506;;7.359364628791808;46.2274606182505;;f;CH;f;Europe/Zurich;t;CHSIR;;t;;f;8501506;t;;f;;f;8501506;t;;f;;f;;;;Sitten;;;;;;シオン;시옹;;;;Сьон;;;锡永
 18209;Sierre/Siders;sierre-siders;8501509;;7.5328070000;46.2921180000;;f;CH;f;Europe/Zurich;t;CHZKO;;t;;f;8501509;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16690,7 +16690,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18223;Sursee;sursee;8502007;;8.0978780000;47.1707780000;;f;CH;f;Europe/Zurich;t;CHAAV;;f;;f;8502007;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18224;Unterkulm;unterkulm;8502162;;8.1151370000;47.3102450000;;f;CH;f;Europe/Zurich;t;;;f;;f;8502162;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18225;Menziken;menziken;8502169;;8.1891190000;47.2405790000;;f;CH;f;Europe/Zurich;t;;;f;;f;8502169;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18226;Cham;cham;8502203;;8.4574830000;47.1782480000;;f;CH;f;Europe/Zurich;t;;;f;;f;8502203;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18226;Cham;cham;8502203;;8.4574830000;47.1782480000;;f;CH;f;Europe/Zurich;t;;;f;;f;8502203;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18227;Wohlen AG;wohlen-ag;8502213;;8.2697880000;47.3484670000;;f;CH;f;Europe/Zurich;t;CHADU;;f;;f;8502213;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18228;Birmensdorf ZH;birmensdorf-zh;8502221;;8.4375350000;47.3574480000;;f;CH;f;Europe/Zurich;t;;;f;;f;8502221;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18229;Affoltern am Albis;affoltern-am-albis;8502224;;8.4465880000;47.2760680000;;f;CH;f;Europe/Zurich;t;;;f;;f;8502224;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16698,14 +16698,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18231;Cham (CH) See;cham-ch-see;;;8.4634780000;47.1786790000;;f;CH;f;Europe/Zurich;f;;;f;;f;8502250;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18232;Wohlen AG Bahnhof;wohlen-ag-bahnhof;;;8.2694640000;47.3488720000;;f;CH;f;Europe/Zurich;f;;;f;;f;8502889;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18233;Sursee Bahnhof;sursee-bahnhof;;;8.0986240000;47.1702290000;;f;CH;f;Europe/Zurich;f;;;f;;f;8502998;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18234;Zürich Flughafen;zurich-flughafen;8503016;;8.5623330000;47.4502790000;;f;CH;f;Europe/Zurich;t;CHAJO;;f;;f;8503016;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Zúrich;Curych;;;チューリッヒ;취리히;;Zurych;Zurique;Цюрих;;Zürih;
+18234;Zürich Flughafen;zurich-flughafen;8503016;;8.5623330000;47.4502790000;;f;CH;f;Europe/Zurich;t;CHAJO;;f;;f;8503016;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Zúrich Aeropuerto;Curych;;;チューリッヒ;취리히;;Zurych;Zurique;Цюрих;;Zürih;
 18235;Zürich HB SZU;zurich-hb-szu;8503088;;8.5392030000;47.3781860000;;f;CH;f;Europe/Zurich;f;;;f;;f;8503088;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18236;Küsnacht ZH;kusnacht-zh;8503101;;8.5806260000;47.3191630000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503101;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18237;Erlenbach ZH;erlenbach-zh;8503102;;8.5915120000;47.3057780000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503102;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18238;Meilen;meilen;8503104;;8.6442870000;47.2698030000;;f;CH;f;Europe/Zurich;t;CHAKF;;f;;f;8503104;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18239;Männedorf;mannedorf;8503106;;8.6923350000;47.2534150000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503106;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18240;Uznach;uznach;8503116;;8.9806910000;47.2242630000;;f;CH;f;Europe/Zurich;t;CHAAE;;f;;f;8503116;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18241;Kilchberg;kilchberg;8503200;;8.5478600000;47.3244660000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503200;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18241;Kilchberg;kilchberg;8503200;;8.5478600000;47.3244660000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503200;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18242;Thalwil;thalwil;8503202;;8.5645170000;47.2958440000;;f;CH;f;Europe/Zurich;t;CHADS;;f;;f;8503202;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18243;Richterswil;richterswil;8503207;;8.7074640000;47.2083610000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503207;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18244;Lachen;lachen;8503220;;8.8527020000;47.1900680000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503220;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16722,9 +16722,9 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18255;Rafz;rafz;8503404;;8.5434190000;47.6037700000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503404;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18256;Lottstetten;lottstetten;8503420;;8.5668270000;47.6257310000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503420;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18257;Jestetten;jestetten;8503421;;8.5732820000;47.6544060000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503421;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18258;Neuhausen;neuhausen;8503423;;8.6249160000;47.6831360000;;f;CH;f;Europe/Zurich;t;CHAHG;;f;;f;8503423;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18258;Neuhausen;neuhausen;8503423;;8.6249160000;47.6831360000;;f;CH;f;Europe/Zurich;t;CHAHG;;f;;f;8503423;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18259;Turgi;turgi;8503503;;8.2534540000;47.4917550000;;f;CH;f;Europe/Zurich;t;CHAAF;;f;;f;8503503;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18260;Baden;baden;8503504;;8.3075780000;47.4764380000;;f;CH;f;Europe/Zurich;t;CHBDS;;f;;f;8503504;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;バーデン;바덴;;;;Баден;;;巴登
+18260;Baden;baden;8503504;;8.3075780000;47.4764380000;;f;CH;f;Europe/Zurich;t;CHBDS;;f;;f;8503504;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;バーデン;바덴;;;;Баден;;;巴登
 18261;Killwangen-Spreitenbach;killwangen-spreitenbach;8503506;;8.3541870000;47.4333340000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503506;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18262;Schlieren;schlieren;8503509;;8.4469380000;47.3993370000;;f;CH;f;Europe/Zurich;t;CHAIA;;f;;f;8503509;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18263;Regensdorf-Watt;regensdorf-watt;8503526;;8.4728090000;47.4371550000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503526;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16735,7 +16735,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18268;Männedorf ZSG;mannedorf-zsg;;;8.6890810000;47.2527860000;;f;CH;f;Europe/Zurich;f;;;f;;f;8503664;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18269;Richterswil ZSG;richterswil-zsg;;;8.7073020000;47.2090990000;;f;CH;f;Europe/Zurich;f;;;f;;f;8503669;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18270;Thalwil ZSG;thalwil-zsg;;;8.5680500000;47.2966980000;;f;CH;f;Europe/Zurich;f;;;f;;f;8503674;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18271;Kilchberg Bendlikon;kilchberg-bendlikon;;;8.5517880000;47.3225600000;;f;CH;f;Europe/Zurich;f;;;f;;f;8503677;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18271;Kilchberg Bendlikon;kilchberg-bendlikon;;;8.5517880000;47.3225600000;;f;CH;f;Europe/Zurich;f;;;f;;f;8503677;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18272;Turgi Bahnhof;turgi-bahnhof;;;8.2538950000;47.4922590000;;f;CH;f;Europe/Zurich;f;;;f;;f;8503877;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18273;Romont;romont;8504023;;6.9117960000;46.6935040000;;f;CH;f;Europe/Zurich;t;CHAFW;;f;;f;8504023;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18274;Bulle;bulle;8504086;;7.0549320000;46.6181480000;;f;CH;f;Europe/Zurich;t;CHAGF;;f;;f;8504086;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16749,7 +16749,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18282;Brunnen;brunnen;8505007;;8.6100650000;46.9991650000;;f;CH;f;Europe/Zurich;t;CHBNN;;f;;f;8505007;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18283;Brunnen Bahnhof;brunnen-bahnhof;;;8.6098320000;46.9995150000;;f;CH;f;Europe/Zurich;f;;;f;;f;8505098;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18284;Flüelen;fluelen;8505112;;8.6242950000;46.9017210000;;f;CH;f;Europe/Zurich;t;CHFLL;;f;;f;8505112;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Флюйлен;;;
-18285;Altdorf;altdorf;8505113;;8.6315770000;46.8757340000;;f;CH;f;Europe/Zurich;t;CHLDF;;f;;f;8505113;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18285;Altdorf;altdorf;8505113;;8.6315770000;46.8757340000;;f;CH;f;Europe/Zurich;t;CHLDF;;f;;f;8505113;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18286;Erstfeld;erstfeld;8505114;;8.6509570000;46.8210430000;;f;CH;f;Europe/Zurich;t;CHERS;;f;;f;8505114;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18287;Realp;realp;8505163;;8.5037770000;46.5987850000;;f;CH;f;Europe/Zurich;t;;;f;;f;8505163;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18288;Sedrun;sedrun;8505176;;8.7694080000;46.6820970000;;f;CH;f;Europe/Zurich;t;CHABI;;f;;f;8505176;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16813,7 +16813,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18346;Brienz BrS;brienz-brs;;;8.0383600000;46.7537590000;;f;CH;f;Europe/Zurich;f;;;f;;f;8508376;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18347;Niederrickenbach Station;niederrickenbach-station;8508384;;8.3961760000;46.9278440000;;f;CH;f;Europe/Zurich;t;;;f;;f;8508384;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18348;Stansstad;stansstad;8508390;;8.3363350000;46.9762780000;;f;CH;f;Europe/Zurich;t;;;f;;f;8508390;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18349;Engelberg;engelberg;8508399;;8.4026840000;46.8195060000;;f;CH;f;Europe/Zurich;t;CHZHB;;f;;f;8508399;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;エンゲルベルク;;;;;Энгельберг;;;恩格尔贝格
+18349;Engelberg;engelberg;8508399;;8.4026840000;46.8195060000;;f;CH;f;Europe/Zurich;t;CHZHB;;f;;f;8508399;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;エンゲルベルク;;;;;Энгельберг;;;恩格尔贝格
 18350;Alpnachstad PB;alpnachstad-pb;8508458;;8.2771770000;46.9554950000;;f;CH;f;Europe/Zurich;f;;;f;;f;8508458;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18351;Flüelen SGV;fluelen-sgv;;;8.6239360000;46.9033660000;;f;CH;f;Europe/Zurich;f;;;f;;f;8508476;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18352;Stansstad SGV;stansstad-sgv;;;8.3361550000;46.9806470000;;f;CH;f;Europe/Zurich;f;;;f;;f;8508483;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17020,7 +17020,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18553;Zermatt Bahnhof;zermatt-bahnhof;;;7.7484580000;46.0241940000;;f;CH;f;Europe/Zurich;f;;;f;;f;8594556;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18554;Sierre Hôtel de Ville - CFF;sierre-hotel-de-ville-cff;;;7.5339580000;46.2933400000;;f;CH;f;Europe/Zurich;f;;;f;;f;8594615;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18555;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18556;Dornach-Arlesheim;dornach-arlesheim;8500118;;7.6108420000;47.4892650000;;f;CH;f;Europe/Zurich;t;;;f;;f;8500118;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18556;Dornach-Arlesheim;dornach-arlesheim;8500118;;7.6108420000;47.4892650000;;f;CH;f;Europe/Zurich;t;;;f;;f;8500118;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18557;Morges;morges;8501037;;6.4939420000;46.5111040000;;f;CH;f;Europe/Zurich;t;CHAIN;;f;;f;8501037;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18558;Leysin-Feydey;leysin-feydey;8501482;;7.0083580000;46.3444440000;;f;CH;f;Europe/Zurich;t;CHACV;;f;;f;8501482;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18559;Fiesch;fiesch;8501672;;8.1326120000;46.4030450000;;f;CH;f;Europe/Zurich;t;CHFSC;;f;;f;8501672;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17032,7 +17032,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18565;Kreuzlingen;kreuzlingen;8506131;;9.1690870000;47.6525540000;;f;CH;f;Europe/Zurich;t;CHAHT;;f;;f;8506131;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Кройцлинген;;;克羅伊茨林根
 18566;Kreuzlingen Bernrain;kreuzlingen-bernrain;8506197;;9.1631990000;47.6421000000;;f;CH;f;Europe/Zurich;t;;;f;;f;8506197;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18567;Belp;belp;8507076;;7.4985850000;46.8888850000;;f;CH;f;Europe/Zurich;t;;;f;;f;8507076;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бельп;;;貝爾普
-18568;Wengen;wengen;8507372;;7.9210060000;46.6048980000;;f;CH;f;Europe/Zurich;t;CHACZ;;f;;f;8507372;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;;;;;;;;;;;;;
+18568;Wengen;wengen;8507372;;7.9210060000;46.6048980000;;f;CH;f;Europe/Zurich;t;CHACZ;;f;;f;8507372;t;;f;;f;;f;;f;;f;;Suisse;Switzerland;Schweiz;Svizzera;Suiza;;;;;;;;;;;;
 18569;Lauterbrunnen BLM;lauterbrunnen-blm;8507377;;7.9073070000;46.5989200000;;f;CH;f;Europe/Zurich;f;;;f;;f;8507377;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18570;Mürren BLM;murren-blm;8507379;;7.8972570000;46.5641140000;;f;CH;f;Europe/Zurich;t;;;f;;f;8507379;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18571;Grindelwald;grindelwald;8507380;;8.0333000000;46.6243680000;;f;CH;f;Europe/Zurich;t;CHZHJ;;f;;f;8507380;t;;f;;f;;f;;f;;f;;;;;;;;;;グリンデルワルト;;;;;Гриндельвальд;;;格林德瓦
@@ -17042,7 +17042,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18575;Lauterbrunnen;lauterbrunnen;8507384;;7.9086100000;46.5989110000;;f;CH;f;Europe/Zurich;t;CHAKE;;f;;f;8507384;t;;f;;f;;f;;f;;f;;;;;;;;;;ラウターブルンネン;라우터브루넨;;;;Лаутербруннен;;;盧達本納
 18576;Interlaken Ost;interlaken-ost;8507492;85074922;7.8689770000;46.6906910000;;f;CH;f;Europe/Zurich;t;CHZTG;;t;;f;8507492;t;;f;;f;;f;;f;;f;;;;;;Entrelagos;;;;インターラーケン;인터라켄;;;;Интерлакен;;;因特拉肯
 18577;Plzeň hl.n.;plzen-hl-n;5473275;;13.3882460000;49.7431670000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400012;t;;f;;f;;f;;f;;f;;Pilsen;Pilsen;Pilsen;Pilsen;Pilsen;Plzeň;;Plzeň;プルゼニ;플젠;Pilsen;Pilzno;Plzeň;Пльзень;;;比尔森
-18578;Kolín;kolin;5453414;;15.2135320000;50.0254010000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400022;t;;f;;f;;f;;f;;f;;République Tchèque;Czech Republic;Tschechien;Repubblica Ceca;;;;;;;;;;;;;
+18578;Kolín;kolin;5453414;;15.2135320000;50.0254010000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400022;t;;f;;f;;f;;f;;f;;République Tchèque;Czech Republic;Tschechien;Repubblica Ceca;República Checa;;;;;;;;;;;;
 18579;Česka Lípa hl.n.;ceska-lipa-hl-n;5456809;;14.5409500000;50.6790790000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400045;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18580;Praha-Libeň;praha-liben;5457176;;14.5014340000;50.1012610000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400130;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18581;Pardubice hl.n.;pardubice-hl-n;5453613;;15.7587100000;50.0312620000;;f;CZ;f;Europe/Prague;t;CSAMP;;f;;f;5400161;t;;f;;f;;f;;f;;f;;;;;;;;;;パルドゥビツェ;파르두비체;;;;Пардубице;;;帕尔杜比采
@@ -17059,7 +17059,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18592;Praha Nádraží Holešovice (M);praha-nadrazi-holesovice-m;;;14.4400100000;50.1102140000;;f;CZ;f;Europe/Prague;f;;;f;;f;5480000;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18593;Praha Smíchovské nádraží (M);praha-smichovske-nadrazi-m;;;14.4078110000;50.0607830000;;f;CZ;f;Europe/Prague;f;;;f;;f;5480035;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18594;Praha Náměšti Republiky (M);praha-namesti-republiky-m;;;14.4324510000;50.0883700000;;f;CZ;f;Europe/Prague;f;;;f;;f;5480040;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18595;Alken St.;alken-st;8600260;;9.8457680000;56.0525960000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600042;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;;;;;;;;;;;;;
+18595;Alken St.;alken-st;8600260;;9.8457680000;56.0525960000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600042;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;Dinamarca;;;;;;;;;;;;
 18596;Ålsgårde St.;alsgarde-st;8601633;;12.5377040000;56.0750600000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600057;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18597;Arden St.;arden-st;8600029;;9.8598270000;56.7692520000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600083;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18598;Aulum St.;aulum-st;8600300;;8.7874500000;56.2641310000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600146;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17070,7 +17070,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18603;Borris St.;borris-st;8600280;;8.6440360000;55.9581920000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600272;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18604;Borup St.;borup-st;8600614;;11.9729300000;55.4948970000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600276;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18605;Bramming St.;bramming-st;8600219;;8.7067800000;55.4645130000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600297;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;Gmina Bramming;;;;;
-18606;Brande St.;brande-st;8600291;;9.1238800000;55.9396290000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600300;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;;;;;;;;Gmina Brande;;;;;
+18606;Brande St.;brande-st;8600291;;9.1238800000;55.9396290000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600300;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;Dinamarca;;;;;;;Gmina Brande;;;;;
 18607;Bred St.;bred-st;8600507;;10.1057720000;55.3732910000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600310;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18608;Bredebro St.;bredebro-st;8600430;;8.8230650000;55.0568970000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600313;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;Gmina Bredebro;;;;;
 18609;Brejning St.;brejning-st;8600076;;9.6591870000;55.6666710000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600330;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17087,7 +17087,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18620;Frederikshavn St.;frederikshavn-st;8600001;;10.5406700000;57.4426790000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600629;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18621;Fruens Bøge St.;fruens-boge-st;8600533;;10.3775240000;55.3696230000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600644;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18622;Gadstrup St.;gadstrup-st;8600800;;12.0994260000;55.5729860000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600658;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18623;Gaarde St.;gaarde-st;8600209;;8.6112880000;55.7638810000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600669;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;;;;;;;;;;;;;
+18623;Gaarde St.;gaarde-st;8600209;;8.6112880000;55.7638810000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600669;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;Dinamarca;;;;;;;;;;;;
 18624;Gelsted St.;gelsted-st;8600505;;9.9743940000;55.3962130000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600681;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18625;Give St.;give-st;8600289;;9.2367570000;55.8427610000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600702;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18626;Glumsø St.;glumso-st;8600773;;11.6958290000;55.3533340000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8600746;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17154,7 +17154,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18687;Marienlyst St.;marienlyst-st;8601623;;12.6019770000;56.0433110000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8601563;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18688;Mårum (Græsted-Gilleleje) St.;marum-graested-gilleleje-st;8601427;;12.3168570000;56.0308690000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8601572;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18689;Mørdrup St.;mordrup-st;8600779;;12.5326520000;56.0021940000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8601613;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18690;Mørkøv St.;morkov-st;8600722;;11.5018320000;55.6545180000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8601616;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;;;;;;;;;;;;;
+18690;Mørkøv St.;morkov-st;8600722;;11.5018320000;55.6545180000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8601616;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;Dinamarca;;;;;;;;;;;;
 18691;Nivå St.;niva-st;8600665;;12.5068980000;55.9340830000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8601666;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18692;Nørre Alslev St.;norre-alslev-st;8600821;;11.8857350000;54.8967540000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8601683;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18693;Nyborg St.;nyborg-st;8600518;;10.8029210000;55.3140700000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8601739;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Нюборг;;;尼堡自治市
@@ -17179,7 +17179,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18712;Saltrup St.;saltrup-st;8601431;;12.3217020000;56.0544300000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8602076;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18713;Saunte St.;saunte-st;8601625;;12.4845780000;56.0770020000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8602096;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18714;Sejstrup St.;sejstrup-st;8600420;;8.7333340000;55.4353160000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8602117;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18715;Sig St.;sig-st;8600211;;8.5774620000;55.6655300000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8602127;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;;;;;;;;;;;;;
+18715;Sig St.;sig-st;8600211;;8.5774620000;55.6655300000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8602127;t;;f;;f;;f;;f;;f;;Danemark;Denmark;Dänemark;Danimarca;Dinamarca;;;;;;;;;;;;
 18716;Silkeborg St.;silkeborg-st;8600266;;9.5440270000;56.1641700000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8602130;t;;f;;f;;f;;f;;f;;;;;;;;;;シルケボー;실케보르;;;;Силькеборг;;;锡尔克堡
 18717;Sindal St.;sindal-st;8600007;;10.1989450000;57.4692780000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8602137;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;Gmina Sindal;;;;;
 18718;Sjørring St.;sjorring-st;8600403;;8.5877360000;56.9518320000;;f;DK;f;Europe/Copenhagen;t;;;f;;f;8602151;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17273,7 +17273,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18806;Debrecen;debrecen;5513912;;21.6287920000;47.5196310000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500058;t;;f;;f;;f;;f;;f;;;;;;;Debrecín;;;デブレツェン;데브레첸;;Debreczyn;;Дебрецен;;;德布勒森
 18807;Balatonfüred;balatonfured;5504416;;17.9018640000;46.9624530000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500073;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18808;Szeged;szeged;5517228;;20.1431810000;46.2398100000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500101;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18809;Eger;eger;5512401;;20.3821230000;47.8916230000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500120;t;;f;;f;;f;;f;;f;;Hongrie;Hungary;Ungarn;Ungheria;;;;;エゲル;에게르;;;;Эгер;;Eğri;埃格爾
+18809;Eger;eger;5512401;;20.3821230000;47.8916230000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500120;t;;f;;f;;f;;f;;f;;Hongrie;Hungary;Ungarn;Ungheria;Hungría;;;;エゲル;에게르;;;;Эгер;;Eğri;埃格爾
 18810;Budapest-Ferencváros;budapest-ferencvaros;5510025;;19.0907870000;47.4689860000;18819;f;HU;f;Europe/Budapest;t;;;f;;f;5500133;t;;f;;f;;f;;f;;f;;;;;;;;;;ブダペスト;부다페스트;Boedapest;Budapeszt;Budapeste;Будапешт;;Budapeşte;布达佩斯
 18811;Angyalföld;angyalfold;;;19.0901390000;47.5497360000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500346;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18812;Üröm;urom;;;19.0015240000;47.5809010000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500347;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17358,7 +17358,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18891;Bilthoven;bilthoven;8400114;;5.2041870000;52.1301350000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400114;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18892;Bloemendaal;bloemendaal;8400118;;4.6275740000;52.4043240000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400118;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18893;Bodegraven;bodegraven;8400121;;4.7461960000;52.0814860000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400121;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18894;Borne Station;borne-station;8400124;;6.7484170000;52.2987190000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400124;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;;;;;;;;;;;;;
+18894;Borne Station;borne-station;8400124;;6.7484170000;52.2987190000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400124;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;Países Bajos;;;;;;;;;;;;
 18895;Bovenkarspel-Grootebroek;bovenkarspel-grootebroek;8400127;;5.2364680000;52.6950620000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400127;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18896;Boxtel;boxtel;8400129;;5.3189170000;51.5847330000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400129;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бокстел;;;
 18897;Breda-Prinsenbeek;breda-prinsenbeek;8400132;;4.7213500000;51.6057140000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400132;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17385,7 +17385,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18918;Eindhoven Beukenlaan;eindhoven-beukenlaan;8400196;;5.4570540000;51.4503620000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400196;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18919;Ede-Wageningen;ede-wageningen;8400200;;5.6715550000;52.0278650000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400200;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18920;Elst;elst;8400207;;5.8550240000;51.9171900000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400207;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18921;Emmen;emmen;8400208;;6.8996880000;52.7901140000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400208;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;;;;;エメン;;;;;Эммен;;;埃門
+18921;Emmen;emmen;8400208;;6.8996880000;52.7901140000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400208;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;Países Bajos;;;;エメン;;;;;Эммен;;;埃門
 18922;Enkhuizen;enkhuizen;8400210;;5.2880300000;52.6995120000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400210;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18923;Enschede Drienerlo;enschede-drienerlo;8400221;;6.8389930000;52.2372870000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400213;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18924;Ermelo;ermelo;8400216;;5.6144820000;52.3012540000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400216;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Эрмело;;;
@@ -17401,7 +17401,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18934;Den Haag Mariahoeve;den-haag-mariahoeve;8400278;;4.3689730000;52.0905290000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400278;t;;f;;f;;f;;f;;f;;La Haye;The Hague;;L’Aia;;;;;;;;;;;;;
 18935;Den Haag Moerwijk;den-haag-moerwijk;8400279;;4.3085470000;52.0538620000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400279;t;;f;;f;;f;;f;;f;;La Haye;The Hague;;L’Aia;;;;;;;;;;;;;
 18936;Hardenberg;hardenberg;8400293;;6.6281510000;52.5724410000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400293;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Харденберге;;;哈登貝赫
-18937;Haren Station;haren-station;8400297;;6.6183260000;53.1749880000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400297;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;;;;;;;;;;;;;
+18937;Haren Station;haren-station;8400297;;6.6183260000;53.1749880000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400297;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;Países Bajos;;;;;;;;;;;;
 18938;Helmond Brouwhuis;helmond-brouwhuis;8400299;;5.7028280000;51.4703810000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400299;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18939;Helmond ’t Hout;helmond-t-hout;8400300;;5.6313100000;51.4680350000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400300;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18940;Den Helder Zuid;den-helder-zuid;8400303;;4.7643450000;52.9325030000;;f;NL;f;Europe/Amsterdam;t;NLABX;;f;;f;8400303;t;;f;;f;;f;;f;;f;;Le Helder;;;;;;;;デン・ヘルダー;;;;;Ден-Хелдер;;;登海尔德
@@ -17436,7 +17436,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18969;Maarssen;maarssen;8400419;;5.0332220000;52.1357450000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400419;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18970;Maassluis West;maassluis-west;8400421;;4.2360310000;51.9256580000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400421;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18971;Maassluis;maassluis;8400422;;4.2536230000;51.9165160000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400422;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18972;Marienberg;marienberg;8400428;;6.5749890000;52.5092730000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400428;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;;;;;;;;;;;;;
+18972;Marienberg;marienberg;8400428;;6.5749890000;52.5092730000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400428;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;Países Bajos;;;;;;;;;;;;
 18973;Meppel;meppel;8400435;;6.1978820000;52.6919070000;;f;NL;f;Europe/Amsterdam;t;NLABV;;f;;f;8400435;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Меппел;;;
 18974;Middelburg;middelburg;8400436;;3.6170790000;51.4948320000;;f;NL;f;Europe/Amsterdam;t;NLAAV;;f;;f;8400436;t;;f;;f;;f;;f;;f;;Middelbourg;;;;;;;;ミデルブルフ;미델뷔르흐;;;Midelburgo;Мидделбург;;;米德尔堡
 18975;Almere Poort;almere-poort;8400450;;5.1521670000;52.3427390000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400450;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17450,7 +17450,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18983;Nijmegen Dukenburg;nijmegen-dukenburg;8400475;;5.7953720000;51.8240710000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400475;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18984;Obdam;obdam;8400480;;4.9076060000;52.6780370000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400480;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18985;Oisterwijk;oisterwijk;8400482;;5.1948300000;51.5823870000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400482;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Ойстервейк;;;
-18986;Olst;olst;8400486;;6.1133030000;52.3352690000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400486;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;;;;;;;;;;;;;
+18986;Olst;olst;8400486;;6.1133030000;52.3352690000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400486;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;Países Bajos;;;;;;;;;;;;
 18987;Ommen;ommen;8400487;;6.4166970000;52.5096330000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400487;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18988;Oosterbeek;oosterbeek;8400489;;5.8400750000;51.9948660000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400489;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18989;Oss;oss;8400495;;5.5303610000;51.7650290000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400495;t;;f;;f;;f;;f;;f;;;;;;;;;;オス;;;;;Осс;;;奥斯
@@ -17464,7 +17464,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18997;Raalte;raalte;8400513;;6.2784160000;52.3913080000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400513;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Раалт;;;
 18998;Ravenstein;ravenstein;8400515;;5.6364610000;51.7944240000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400515;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18999;Rhenen;rhenen;8400517;;5.5783190000;51.9580100000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400517;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19000;Rheden;rheden;8400519;;6.0330920000;52.0106150000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400519;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;;;;;;;;;;;;;
+19000;Rheden;rheden;8400519;;6.0330920000;52.0106150000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400519;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;Países Bajos;;;;;;;;;;;;
 19001;Almelo de Riet;almelo-de-riet;8400520;;6.6664000000;52.3422180000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400520;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19002;Rilland-Bath;rilland-bath;8400521;;4.1608360000;51.4226480000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400521;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19003;Roermond;roermond;8400523;;5.9945100000;51.1928480000;;f;NL;f;Europe/Amsterdam;t;NLABA;;f;;f;8400523;t;;f;;f;;f;;f;;f;;Ruremonde;;;;;;;;ルールモント;;;;;Рурмонд;;;鲁尔蒙德
@@ -17480,10 +17480,10 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19013;Schagen;schagen;8400549;;4.8053810000;52.7847480000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400549;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Схаген;;;斯哈亨
 19014;Schinnen;schinnen;8400554;;5.8746390000;50.9390560000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400554;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19015;Schiedam Nieuwland;schiedam-nieuwland;8400563;;4.3824840000;51.9224310000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400563;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19016;Soest Station;soest-station;8400567;;5.3101250000;52.1728160000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400567;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;;;;;;;;;;;;;
+19016;Soest Station;soest-station;8400567;;5.3101250000;52.1728160000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400567;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;Países Bajos;;;;;;;;;;;;
 19017;Soestdijk;soestdijk;8400569;;5.2999860000;52.1835220000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400569;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19018;Hilversum Sportpark;hilversum-sportpark;8400570;;5.1872070000;52.2166570000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400570;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19019;Soest Zuid;soest-zuid;8400571;;5.3030150000;52.1653640000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400571;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;;;;;;;;;;;;;
+19019;Soest Zuid;soest-zuid;8400571;;5.3030150000;52.1653640000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400571;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;Países Bajos;;;;;;;;;;;;
 19020;Spaubeek;spaubeek;8400572;;5.8503140000;50.9433340000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400572;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19021;Steenwijk;steenwijk;8400578;;6.1163950000;52.7911570000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400578;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19022;Susteren;susteren;8400582;;5.8628270000;51.0607700000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400582;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17517,7 +17517,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19050;Zandvoort aan Zee;zandvoort-aan-zee;8400733;;4.5328100000;52.3754060000;;f;NL;f;Europe/Amsterdam;t;NLABJ;;f;;f;8400733;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19051;Zevenbergen;zevenbergen;8400737;;4.6096860000;51.6409510000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400737;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19052;Zoetermeer Oost;zoetermeer-oost;8400740;;4.4927450000;52.0463470000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400740;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19053;Zwijndrecht Station;zwijndrecht-station;8400752;;4.6412380000;51.8151620000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400752;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;;;;;;;;;;;;;
+19053;Zwijndrecht Station;zwijndrecht-station;8400752;;4.6412380000;51.8151620000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400752;t;;f;;f;;f;;f;;f;;Pays-Bas;Netherlands;Niederlande;Paesi Bassi;Países Bajos;;;;;;;;;;;;
 19054;Haarlem Spaarnwoude;haarlem-spaarnwoude;8400270;;4.6728620000;52.3830650000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8402735;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19055;Hoek van Holland Strand;hoek-van-holland-strand;8400342;;4.1191980000;51.9818490000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8479001;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19056;Almere Parkwijk;almere-parkwijk;8400104;;5.2449450000;52.3768620000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8479008;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17556,7 +17556,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19089;Katowice Dworzec autobusowy Piotra Skargi 8;katowice-dworzec-autobusowy-piotra-skargi-8;;;19.0171830000;50.2626800000;;f;PL;f;Europe/Warsaw;f;;;f;;f;5104614;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19090;Wrocław Główny (Dworzec autobusowy Sucha 1-11);wroclaw-glowny-dworzec-autobusovy-sucha-1-11;;;17.0339470000;51.0965560000;;f;PL;f;Europe/Warsaw;f;;;f;;f;5104651;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19091;Świnoujście Centrum;swinoujscie-centrum;5189954;;14.2360000000;53.9129930000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5189954;t;;f;;f;;f;;f;;f;;;;;;;;;;シフィノウイシチェ;시비노우이시치에;;;;Свиноуйсьце;;;希維諾烏伊希切
-19092;Jesenice;jesenice;7942400;;14.0533040000;46.4363500000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900001;t;;f;;f;;f;;f;;f;;Slovénie;Slovenia;Slowenien;Slovenia;;;;;イェセニツェ;;;;;;;;
+19092;Jesenice;jesenice;7942400;;14.0533040000;46.4363500000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900001;t;;f;;f;;f;;f;;f;;Slovénie;Slovenia;Slowenien;Slovenia;Eslovenia;;;;イェセニツェ;;;;;;;;
 19093;Lesce Bled;lesce-bled;7942313;;14.1576320000;46.3604270000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900002;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19094;Ljubljana;ljubljana;7942300;;14.5129400000;46.0586860000;;f;SI;f;Europe/Ljubljana;t;SILJU;;f;;f;7900003;t;;f;;f;;f;;f;;f;;;;;Lubiana;Liubliana;Lublaň;;;リュブリャナ;류블랴나;;Lublana;Liubliana;Любляна;;;卢布尔雅那
 19095;Zidani Most;zidani-most;7942200;;15.1707080000;46.0852670000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900004;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17586,14 +17586,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19119;Uppsala Central;uppsala-central;7404351;;17.6467500000;59.8580990000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400102;t;;f;;f;;f;;f;;f;;;;;;Upsala;;;;ウプサラ;웁살라;;;;Уппсала;;;乌普萨拉
 19120;Sölvesborg station;solvesborg-station;7403989;;14.5839280000;56.0498730000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400127;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19121;Ronneby station;ronneby-station;7403219;;15.2833510000;56.2066360000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400135;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19122;Osby;osby;7403074;;13.9948110000;56.3798760000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400157;t;;f;;f;;f;;f;;f;;Suède;Sweden;Schweden;Svezia;;;;;;;;;;;;;
+19122;Osby;osby;7403074;;13.9948110000;56.3798760000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400157;t;;f;;f;;f;;f;;f;;Suède;Sweden;Schweden;Svezia;Suecia;;;;;;;;;;;;
 19123;Höör Station;hoor-station;7401761;;13.5418440000;55.9369230000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400286;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19124;Bräkne-Hoby station;brakne-hoby-station;7400521;;15.1160260000;56.2310590000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400288;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19125;Mörrum station;morrum-station;7402832;;14.7432620000;56.1868320000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400289;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19126;Kävlinge Station;kavlinge-station;7402256;;13.1116830000;55.7939050000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400309;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19127;Landskrona station;landskrona-station;7402300;;12.8571900000;55.8790870000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400311;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19128;Södertälje Syd station;sodertalje-syd-station;7403976;;17.6456720000;59.1625130000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400700;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19129;Falkenberg;falkenberg;7400839;;12.5083100000;56.9198040000;;f;SE;f;Europe/Stockholm;t;SEAHJ;;f;;f;7400965;t;;f;;f;;f;;f;;f;;Suède;Sweden;Schweden;Svezia;;;;;;;;;;;;;
+19129;Falkenberg;falkenberg;7400839;;12.5083100000;56.9198040000;;f;SE;f;Europe/Stockholm;t;SEAHJ;;f;;f;7400965;t;;f;;f;;f;;f;;f;;Suède;Sweden;Schweden;Svezia;Suecia;;;;;;;;;;;;
 19130;Lund Central;lund-central;7402485;;13.1865820000;55.7055230000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400115;t;;f;;f;;f;;f;;f;;;;;;;;;;ルンド;;;;;Лунд;;;隆德
 19132;Ascoli Satriano;ascoli-satriano;8311203;;15.547625;41.219712;;;IT;f;Europe/Rome;t;;;f;;f;8302751;f;;f;;f;8311203;t;;f;;f;;;;;;;;;;;;;;;;;;
 19133;Borgone;borgone;8300210;;7.236127;45.125354;;;IT;f;Europe/Rome;t;;;f;;f;8301226;f;;f;;f;8300210;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17691,7 +17691,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19226;Arvier;arvier;8300134;;7.166551;45.704286;;;IT;f;Europe/Rome;t;;;f;;f;8301160;f;;f;;f;8300134;t;;f;;f;;;;;;;;;;;;;;;;;;
 19227;Bicocca;bicocca;8312338;;15.044922;37.460935;;;IT;f;Europe/Rome;t;;;f;;f;8300842;f;;f;;f;8312338;t;;f;;f;;;;;;;;;;;;;;;;;;
 19228;Biforco;biforco;8306621;;11.602233;44.068411;;;IT;f;Europe/Rome;t;;;f;;f;8301212;f;;f;;f;8306621;t;;f;;f;;;;;;;;;;;;;;;;;;
-19229;Catanzaro Lido;catanzaro-lido;8311833;;16.613647;38.822451;;;IT;f;Europe/Rome;t;;;f;;f;8300312;f;;f;;f;8311833;t;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;;;;;;;;;;;;;
+19229;Catanzaro Lido;catanzaro-lido;8311833;;16.613647;38.822451;;;IT;f;Europe/Rome;t;;;f;;f;8300312;f;;f;;f;8311833;t;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;Estación central;;;;;;;;;;;;
 19230;Catenanuova-Centuripe;catenanuova-centuripe;8312244;;14.688994;37.561642;;;IT;f;Europe/Rome;t;;;f;;f;8300314;f;;f;;f;8312244;t;;f;;f;;;;;;;;;;;;;;;;;;
 19231;Caulonia;caulonia;8311846;;16.46724;38.343793;;;IT;f;Europe/Rome;t;;;f;;f;8300830;f;;f;;f;8311846;t;;f;;f;;;;;;;;;;;;;;;;;;
 19232;Cava dei Tirreni;cava-dei-tirreni;8309816;;14.708491;40.703587;;;IT;f;Europe/Rome;t;;;f;;f;8301021;f;;f;;f;8309816;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -19419,7 +19419,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20964;Naturno/Naturns;naturno-naturns;8302211;;11.004225;46.645151;;;IT;f;Europe/Rome;t;;;f;;f;8300087;f;;f;;f;8302211;t;;f;;f;;;;;;;;;;;;;;;;;;
 20965;Volpiano;volpiano;8300880;;7.779867;45.200648;;;IT;f;Europe/Rome;t;;;f;;f;8303722;f;;f;;f;8300880;t;;f;;f;;;;;;;;;;ヴォルピャーノ;;;;;;;;
 20966;Palmiro Togliatti;palmiro-togliatti;8308509;;12.574218;41.903315;;;IT;f;Europe/Rome;t;;;f;;f;8308509;f;;f;;f;8308509;t;;f;;f;;;;;;;;;;;;;;;;;;
-20967;Rho-Fiera Milano;rho-fiera-milano;8301039;;9.08857;45.521131;;;IT;f;Europe/Rome;t;ITFRA;;t;;f;8309660;f;;f;;f;8301039;t;RRO;t;;f;;Expo 2015 Milan;Expo 2015 Milan;Expo 2015 Mailand;Expo 2015;;;;;;;;;;;;;
+20967;Rho-Fiera Milano;rho-fiera-milano;8301039;;9.08857;45.521131;;;IT;f;Europe/Rome;t;ITFRA;;t;;f;8309660;f;;f;;f;8301039;t;RRO;t;;f;;Expo 2015 Milan;Expo 2015 Milan;Expo 2015 Mailand;Expo 2015;Expo 2015;;;;;;;;;;;;
 20968;San Bonifacio;san-bonifacio;8302440;;11.274441;45.402752;;;IT;f;Europe/Rome;t;;;f;;f;8300919;f;;f;;f;8302440;t;;f;;f;;;;;;;;;;;;;;;;;;
 20969;Tarvisio Boscoverde;tarvisio-boscoverde;8303001;;13.607214;46.506358;;;IT;f;Europe/Rome;t;;;f;;f;8303915;f;;f;;f;8303001;t;;f;;f;;;;;;;;;;;;;;;;;;
 20970;Santa Maria a Vico;santa-maria-a-vico;8339020;;14.462816;41.028601;;;IT;f;Europe/Rome;t;;;f;;f;8303229;f;;f;;f;8339020;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -19630,7 +19630,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 21175;Bianzone;bianzone;8301438;;10.1125;46.1795;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8301438;t;;f;;f;;;;;;;;;;;;;;;;;;
 21176;Castrofilippo;castrofilippo;8312374;;13.780555556;37.363888889;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8312374;t;;f;;f;;;;;;;;;;;;;;;;;;
 21177;Collevalenza-Rosceto-Rosarno;collevalenza-rosceto-rosarno;8335125;;12.4698716;42.7269905;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8335125;t;;f;;f;;;;;;;;;;;;;;;;;;
-21178;Cologne;cologne;8301539;;9.93551;45.5767;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8301539;t;;f;;f;;Italie;Italy;Italien;Italia;;;;;コローニェ;;;;;;;;
+21178;Cologne;cologne;8301539;;9.93551;45.5767;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8301539;t;;f;;f;;Italie;Italy;Italien;Italia;Italia;;;;コローニェ;;;;;;;;
 21179;Cassano D’Adda;cassano-dadda;8301707;;9.5128004;45.5143496;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8301707;t;;f;;f;;;;;;;;;;;;;;;;;;
 21180;Cassano Spinola;cassano-spinola;8304302;;8.85898;44.7626;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8304302;t;;f;;f;;;;;;;;;;;;;;;;;;
 21181;Cassibile;cassibile;8312427;;15.1918;36.9628;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8312427;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -19713,7 +19713,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 21258;Milano Nord Cadorna;milano-nord-cadorna;8325001;;9.17529;45.4685697;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8325001;t;;f;;f;;;;;;;;;;;;;;;;;;
 21259;Lucera;lucera;8311000;;15.3316;41.4996;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8311000;t;;f;;f;;;;;;;;;;;;;;;Лучера;;;
 21260;Lisiera;lisiera;8302530;;11.6105;45.5787;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8302530;t;;f;;f;;;;;;;;;;;;;;;;;;
-21261;Stazione Lison;stazione-lison;8302663;;12.759166667;45.751666667;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8302663;t;;f;;f;;Italie;Italy;Italien;Italia;;;;;;;;;;;;;
+21261;Stazione Lison;stazione-lison;8302663;;12.759166667;45.751666667;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8302663;t;;f;;f;;Italie;Italy;Italien;Italia;Italia;;;;;;;;;;;;
 21262;Casole-Trenta;casole-trenta;8354229;;16.324235200881954;39.28040388306708;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8354229;t;;f;;f;;;;;;;;;;;;;;;;;;
 21263;Casoli;casoli;8351010;;14.290251731872557;42.11469904392092;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8351010;t;;f;;f;;;;;;;;;;;;;;;;;;
 21264;Garbagnate Milanese;garbagnate-milanese;8325114;;9.08031;45.5802;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8325114;t;;f;;f;;;;;;;;;;ガルバニャーテ・ミラネーゼ;;;;;;;;
@@ -21065,7 +21065,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22620;Kiel Hbf Kaiserstraße;kiel-hbf-kaiserstasse;;;10.131975;54.314982;;f;DE;f;Europe/Berlin;f;;;f;;f;8071199;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22621;Bad Rappenau Busbf R;bad-rappenau-busbf-r;;;9.101308;49.237721;;f;DE;f;Europe/Berlin;f;;;f;;f;8070924;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22622;Neckarsulm Bhf West;neckarsulm-bhf-west;;;9.220064;49.188973;;f;DE;f;Europe/Berlin;f;;;f;;f;8070923;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-22623;Hahn Flughafen Terminal 2;hahn-flughafen-terminal-2;8013370;;7.270996;49.946853;;f;DE;f;Europe/Berlin;t;;;f;;f;8002518;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
+22623;Hahn Flughafen Terminal 2;hahn-flughafen-terminal-2;8013370;;7.270996;49.946853;;f;DE;f;Europe/Berlin;t;;;f;;f;8002518;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Aeropuerto;;;;;;;;;;;;
 22624;Ljubljana Avtobus po;ljubljana-avtobus-po;;;14.51294;46.058686;;f;SI;f;Europe/Ljubljana;f;;;f;;f;7989003;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22625;Zagreb Autobusni kol;zagreb-autobusni-kol;;;15.978478;45.804453;;f;HR;t;Europe/Zagreb;f;;;f;;f;7889051;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22626;Budapest-Kelenföld;budapest-kelenfold;5501024;;19.020455;47.464356;;f;HU;t;Europe/Budapest;t;HUAAE;;f;;f;5500008;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -21086,7 +21086,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22641;La Chapelle Erdre Active;la-chapelle-erdre-active;8763662;;-1.54445;47.28284;;f;FR;f;Europe/Paris;t;FRRPL;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22642;Babinière;babiniere;8759034;;-1.54417;47.25878;;f;FR;f;Europe/Paris;t;FRVKR;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22643;Haluchère Batignolles;haluchere-batignolles;8759033;;-1.52264;47.24878;;f;FR;f;Europe/Paris;t;FRVKQ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-22644;Wien Hbf;wien-hbf;8101003;;16.375864;48.184923;;f;AT;f;Europe/Vienna;t;ATALV;;f;;f;8103000;t;;f;;f;;f;;f;;f;;Vienne Gare centrale;Vienna Main station;;Vienna Stazione centrale;Viena;Vídeň;;Bécs;;빈;Wenen;Wiedeń;Viena;Вена;;Viyana;
+22644;Wien Hbf;wien-hbf;8101003;;16.375864;48.184923;;f;AT;f;Europe/Vienna;t;ATALV;;f;;f;8103000;t;;f;;f;;f;;f;;f;;Vienne Gare centrale;Vienna Main station;;Vienna Stazione centrale;Viena Estación central;Vídeň;;Bécs;;빈;Wenen;Wiedeń;Viena;Вена;;Viyana;
 22645;Gare fictive 1;gare-fictive-1;;;;;;f;FR;f;Europe/Paris;f;FRMMM;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22646;Gare fictive 2;gare-fictive-2;;;;;;f;FR;f;Europe/Paris;f;FRNNN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22647;Gare fictive 3;gare-fictive-3;8734333;;;;;f;FR;f;Europe/Paris;f;FROOO;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -21095,8 +21095,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22650;Gare fictive 6;gare-fictive-6;8722209;;;;;f;FR;f;Europe/Paris;f;FRRRR;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22651;Gare fictive 1 CE;gare-fictive-1-ce;8718892;;;;;f;FR;f;Europe/Paris;f;FRSSS;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22652;Köln Arcaden;koln-arcaden;;;6.99536;50.93940;7558;f;DE;f;Europe/Berlin;f;;;f;;f;;f;XCG;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-22653;Aachen Wilmerdorferstraße;aachen-wilmerdorferstrasse;;;6.13759;50.78590;6698;t;DE;f;Europe/Berlin;f;;;f;;f;;f;XAA;f;;f;;f;;f;;f;;Aix-la-Chapelle;;;Aquisgrana;;;;;;;;;;;;;
-22654;London Victoria c.st;london-victoria-cst;;;-0.14352500438690186;51.49589967008447;8267;f;GB;f;Europe/London;f;;;f;;f;7002842;t;;f;;f;;f;;f;;f;;Londres;;;Londra;;;;;;;;;;;;;
+22653;Aachen Wilmerdorferstraße;aachen-wilmerdorferstrasse;;;6.13759;50.78590;6698;t;DE;f;Europe/Berlin;f;;;f;;f;;f;XAA;f;;f;;f;;f;;f;;Aix-la-Chapelle;;;Aquisgrana;Aquisgrán;;;;;;;;;;;;
+22654;London Victoria c.st;london-victoria-cst;;;-0.14352500438690186;51.49589967008447;8267;f;GB;f;Europe/London;f;;;f;;f;7002842;t;;f;;f;;f;;f;;f;;Londres;;;Londra;Londres;;;;;;;;;;;;
 22655;Sainte-Ménéhould Médiathèque;sainte-menehould-mediatheque;8763593;;4.8666670000;49.1000000000;;f;FR;f;Europe/Paris;t;FRZKT;;t;;f;8701999;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22656;Hamburg Hbf;hamburg-hbf;8001019;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;7474;;;;;;;;;;;;;;;;;
 22657;Hamburg Hbf;hamburg-hbf;8001020;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;7474;;;;;;;;;;;;;;;;;
@@ -21461,7 +21461,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 23016;Frankfurt (Oder);frankfurt-oder;8053626;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;7730;;;;;;;;;;;;;;;;;
 23017;Berlin Friedrichstr;berlin-friedrichstr;8003137;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;7512;;;;;;;;;;;;;;;;;
 23018;Auch Hôpital;auch-hopital;8766846;;0.57897;43.63068;;f;FR;f;Europe/Paris;t;FRLJX;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-23019;Flughafen Wien;flughafen-wien;8102924;;16.563056;48.120833;;f;AT;f;Europe/Berlin;t;;;f;;f;8100353;t;;f;;f;;f;;f;;f;;Vienne Aéroport;Vienna Airport;;Vienna Aeroporto;;;;;;;;;;;;;
+23019;Flughafen Wien;flughafen-wien;8102924;;16.563056;48.120833;;f;AT;f;Europe/Berlin;t;;;f;;f;8100353;t;;f;;f;;f;;f;;f;;Vienne Aéroport;Vienna Airport;;Vienna Aeroporto;Viena Aeropuerto;;;;;;;;;;;;
 23020;La Barasse;la-barasse;8763558;87635581;5.4845101;43.2858384;4790;f;FR;f;Europe/Paris;t;FRSSA;;t;;f;;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marsella;Marseille;Marseille;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
 23021;bari-policlinico;bari-policlinico;8311517;;16.855000000;41.109444444;22157;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;8311517;f;;f;;f;;;;;;;;;;;;;;;;;;
 23022;Torino di Sangro-Paglieta;torino-di-sangro-paglieta;8307820;;14.552500000;42.228055556;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;8307820;f;;f;;f;;;;;;;;;;;;;;;;;;

--- a/stations.csv
+++ b/stations.csv
@@ -1,4 +1,4 @@
-id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;is_main_station;time_zone;is_suggestable;sncf_id;sncf_tvs_id;sncf_is_enabled;idtgv_id;idtgv_is_enabled;db_id;db_is_enabled;idbus_id;idbus_is_enabled;ouigo_id;ouigo_is_enabled;trenitalia_id;trenitalia_is_enabled;ntv_id;ntv_is_enabled;hkx_id;hkx_is_enabled;same_as;info:fr;info:en;info:de;info:it;info:cs;info:da;info:es;info:hu;info:ja;info:ko;info:nl;info:pl;info:pt;info:ru;info:sv;info:tr;info:zh
+id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;is_main_station;time_zone;is_suggestable;sncf_id;sncf_tvs_id;sncf_is_enabled;idtgv_id;idtgv_is_enabled;db_id;db_is_enabled;idbus_id;idbus_is_enabled;ouigo_id;ouigo_is_enabled;trenitalia_id;trenitalia_is_enabled;ntv_id;ntv_is_enabled;hkx_id;hkx_is_enabled;same_as;info:fr;info:en;info:de;info:it;info:es;info:cs;info:da;info:hu;info:ja;info:ko;info:nl;info:pl;info:pt;info:ru;info:sv;info:tr;info:zh
 1;Château-Arnoux—St-Auban;chateau-arnoux-st-auban;;;6.0016250000;44.0817900000;;t;FR;f;Europe/Paris;f;FRAAA;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2;Château-Arnoux—St-Auban;chateau-arnoux-st-auban;8775123;87751230;5.997342;44.061499;1;f;FR;t;Europe/Paris;t;FRCAA;;t;;f;8700156;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3;Château-Arnoux Mairie;chateau-arnoux-mairie;8775122;87751222;6.011248;44.063863;1;f;FR;f;Europe/Paris;t;FRHXG;;t;;f;8704959;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -34,7 +34,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 42;Pontrieux;pontrieux;8747384;87473843;-3.156382;48.706018;40;f;FR;t;Europe/Paris;t;FREAC;;t;;f;8704287;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 43;Auboué;auboue;8719168;87191684;5.9714555740356445;49.216167463145354;;f;FR;f;Europe/Paris;t;FRABE;;t;;f;8700567;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 44;Périgueux;perigueux;8759500;87595009;0.7075291872024536;45.18725079810115;4957;f;FR;t;Europe/Paris;t;FRABF;PXR;t;;f;8700405;f;;f;;f;;f;;f;;f;;;;;;;;;;ペリグー;;;;;Перигё;;;佩里格
-45;Besançon Viotte;besancon-viotte;8771800;87718007;6.021999;47.24733;5029;f;FR;t;Europe/Paris;t;FRABG;BNV;t;;f;8700044;f;;f;;f;;f;;f;;f;;;;;;;;Besanzón;;ブザンソン;브장송;;;;Безансон;;;贝桑松
+45;Besançon Viotte;besancon-viotte;8771800;87718007;6.021999;47.24733;5029;f;FR;t;Europe/Paris;t;FRABG;BNV;t;;f;8700044;f;;f;;f;;f;;f;;f;;;;;;Besanzón;;;;ブザンソン;브장송;;;;Безансон;;;贝桑松
 47;Douarnenez Office de Tourisme;douarnenez-office-de-tourisme;8747990;87479907;-4.3303728103637695;48.09336269013469;;f;FR;f;Europe/Paris;t;FREEV;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;ドゥアルヌネ;;;;;Дуарнене;;;杜阿尔纳纳
 50;Concarneau;concarneau;;;-3.9166670000;47.8666670000;;t;FR;f;Europe/Paris;f;FRABJ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 51;Concarneau Port;concarneau-port;8747989;87479899;-3.927593;47.867055;50;f;FR;f;Europe/Paris;t;FREEU;;t;;f;8703141;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -47,7 +47,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 60;Labège;labege;;;1.5333330000;43.5333330000;;t;FR;f;Europe/Paris;t;FRABQ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 61;Labège Innopole;labege-innopole;8761200;87612002;1.512974;43.547361;60;f;FR;t;Europe/Paris;t;FRFRV;;t;;f;8702524;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 62;Labège Village;labege-village;8761202;87612028;1.532921;43.530533;60;f;FR;f;Europe/Paris;t;FRFRX;;t;;f;8702526;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-63;Azay-le-Rideau Mairie;azay-le-rideau-mairie;8711029;87110296;0.4666670000;47.2666670000;5083;f;FR;f;Europe/Paris;t;FRABR;;t;;f;8702748;f;;f;;f;;f;;f;;f;;;;;;;;Castillo de Azay-le-Rideau;;アゼ＝ル＝リドー城;아제르리도;;;;Азе-лё-Ридо;;;阿泽莱里多
+63;Azay-le-Rideau Mairie;azay-le-rideau-mairie;8711029;87110296;0.4666670000;47.2666670000;5083;f;FR;f;Europe/Paris;t;FRABR;;t;;f;8702748;f;;f;;f;;f;;f;;f;;;;;;Castillo de Azay-le-Rideau;;;;アゼ＝ル＝リドー城;아제르리도;;;;Азе-лё-Ридо;;;阿泽莱里多
 64;Albas;albas;8761375;87613752;1.2333330000;44.4666670000;9007;f;FR;t;Europe/Paris;t;FRABS;;t;;f;8702636;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 65;Abancourt;abancourt;8731375;87313759;1.7740130424499512;49.68528648603422;;f;FR;f;Europe/Paris;t;FRABT;ABT;t;;f;8700251;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 66;Lunel;lunel;;;4.1333330000;43.6833330000;;t;FR;f;Europe/Paris;f;FRABV;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -60,14 +60,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 77;Dax;dax;8767320;87673202;-1.0500365495681763;43.72076108921594;5776;f;FR;t;Europe/Paris;t;FRACG;DAX;t;ACG;t;8700043;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 80;Rezé;reze;;;-1.5666670000;47.2000000000;;t;FR;f;Europe/Paris;f;FRACJ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 82;Rezé—Pont-Rousseau;reze-pont-rousseau;8748103;87481036;-1.549587;47.193278;80;f;FR;t;Europe/Paris;t;FREFC;;t;;f;8704363;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-83;Cherbourg;cherbourg;8744487;87444877;-1.6210681200027466;49.633295372995704;;f;FR;f;Europe/Paris;t;FRACK;CBU;t;;f;8700227;f;;f;;f;;f;;f;;f;;;;;;;;Cherburgo-Octeville;;シェルブール＝オクトヴィル;셰르부르옥트빌;;;;Шербур-Октевиль;;;瑟堡-奥克特维尔
+83;Cherbourg;cherbourg;8744487;87444877;-1.6210681200027466;49.633295372995704;;f;FR;f;Europe/Paris;t;FRACK;CBU;t;;f;8700227;f;;f;;f;;f;;f;;f;;;;;;Cherburgo-Octeville;;;;シェルブール＝オクトヴィル;셰르부르옥트빌;;;;Шербур-Октевиль;;;瑟堡-奥克特维尔
 84;Angers St-Laud;angers-st-laud;8748400;87484006;-0.5568641424179077;47.46440211188047;344;f;FR;t;Europe/Paris;t;FRACL;ASL;t;;f;8700022;f;QXG;t;ACL;t;;f;;f;;f;;;;;;;;;;アンジェ;앙제;;;;Анже;;;昂热
 85;Saumur;saumur;8748760;87487603;-0.07103562355041504;47.268433556950825;5831;f;FR;t;Europe/Paris;t;FRACN;SUD;t;;f;8704969;f;;f;;f;;f;;f;;f;;;;;;;;;;ソミュール;소뮈르;;;;Сомюр;;;索米尔
 87;Cérences Centre;cerences-centre;8738819;87388199;-1.437824;48.91686;9462;f;FR;f;Europe/Paris;t;FRDGZ;;t;;f;8703000;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-89;Reims;reims;8724856;;4.0333330000;49.2500000000;;t;FR;f;Europe/Paris;t;FRACQ;;t;;f;8796006;f;XIZ;t;;f;;f;;f;;f;;;;;;Remeš;;;;ランス;兰斯;;;;Реймс;;;兰斯
-90;Reims Maison Blanche;reims-maison-blanche;8717127;87171272;4.022484;49.233685;89;f;FR;f;Europe/Paris;t;FRBBX;;t;;f;8701874;f;;f;;f;;f;;f;;f;;;;;;Remeš;;;;ランス;兰斯;;;;Реймс;;;兰斯
-91;Champagne-Ardenne TGV;champagne-ardenne-tgv;8717192;87171926;3.994248;49.214385;89;f;FR;f;Europe/Paris;t;FREAH;CGV;t;;f;8705734;f;;f;;f;;f;;f;;f;;à 8 km de Reims;8km from Reims;8 km von Reims entfernt;8km da Reims;Remeš;;;;ランス;兰斯;;;;Реймс;;;兰斯
-92;Reims Ville;reims-ville;8717100;87171009;4.024156;49.259241;89;f;FR;t;Europe/Paris;t;FRRHE;RMS;t;;f;8700081;f;;f;;f;;f;;f;;f;;;;;;Remeš;;;;ランス;兰斯;;;;Реймс;;;兰斯
+89;Reims;reims;8724856;;4.0333330000;49.2500000000;;t;FR;f;Europe/Paris;t;FRACQ;;t;;f;8796006;f;XIZ;t;;f;;f;;f;;f;;;;;;;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
+90;Reims Maison Blanche;reims-maison-blanche;8717127;87171272;4.022484;49.233685;89;f;FR;f;Europe/Paris;t;FRBBX;;t;;f;8701874;f;;f;;f;;f;;f;;f;;;;;;;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
+91;Champagne-Ardenne TGV;champagne-ardenne-tgv;8717192;87171926;3.994248;49.214385;89;f;FR;f;Europe/Paris;t;FREAH;CGV;t;;f;8705734;f;;f;;f;;f;;f;;f;;à 8 km de Reims;8km from Reims;8 km von Reims entfernt;8km da Reims;;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
+92;Reims Ville;reims-ville;8717100;87171009;4.024156;49.259241;89;f;FR;t;Europe/Paris;t;FRRHE;RMS;t;;f;8700081;f;;f;;f;;f;;f;;f;;;;;;;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
 93;Laval;laval;8747840;87478404;-0.761089;48.076405;4714;f;FR;t;Europe/Paris;t;FRACR;LAL;t;;f;8701470;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 94;Accous;accous;8767278;87672782;-0.6000000000;42.9833330000;;f;FR;f;Europe/Paris;t;FRACS;;t;;f;8702617;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 95;Achiet;achiet;8734204;87342048;2.7500000000;50.1166670000;;f;FR;f;Europe/Paris;t;FRACT;;t;;f;8700583;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -83,17 +83,17 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 107;Carnac;carnac;;;-3.0833330000;47.5833330000;;t;FR;f;Europe/Paris;f;FRADB;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 108;Plouharnel—Carnac;plouharnel-carnac;8747641;87476416;-3.118456;47.6043;107;f;FR;f;Europe/Paris;t;FRECR;;t;;f;8704244;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 109;Les Sables-Blancs;les-sables-blancs;8747626;87476267;-3.132453;47.575598;107;f;FR;f;Europe/Paris;t;FRECL;;t;;f;8704937;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-110;Carnac;carnac;8728967;87289678;-3.0826091766357417;47.584558972342386;107;f;FR;t;Europe/Paris;t;FRRNC;;t;;f;8701865;f;;f;;f;;f;;f;;f;;;;;;;;Alineamientos de Carnac;;カルナック;;;;;;;;卡尔纳克
+110;Carnac;carnac;8728967;87289678;-3.0826091766357417;47.584558972342386;107;f;FR;t;Europe/Paris;t;FRRNC;;t;;f;8701865;f;;f;;f;;f;;f;;f;;;;;;Alineamientos de Carnac;;;;カルナック;;;;;;;;卡尔纳克
 111;St-Pierre-Quiberon;st-pierre-quiberon;;;-3.1333330000;47.5166670000;;t;FR;f;Europe/Paris;f;FRADC;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 112;L’Isthme;listhme;8747627;87476275;-3.133549;47.547102;111;f;FR;f;Europe/Paris;t;FRECM;;t;;f;8704936;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 113;St-Pierre-Quiberon;st-pierre-quiberon;8747644;87476440;-3.138907;47.52106;111;f;FR;t;Europe/Paris;t;FRECU;;t;;f;8704642;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;圣皮耶尔屈伊伯龙
-114;Metz;metz;8719203;87192039;6.177665;49.109382;4827;f;FR;t;Europe/Paris;t;FRADE;MZE;t;;f;8700019;f;XMZ;t;;f;;f;;f;;f;;;;;;Mety;;;;メス;메스;;;;Мец;;;梅斯
+114;Metz;metz;8719203;87192039;6.177665;49.109382;4827;f;FR;t;Europe/Paris;t;FRADE;MZE;t;;f;8700019;f;XMZ;t;;f;;f;;f;;f;;;;;;;Mety;;;メス;메스;;;;Мец;;;梅斯
 115;Forbach;forbach;;;6.9000000000;49.1833330000;;t;FR;f;Europe/Paris;f;FRADF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 117;Forbach Gare;forbach-gare;8719300;87193003;6.900254;49.189215;115;f;FR;t;Europe/Paris;t;FRBQT;FOB;t;;f;8700271;t;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;フォルバック;;;;;Форбах;;;福尔巴克
 118;Sarreguemines;sarreguemines;;;7.0674710000;49.1099500000;;t;FR;f;Europe/Paris;f;FRADG;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 119;Sarreguemines Poste;sarreguemines-poste;8740690;;7.054923;49.110155;118;f;FR;f;Europe/Paris;t;FRZDB;;t;;f;8705509;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 121;Sarreguemines;sarreguemines;8719361;87193615;7.068398594856262;49.10741472240868;118;f;FR;t;Europe/Paris;t;FRSGS;SGS;t;;f;8700439;f;;f;;f;;f;;f;;f;;;;Saargemünd;;;;;;サルグミーヌ;;;;;Саргемин;;;萨尔格米纳
-122;Dunkerque;dunkerque;8728100;87281006;2.3686105012893672;51.03026865635461;;f;FR;f;Europe/Paris;t;FRADI;DKQ;t;;f;8700004;f;XDE;t;;f;;f;;f;;f;;;Dunkirk;Dünkirchen;;Dunkerk;;;;ダンケルク;됭케르크;Duinkerke;Dunkierka;Dunquerque;Дюнкерк;;;敦刻尔克
+122;Dunkerque;dunkerque;8728100;87281006;2.3686105012893672;51.03026865635461;;f;FR;f;Europe/Paris;t;FRADI;DKQ;t;;f;8700004;f;XDE;t;;f;;f;;f;;f;;;Dunkirk;Dünkirchen;;;Dunkerk;;;ダンケルク;됭케르크;Duinkerke;Dunkierka;Dunquerque;Дюнкерк;;;敦刻尔克
 123;Lille-Flandres;lille-flandres;8728600;87286005;3.071128;50.637486;4652;f;FR;f;Europe/Paris;t;FRADJ;LLF;t;;f;8700030;f;;f;;f;;f;;f;;f;;;;;Lilla;;;;;リール;릴;Rijsel;;;Лилль;;;里尔
 124;Haubourdin;haubourdin;8728609;87286096;2.990228533744812;50.6069682482955;;f;FR;f;Europe/Paris;t;FRADK;;t;;f;8701242;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 125;Tourcoing;tourcoing;8728654;87286542;3.168176;50.716573;5840;f;FR;t;Europe/Paris;t;FRADM;TRG;t;;f;8700121;f;;f;ADM;t;;f;;f;;f;;;;;;;;;;トゥールコワン;;Toerkonje;;;Туркуэн;;;图尔宽
@@ -114,12 +114,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 149;Boulogne-sur-Mer Ville;boulogne-sur-mer-ville;8731758;87317586;1.610097885131836;50.71549602881634;5758;f;FR;t;Europe/Paris;t;FRAEB;BEM;t;;f;8700450;f;;f;;f;;f;;f;;f;;;;;;;;;;ブローニュ＝シュル＝メール;불로뉴쉬르메르;;;Bolonha-sobre-o-Mar;Булонь-сюр-Мер;;;滨海布洛涅
 150;Allenc;allenc;8778365;87783654;3.6666670000;44.5333330000;;f;FR;f;Europe/Paris;t;FRAEC;;t;;f;8702645;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 151;Pau;pau;8767200;87672006;-0.3697478771209717;43.29155258667031;5006;f;FR;t;Europe/Paris;t;FRAEE;PAU;t;;f;8700106;f;;f;;f;;f;;f;;f;;;;;;;;;;ポー;;;;;Пау;;;
-152;Hendaye;hendaye;8767700;87677005;-1.7820382118225098;43.3531128691334;5785;f;FR;t;Europe/Paris;t;FRAEF;HED;t;AEF;t;8700149;f;;f;;f;;f;;f;;f;;;;;;;;Hendaya;;アンダイエ;;;;;Андай;;;昂代伊
-153;Strasbourg;strasbourg;8721202;87212027;7.734067;48.585338;5260;f;FR;t;Europe/Paris;t;FRAEG;STG;t;AEG;f;8700023;t;XER;t;;f;;f;;f;;f;;;;Straßburg;Strasburgo;Štrasburk;;Estrasburgo;;ストラスブール;스트라스부르;Straatsburg;Strasburg;Estrasburgo;Страсбург;;Strazburg;斯特拉斯堡
+152;Hendaye;hendaye;8767700;87677005;-1.7820382118225098;43.3531128691334;5785;f;FR;t;Europe/Paris;t;FRAEF;HED;t;AEF;t;8700149;f;;f;;f;;f;;f;;f;;;;;;Hendaya;;;;アンダイエ;;;;;Андай;;;昂代伊
+153;Strasbourg;strasbourg;8721202;87212027;7.734067;48.585338;5260;f;FR;t;Europe/Paris;t;FRAEG;STG;t;AEG;f;8700023;t;XER;t;;f;;f;;f;;f;;;;Straßburg;Strasburgo;Estrasburgo;Štrasburk;;;ストラスブール;스트라스부르;Straatsburg;Strasburg;Estrasburgo;Страсбург;;Strazburg;斯特拉斯堡
 154;Mertzwiller;mertzwiller;;;7.6833330000;48.8666670000;;t;FR;f;Europe/Paris;f;FRAEH;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 155;Mertzwiller;mertzwiller;8721320;87213207;7.677704;48.871609;154;f;FR;t;Europe/Paris;t;FRBVY;;t;;f;8701652;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 157;Colmar;colmar;8718201;87182014;7.346677780151368;48.07254485668853;1349;f;FR;t;Europe/Paris;t;FRAEJ;CMR;t;;f;8700178;f;;f;;f;;f;;f;;f;;;;;;;;;;コルマール;콜마르;;;;Кольмар;;;科尔马
-158;Mulhouse;mulhouse;8718206;87182063;7.343045;47.741952;4753;f;FR;t;Europe/Paris;t;FRAEK;MSE;t;AEK;f;8700031;t;;f;;f;;f;;f;;f;;;;Mülhausen;;Mylhúzy;;;;ミュルーズ;뮐루즈;;Miluza;;Мюлуз;;;米卢斯
+158;Mulhouse;mulhouse;8718206;87182063;7.343045;47.741952;4753;f;FR;t;Europe/Paris;t;FRAEK;MSE;t;AEK;f;8700031;t;;f;;f;;f;;f;;f;;;;Mülhausen;;;Mylhúzy;;;ミュルーズ;뮐루즈;;Miluza;;Мюлуз;;;米卢斯
 159;St-Louis (Haut Rhin);st-louis-haut-rhin;;;7.5666670000;47.5833330000;;t;FR;f;Europe/Paris;f;FRAEL;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 160;St-Louis La-Chaussée;st-louis-la-chaussee;8718101;87181016;7.531252;47.609442;159;f;FR;f;Europe/Paris;t;FRBIH;SLU;t;;f;8701987;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 161;St-Louis;st-louis;8718213;87182139;7.555379;47.590178;159;f;FR;t;Europe/Paris;t;FRXLI;STL;t;;f;8700133;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -130,14 +130,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 166;Aspach-le-Haut;aspach-le-haut;;;7.2333330000;47.6500000000;;t;FR;f;Europe/Paris;f;FRAEQ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 167;Aspach-le-Haut;aspach-le-haut;8767414;87674143;7.142379;47.769396;166;f;FR;t;Europe/Paris;t;FRGII;;t;;f;8704940;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 168;Aspach-le-Bas;aspach-le-bas;8721537;87215376;7.152375;47.759832;166;f;FR;f;Europe/Paris;t;FRCAQ;;t;;f;8704939;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-171;Avignon Centre;avignon-centre;8776500;87765008;4.8052096366882315;43.941668244510936;489;f;FR;f;Europe/Paris;t;FRAES;AVI;t;;f;8700172;f;;f;;f;;f;;f;;f;;;;;Avignone;;;Aviñón;;アヴィニョン;아비뇽;;Awinion;Avinhão;Авиньон;;;亞維農
+171;Avignon Centre;avignon-centre;8776500;87765008;4.8052096366882315;43.941668244510936;489;f;FR;f;Europe/Paris;t;FRAES;AVI;t;;f;8700172;f;;f;;f;;f;;f;;f;;;;;Avignone;Aviñón;;;;アヴィニョン;아비뇽;;Awinion;Avinhão;Авиньон;;;亞維農
 172;Le Mans;le-mans;8739600;87396002;0.1921534538269043;47.995364119768475;4661;f;FR;t;Europe/Paris;t;FRAET;LEN;t;;f;8700435;f;;f;AET;t;;f;;f;;f;;;;;;;;;;ル・マン;르망;;;;Ле-Ман;;;勒芒
 173;Joué-lès-Tours Berthelot;joue-les-tours-berthelot;8711028;87110288;0.6666670000;47.3500000000;4580;f;FR;f;Europe/Paris;t;FRAEV;;t;;f;8703510;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 174;Eu;eu;;;1.4166670000;50.0500000000;;t;FR;f;Europe/Paris;f;FRAEX;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 175;Eu-la-Mouillette;eu-la-mouillette;8731676;87316760;1.4253687858581543;50.04890671485088;174;f;FR;f;Europe/Paris;t;FRCVR;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 176;Eu;eu;8731753;87317537;1.416771;50.054355;174;f;FR;t;Europe/Paris;t;FREUX;;t;;f;8701093;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 177;Alleyras;alleyras;8773188;87731885;3.6822491884231567;44.90590260319495;;f;FR;f;Europe/Paris;t;FRAEY;;t;;f;8704935;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-178;Le Havre;le-havre;8741301;87413013;0.12557029724121094;49.492800002017034;4630;f;FR;t;Europe/Paris;t;FRAEZ;LHA;t;;f;8700112;f;XLH;t;;f;;f;;f;;f;;;;;;;;El Havre;;ル・アーヴル;르아브르;;Hawr;;Гавр;;;勒阿弗尔
+178;Le Havre;le-havre;8741301;87413013;0.12557029724121094;49.492800002017034;4630;f;FR;t;Europe/Paris;t;FRAEZ;LHA;t;;f;8700112;f;XLH;t;;f;;f;;f;;f;;;;;;El Havre;;;;ル・アーヴル;르아브르;;Hawr;;Гавр;;;勒阿弗尔
 179;Harfleur;harfleur;;;0.1982690000;49.5065960000;;t;FR;f;Europe/Paris;f;FRAFA;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 180;Harfleur-Halte;harfleur-halte;8741370;87413708;0.192081;49.505896;179;f;FR;f;Europe/Paris;t;FRDOR;;t;;f;8703460;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 181;Harfleur;harfleur;8741330;87413302;0.198976;49.513717;179;f;FR;t;Europe/Paris;t;FRDOE;;t;;f;8703459;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -148,7 +148,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 188;Péronne;peronne;;;2.6500000000;50.0000000000;;t;FR;f;Europe/Paris;f;FRAFI;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 189;Péronne Centre;peronne-centre;8731341;87313411;2.938987;49.934997;188;f;FR;t;Europe/Paris;t;FRCRJ;;t;;f;8701752;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 190;Péronne La Chapelette;peronne-la-chapelette;8731386;87313866;2.933359;49.924488;188;f;FR;f;Europe/Paris;t;FRCSU;;t;;f;8701770;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-191;Albi Ville;albi-ville;8761500;87615005;2.13785;43.922472;4604;f;FR;t;Europe/Paris;t;FRAFJ;ALB;t;;f;8704917;f;;f;;f;;f;;f;;f;;;;;Albé;;;Albé;;アルビ;알비;Albé;Albé;Albé;Альбе;;;阿尔比
+191;Albi Ville;albi-ville;8761500;87615005;2.13785;43.922472;4604;f;FR;t;Europe/Paris;t;FRAFJ;ALB;t;;f;8704917;f;;f;;f;;f;;f;;f;;;;;Albé;Albé;;;;アルビ;알비;Albé;Albé;Albé;Альбе;;;阿尔比
 192;Orléans;orleans;8754300;87543009;1.9047331809997559;47.90807935070001;4894;f;FR;t;Europe/Paris;f;FRAFK;ORL;t;;f;8700404;f;;f;;f;;f;;f;;f;;;;;;;;;;オルレアン;오를레앙;;Orlean;Orleães;Орлеан;;;奥尔良
 194;Vendôme;vendome;8757455;87574558;1.067837;47.802198;5846;f;FR;f;Europe/Paris;t;FRAFM;;t;;f;8702203;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 195;Fréjus;frejus;8775750;87757500;6.7329078912734985;43.43200708149751;4583;f;FR;t;Europe/Paris;t;FRAFN;FRJ;t;;f;8700472;f;;f;;f;;f;;f;;f;;;;;;;;;;フレジュス;;;;;Фрежюс;;;弗雷瑞斯
@@ -222,7 +222,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 344;Angers;angers;;;-0.5500000000;47.4666670000;;t;FR;f;Europe/Paris;f;FRANE;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 345;Angers Maître École;angers-maitre-ecole;8748404;87484048;-0.531891;47.467089;344;f;FR;f;Europe/Paris;t;FREHA;;t;;f;8700610;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 346;Blondefontaine;blondefontaine;8711736;87117366;5.8666670000;47.8833330000;;f;FR;f;Europe/Paris;t;FRANF;;t;;f;8700692;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-347;Angoulême;angouleme;8758300;87583005;0.16449451446533203;45.653603206036394;;f;FR;f;Europe/Paris;t;FRANG;ANG;t;ANG;f;8700063;f;;f;;f;;f;;f;;f;;;;;;;;Angulema;;アングレーム;앙굴렘;;;;Ангулем;;;昂古莱姆
+347;Angoulême;angouleme;8758300;87583005;0.16449451446533203;45.653603206036394;;f;FR;f;Europe/Paris;t;FRANG;ANG;t;ANG;f;8700063;f;;f;;f;;f;;f;;f;;;;;;Angulema;;;;アングレーム;앙굴렘;;;;Ангулем;;;昂古莱姆
 348;Raincourt;raincourt;8711737;87117374;5.885946750640868;47.859879227409714;;f;FR;f;Europe/Paris;t;FRANH;;t;;f;8701836;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 349;Gévigney;gevigney;8711738;87117382;5.9333330000;47.8000000000;;f;FR;f;Europe/Paris;t;FRANI;;t;;f;8701227;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 350;Baulay;baulay;8711739;87117390;6.0166670000;47.7833330000;;f;FR;f;Europe/Paris;t;FRANJ;;t;;f;8700667;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -345,11 +345,11 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 482;Froncles;froncles;8714224;87142240;5.1500000000;48.3000000000;;f;FR;f;Europe/Paris;t;FRAUS;;t;;f;8701111;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 483;Gudmont;gudmont;8714226;87142265;5.1333330000;48.3500000000;5551;f;FR;t;Europe/Paris;t;FRAUT;;t;;f;8701183;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 484;Donjeux;donjeux;8714227;87142273;5.1500000000;48.3666670000;;f;FR;f;Europe/Paris;t;FRAUU;;t;;f;8701035;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-485;Avignon TGV;avignon-tgv;8731896;87318964;4.785983562469482;43.92160621687953;489;f;FR;f;Europe/Paris;t;FRAVG;AVV;t;AVG;t;8704918;t;;f;AVG;t;;f;;f;;f;;;;;Avignone;;;Aviñón;;アヴィニョン;아비뇽;;Awinion;Avinhão;Авиньон;;;亞維農
+485;Avignon TGV;avignon-tgv;8731896;87318964;4.785983562469482;43.92160621687953;489;f;FR;f;Europe/Paris;t;FRAVG;AVV;t;AVG;t;8704918;t;;f;AVG;t;;f;;f;;f;;;;;Avignone;Aviñón;;;;アヴィニョン;아비뇽;;Awinion;Avinhão;Авиньон;;;亞維農
 486;Avail;avail;8730469;87304691;2.05319;46.960187;;f;FR;f;Europe/Paris;t;FRAVI;;t;;f;8700463;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 487;Damblain;damblain;8714249;87142497;5.656414031982422;48.09373173734836;;f;FR;f;Europe/Paris;t;FRAVL;;t;;f;8700997;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 488;Châtillon-sur-Seine;chatillon-sur-seine;8714255;87142554;4.574829339981079;47.86126131518925;;f;FR;f;Europe/Paris;t;FRAVM;;t;;f;8703071;f;;f;;f;;f;;f;;f;;;;;;;;;;シャティヨン＝シュル＝セーヌ;;;;;Шатийон-сюр-Сен;;;塞纳河畔沙蒂隆
-489;Avignon;avignon;9900010;;4.8166670000;43.9500000000;;t;FR;f;Europe/Paris;t;FRAVN;;t;;f;8796005;t;;f;;f;;f;;f;;f;;;;;Avignone;;;Aviñón;;アヴィニョン;아비뇽;;Awinion;Avinhão;Авиньон;;;亞維農
+489;Avignon;avignon;9900010;;4.8166670000;43.9500000000;;t;FR;f;Europe/Paris;t;FRAVN;;t;;f;8796005;t;;f;;f;;f;;f;;f;;;;;Avignone;Aviñón;;;;アヴィニョン;아비뇽;;Awinion;Avinhão;Авиньон;;;亞維農
 493;Aguilcourt—Variscourt;aguilcourt-variscourt;8717170;87171702;3.973106;49.408004;;f;FR;f;Europe/Paris;t;FRAVR;;t;;f;8700652;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 494;Prauthoy;prauthoy;8714261;87142612;5.2833330000;47.6666670000;;f;FR;f;Europe/Paris;t;FRAVS;;t;;f;8705206;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 495;Vaux-sous-Aubigny;vaux-sous-aubigny;8714262;87142620;5.291365;47.657894;;f;FR;f;Europe/Paris;t;FRAVU;;t;;f;8702224;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -540,7 +540,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 710;Tagolsheim;tagolsheim;8718105;87181057;7.264102;47.655026;;f;FR;f;Europe/Paris;t;FRBIN;;t;;f;8702095;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 711;Walheim;walheim;8718106;87181065;7.263391;47.641695;;f;FR;f;Europe/Paris;t;FRBIO;;t;;f;8702261;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 712;Ballersdorf;ballersdorf;8718107;;7.1666670000;47.6333330000;;f;FR;f;Europe/Paris;t;FRBIP;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-713;Biarritz;biarritz;8767340;87673400;-1.5458643436431885;43.45921166498582;;f;FR;f;Europe/Paris;t;FRBIQ;BIZ;t;BIQ;t;8700114;f;;f;;f;;f;;f;;f;;;;;;;;Biarriz;;ビアリッツ;;;;;Биарриц;;;比亚里茨
+713;Biarritz;biarritz;8767340;87673400;-1.5458643436431885;43.45921166498582;;f;FR;f;Europe/Paris;t;FRBIQ;BIZ;t;BIQ;t;8700114;f;;f;;f;;f;;f;;f;;;;;;Biarriz;;;;ビアリッツ;;;;;Биарриц;;;比亚里茨
 714;Valdieu;valdieu;8718108;;7.056044340133667;47.631315550149495;;f;FR;f;Europe/Paris;t;FRBIR;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 715;Graffenwald;graffenwald;8718113;87181131;7.224774;47.780839;;f;FR;f;Europe/Paris;t;FRBIS;;t;;f;8701212;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 716;St-André (Haut Rhin);st-andre-haut-rhin;8718114;87181149;7.155053;47.79097;;f;FR;f;Europe/Paris;t;FRBIT;;t;;f;8704971;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -637,8 +637,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 823;Metzervisse;metzervisse;8719133;87191338;6.2833330000;49.3166670000;;f;FR;f;Europe/Paris;t;FRBNZ;;t;;f;8701627;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 824;Kédange;kedange;8719134;87191346;6.3333330000;49.3166670000;9047;f;FR;f;Europe/Paris;t;FRBOA;;t;;f;8701333;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 825;Hombourg-Budange;hombourg-budange;8719135;87191353;6.350741386413574;49.28237811811285;3641;f;FR;t;Europe/Paris;t;FRBOB;;t;;f;8701240;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-827;Bordeaux;bordeaux;;;-0.577431321144104;44.83773065393117;;t;FR;f;Europe/Paris;t;FRBOD;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;Burdeos;;ボルドー;보르도;;;Bordéus;Бордо;;;波尔多
-828;Bordeaux St-Jean;bordeaux-st-jean;8758100;87581009;-0.555919;44.82649;827;f;FR;t;Europe/Paris;t;FRBOJ;BXJ;t;BOJ;t;8700047;f;ZFQ;t;;f;;f;;f;;f;;;;;;;;Burdeos;;ボルドー;보르도;;;Bordéus;Бордо;;;波尔多
+827;Bordeaux;bordeaux;;;-0.577431321144104;44.83773065393117;;t;FR;f;Europe/Paris;t;FRBOD;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;Burdeos;;;;ボルドー;보르도;;;Bordéus;Бордо;;;波尔多
+828;Bordeaux St-Jean;bordeaux-st-jean;8758100;87581009;-0.555919;44.82649;827;f;FR;t;Europe/Paris;t;FRBOJ;BXJ;t;BOJ;t;8700047;f;ZFQ;t;;f;;f;;f;;f;;;;;;Burdeos;;;;ボルドー;보르도;;;Bordéus;Бордо;;;波尔多
 829;Boé;boe;8758234;87582346;0.6333330000;44.1666670000;;f;FR;f;Europe/Paris;t;FRBOE;;t;;f;8702849;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 830;Ébersviller;ebersviller;8719137;87191379;6.4000000000;49.2833330000;9046;f;FR;f;Europe/Paris;f;FRBOF;;f;;f;8701097;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 831;Anzeling;anzeling;8719138;87191387;6.459746360778809;49.262343603905244;;f;FR;f;Europe/Paris;t;FRBOG;;t;;f;8700657;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -889,7 +889,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 1114;Cravant-Bazarnes;cravant-bazarnes;8768364;87683649;3.680929;47.678542;;f;FR;f;Europe/Paris;t;FRCBZ;;t;;f;8703183;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1115;Lamure-sur-Azergues;lamure-sur-azergues;8772186;87721860;4.5000000000;46.0666670000;;f;FR;f;Europe/Paris;t;FRCCB;;t;;f;8703638;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1116;Sorèze;soreze;8723565;87235655;2.072912;43.454232;;f;FR;f;Europe/Paris;t;FRCCC;;t;;f;8704507;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-1119;Carcassonne;carcassonne;8761528;87615286;2.3518198728561397;43.21817571610827;;f;FR;f;Europe/Paris;t;FRCCF;CNE;t;;f;8700100;f;;f;;f;;f;;f;;f;;;;;;;;Carcasona;;カルカソンヌ;카르카손;;;;Каркасон;;;卡尔卡松
+1119;Carcassonne;carcassonne;8761528;87615286;2.3518198728561397;43.21817571610827;;f;FR;f;Europe/Paris;t;FRCCF;CNE;t;;f;8700100;f;;f;;f;;f;;f;;f;;;;;;Carcasona;;;;カルカソンヌ;카르카손;;;;Каркасон;;;卡尔卡松
 1120;Balsièges;balsieges;8711186;87111864;3.45637;44.482167;;f;FR;f;Europe/Paris;t;FRCCG;;t;;f;8702765;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1121;Tournai Frontière;tournai-frontiere;8724164;;;;;f;BE;f;Europe/Paris;f;FRCCH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1122;Froyennes;froyennes;8724175;;;;;f;BE;f;Europe/Paris;f;FRCCK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -957,7 +957,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 1265;Esquelbecq;esquelbecq;8728111;87281113;2.4333330000;50.8833330000;;f;FR;f;Europe/Paris;t;FRCIF;;t;;f;8701084;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1266;Arnèke;arneke;8728112;87281121;2.408280372619629;50.83152250898692;;f;FR;f;Europe/Paris;t;FRCIG;;t;;f;8700626;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1267;Cassel;cassel;8728113;87281139;2.459781;50.78756;;f;FR;f;Europe/Paris;t;FRCIH;;t;;f;8700831;f;;f;;f;;f;;f;;f;;;;;;;;;;;;Kassel;;;;;;
-1268;Gravelines;gravelines;8728124;87281246;2.1166670000;50.9833330000;;f;FR;f;Europe/Paris;t;FRCIJ;;t;;f;8701231;f;;f;;f;;f;;f;;f;;;;;;;;Gravelinas;;グラヴリーヌ;;Grevelingen;;;Гравлин;;;格拉沃利讷
+1268;Gravelines;gravelines;8728124;87281246;2.1166670000;50.9833330000;;f;FR;f;Europe/Paris;t;FRCIJ;;t;;f;8701231;f;;f;;f;;f;;f;;f;;;;;;Gravelinas;;;;グラヴリーヌ;;Grevelingen;;;Гравлин;;;格拉沃利讷
 1269;Bourbourg;bourbourg;8728127;87281279;2.2000000000;50.9500000000;;f;FR;f;Europe/Paris;t;FRCIK;;t;;f;8700672;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1270;Grande-Synthe;grande-synthe;8728131;87281311;2.2833330000;51.0125000000;;f;FR;f;Europe/Paris;t;FRCIL;;t;;f;8701213;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 1271;Courghain;courghain;8728133;;2.2941899299621578;50.99702883034289;;f;FR;f;Europe/Paris;t;FRCIN;;t;;f;8700860;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -1810,7 +1810,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 2420;Ballan;ballan;8757160;87571604;0.6166670000;47.3333330000;;f;FR;f;Europe/Paris;t;FRETF;;t;;f;8702762;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2421;Étang;etang;8769414;87694141;4.183902740478516;46.86790811545109;;f;FR;f;Europe/Paris;t;FRETG;;t;;f;8700168;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2422;Druye;druye;8757161;87571612;0.5166670000;47.3166670000;;f;FR;f;Europe/Paris;t;FRETH;;t;;f;8703250;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-2423;Azay-le-Rideau;azay-le-rideau;8757163;87571638;0.4475051164627075;47.26635137684019;5083;f;FR;t;Europe/Paris;t;FRETJ;;t;;f;8702747;f;;f;;f;;f;;f;;f;;;;;;;;Castillo de Azay-le-Rideau;;アゼ＝ル＝リドー城;아제르리도;;;;Азе-лё-Ридо;;;阿泽莱里多
+2423;Azay-le-Rideau;azay-le-rideau;8757163;87571638;0.4475051164627075;47.26635137684019;5083;f;FR;t;Europe/Paris;t;FRETJ;;t;;f;8702747;f;;f;;f;;f;;f;;f;;;;;;Castillo de Azay-le-Rideau;;;;アゼ＝ル＝リドー城;아제르리도;;;;Азе-лё-Ридо;;;阿泽莱里多
 2424;Rivarennes;rivarennes;8757165;87571653;0.3500000000;47.2666670000;;f;FR;f;Europe/Paris;t;FRETL;;t;;f;8704369;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2425;Chinon;chinon;8757168;87571687;0.2518272399902344;47.16297682646879;;f;FR;f;Europe/Paris;t;FRETN;;t;;f;8703098;f;;f;;f;;f;;f;;f;;;;;;;;;;シノン;;;;;Шинон;;;希农
 2426;La Roche-Clermault;la-roche-clermault;8757170;87571703;0.2000000000;47.1500000000;;f;FR;f;Europe/Paris;t;FRETO;;t;;f;8703602;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2184,7 +2184,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 2848;Le Locle Col des Roches;le-locle-col-des-roches;8759821;87598219;;;4655;f;CH;f;Europe/Paris;f;FRFOP;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2850;Fougères;fougeres;8747160;87471607;-1.1955785751342771;48.35043120511249;;f;FR;f;Europe/Paris;t;FRFOU;;t;;f;8703342;f;;f;;f;;f;;f;;f;;;;;;;;;;フージェール;;;;;Фужер;;;富热尔
 2851;Limoux Flassian;limoux-flassian;8759875;87598755;2.218178;43.068424;4665;f;FR;f;Europe/Paris;t;FRFOV;;t;;f;8703811;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-2852;St-Palais;st-palais;8761025;87610253;-1.0333330000;43.3333330000;;f;FR;f;Europe/Paris;t;FRFOY;;t;;f;8704631;f;;f;;f;;f;;f;;f;;;;;;;;Donapaleu;;;;;;;Сен-Пале-сюр-Мер;;;滨海圣帕莱
+2852;St-Palais;st-palais;8761025;87610253;-1.0333330000;43.3333330000;;f;FR;f;Europe/Paris;t;FRFOY;;t;;f;8704631;f;;f;;f;;f;;f;;f;;;;;;Donapaleu;;;;;;;;;Сен-Пале-сюр-Мер;;;滨海圣帕莱
 2853;Muret;muret;8761103;87611038;1.3242173194885252;43.46491197671351;;f;FR;f;Europe/Paris;t;FRFOZ;MET;t;;f;8700473;f;;f;;f;;f;;f;;f;;;;;;;;;;ミュレ;;;;;Мюре;;;米雷
 2854;Le Fauga;le-fauga;8761104;87611046;1.2833330000;43.4000000000;;f;FR;f;Europe/Paris;t;FRFPA;;t;;f;8701103;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 2855;Carbonne;carbonne;8761106;87611061;1.2124764919281006;43.2983852872489;;f;FR;f;Europe/Paris;t;FRFPB;COA;t;;f;8700840;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2438,7 +2438,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 3149;Séméac—Marcadieu;semeac-marcadieu;8767124;;0.095869;43.222032;;f;FR;f;Europe/Paris;t;FRGDF;;t;;f;8701951;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3150;Ossun;ossun;8767131;87671313;-0.0333330000;43.1833330000;;f;FR;f;Europe/Paris;t;FRGDG;;t;;f;8701724;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3151;Soublecause;soublecause;8767134;87671347;0.000332;43.515701;;f;FR;f;Europe/Paris;t;FRGDH;;t;;f;8704513;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-3152;Villefranque (Hautes Pyrénées);villefranque-hautes-pyrenees;8767135;87671354;0.023075;43.47791;;f;FR;f;Europe/Paris;t;FRGDI;;t;;f;8704859;f;;f;;f;;f;;f;;f;;;;;;;;Milafranga;;;;;;;;;;
+3152;Villefranque (Hautes Pyrénées);villefranque-hautes-pyrenees;8767135;87671354;0.023075;43.47791;;f;FR;f;Europe/Paris;t;FRGDI;;t;;f;8704859;f;;f;;f;;f;;f;;f;;;;;;Milafranga;;;;;;;;;;;;
 3153;St-Pé-de-Bigorre;st-pe-de-bigorre;8767136;87671362;-0.1500000000;43.1166670000;;f;FR;f;Europe/Paris;t;FRGDJ;;t;;f;8702027;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3155;Lau-Balagnas;lau-balagnas;8767139;87671396;-0.0833330000;43.0000000000;;f;FR;f;Europe/Paris;t;FRGDL;;t;;f;8703670;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3156;La Barthe-de-Neste—Avezac-Prat-Lahitte;la-barthe-de-neste-avezac-prat-lahitte;8767140;87671404;0.379776;43.076227;;f;FR;f;Europe/Paris;t;FRGDM;;t;;f;8703616;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2465,7 +2465,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 3177;Maubourguet Centre;maubourguet-centre;8767165;87671651;0.034221;43.462502;;f;FR;f;Europe/Paris;t;FRGEI;;t;;f;8703942;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3178;Caussade (Hautes Pyrénées);caussade-hautes-pyrenees;8767166;87671669;0.0333330000;43.5166670000;;f;FR;f;Europe/Paris;t;FRGEJ;;t;;f;8702988;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3179;Hères;heres;8767167;87671677;0.0000000000;43.5500000000;;f;FR;f;Europe/Paris;t;FRGEK;;t;;f;8703465;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-3190;Genève Eaux-Vives;geneve-eaux-vives;8774592;87745927;6.166044473648071;46.2007119952184;5335;f;CH;f;Europe/Paris;t;FRGEV;;t;;f;8500007;t;;f;;f;;f;;f;;f;;;Geneva;Genf;Ginevra;Ženeva;;Ginebra;Genf;ジュネーヴ;제네바;;Genewa;Genebra;Женева;;Cenevre;日内瓦
+3190;Genève Eaux-Vives;geneve-eaux-vives;8774592;87745927;6.166044473648071;46.2007119952184;5335;f;CH;f;Europe/Paris;t;FRGEV;;t;;f;8500007;t;;f;;f;;f;;f;;f;;;Geneva;Genf;Ginevra;Ginebra;Ženeva;;Genf;ジュネーヴ;제네바;;Genewa;Genebra;Женева;;Cenevre;日内瓦
 3192;Gex Centre;gex-centre;8774527;87745273;6.058391332626343;46.33204691423479;4647;f;FR;t;Europe/Paris;t;FRGEX;;t;;f;8703392;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3193;Montaut—Bétharram;montaut-betharram;8767211;87672113;-0.198302;43.126989;;f;FR;f;Europe/Paris;t;FRGEZ;;t;;f;8701586;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3195;Coarraze—Nay;coarraze-nay;8767213;87672139;-0.241594;43.18185;;f;FR;f;Europe/Paris;t;FRGFB;CZN;t;;f;8700919;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2488,7 +2488,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 3233;Urdos;urdos;8767283;87672832;-0.554391;42.868819;;f;FR;f;Europe/Paris;t;FRGGQ;;t;;f;8704755;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3234;Forges-d’Abel;forges-dabel;8767284;87672840;-0.564288;42.821617;;f;FR;f;Europe/Paris;t;FRGGR;;t;;f;8701143;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3235;Canfranc;canfranc;8767290;;;;6631;f;ES;f;Europe/Paris;f;FRGGS;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-3236;Boucau;boucau;8767309;87673095;-1.4655590000;43.5277040000;;f;FR;f;Europe/Paris;t;FRGGT;;t;;f;8700678;f;;f;;f;;f;;f;;f;;;;;;;;Bokale;;;;;;;;;;
+3236;Boucau;boucau;8767309;87673095;-1.4655590000;43.5277040000;;f;FR;f;Europe/Paris;t;FRGGT;;t;;f;8700678;f;;f;;f;;f;;f;;f;;;;;;Bokale;;;;;;;;;;;;
 3240;Saubusse-les-Bains;saubusse-les-bains;8767325;87673251;-1.190171;43.660337;;f;FR;f;Europe/Paris;t;FRGGY;;t;;f;8701928;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3241;St-Geours;st-geours;8767326;87673269;-1.240933;43.671268;;f;FR;f;Europe/Paris;t;FRGGZ;;t;;f;8701967;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3242;St-Vincent-de-Tyrosse;st-vincent-de-tyrosse;8767327;87673277;-1.3064181804656982;43.65756444769408;;f;FR;f;Europe/Paris;t;FRGHA;;t;;f;8702163;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2496,13 +2496,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 3244;Labenne;labenne;8767329;87673293;-1.4289093017578125;43.58704336534418;;f;FR;f;Europe/Paris;t;FRGHC;;t;;f;8701361;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3245;Ondres;ondres;8767331;87673319;-1.4333330000;43.5666670000;;f;FR;f;Europe/Paris;t;FRGHD;;t;;f;8701716;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3247;Guéthary;guethary;8767345;87673459;-1.6098511219024658;43.42535304691872;;f;FR;f;Europe/Paris;t;FRGHG;GTH;t;;f;8701222;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-3249;Villefranque (Pyrénées Atlantiques);villefranque-pyrenees-atlantiques;8767361;87673616;-1.45645;43.431499;;f;FR;f;Europe/Paris;t;FRGHI;;t;;f;8704858;f;;f;;f;;f;;f;;f;;;;;;;;Milafranga;;;;;;;;;;
-3250;Ustaritz;ustaritz;8767362;87673624;-1.448971;43.404801;;f;FR;f;Europe/Paris;t;FRGHJ;;t;;f;8704758;f;;f;;f;;f;;f;;f;;;;;;;;Uztaritze;;;;;;;;;;于斯塔里特
-3251;Jatxou;jatxou;8767363;87673632;-1.4333330000;43.3833330000;;f;FR;f;Europe/Paris;t;FRGHK;;t;;f;8703497;f;;f;;f;;f;;f;;f;;;;;;;;Lapurdi;;;;;;;;;;
+3249;Villefranque (Pyrénées Atlantiques);villefranque-pyrenees-atlantiques;8767361;87673616;-1.45645;43.431499;;f;FR;f;Europe/Paris;t;FRGHI;;t;;f;8704858;f;;f;;f;;f;;f;;f;;;;;;Milafranga;;;;;;;;;;;;
+3250;Ustaritz;ustaritz;8767362;87673624;-1.448971;43.404801;;f;FR;f;Europe/Paris;t;FRGHJ;;t;;f;8704758;f;;f;;f;;f;;f;;f;;;;;;Uztaritze;;;;;;;;;;;;于斯塔里特
+3251;Jatxou;jatxou;8767363;87673632;-1.4333330000;43.3833330000;;f;FR;f;Europe/Paris;t;FRGHK;;t;;f;8703497;f;;f;;f;;f;;f;;f;;;;;;Lapurdi;;;;;;;;;;;;
 3252;Halsou-Larressore;halsou-larressore;8767364;87673640;-1.428017;43.378031;;f;FR;f;Europe/Paris;t;FRGHL;;t;;f;8703457;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-3253;Cambo-les-Bains;cambo-les-bains;8767365;87673657;-1.3966476917266846;43.36560931356253;;f;FR;f;Europe/Paris;t;FRGHM;;t;;f;8702957;f;;f;;f;;f;;f;;f;;;;;;;;Kanbo;;カンボ＝レ＝バン;;;;;Камбо-ле-Бен;;;康博莱班
-3254;Itxassou;itxassou;8767366;87673665;-1.4000000000;43.3166670000;;f;FR;f;Europe/Paris;t;FRGHN;;t;;f;8703488;f;;f;;f;;f;;f;;f;;;;;;;;Itsasu;;イチャスー;;;;;;;;伊特萨苏
-3255;Louhossoa;louhossoa;8767367;87673673;-1.3623905181884766;43.30581839344785;;f;FR;f;Europe/Paris;t;FRGHO;;t;;f;8703835;f;;f;;f;;f;;f;;f;;;;;;;;Luhuso;;;;;;;;;;卢奥索阿
+3253;Cambo-les-Bains;cambo-les-bains;8767365;87673657;-1.3966476917266846;43.36560931356253;;f;FR;f;Europe/Paris;t;FRGHM;;t;;f;8702957;f;;f;;f;;f;;f;;f;;;;;;Kanbo;;;;カンボ＝レ＝バン;;;;;Камбо-ле-Бен;;;康博莱班
+3254;Itxassou;itxassou;8767366;87673665;-1.4000000000;43.3166670000;;f;FR;f;Europe/Paris;t;FRGHN;;t;;f;8703488;f;;f;;f;;f;;f;;f;;;;;;Itsasu;;;;イチャスー;;;;;;;;伊特萨苏
+3255;Louhossoa;louhossoa;8767367;87673673;-1.3623905181884766;43.30581839344785;;f;FR;f;Europe/Paris;t;FRGHO;;t;;f;8703835;f;;f;;f;;f;;f;;f;;;;;;Luhuso;;;;;;;;;;;;卢奥索阿
 3256;Bidarray—Pont-Noblia;bidarray-pont-noblia;8767369;87673699;-1.345289;43.268309;;f;FR;f;Europe/Paris;t;FRGHP;;t;;f;8704274;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3258;St-Jean-Pied-de-Port;st-jean-pied-de-port;8767372;87673723;-1.238011121749878;43.167927992481665;;f;FR;f;Europe/Paris;t;FRGHR;;t;;f;8704593;f;;f;;f;;f;;f;;f;;;;;;;;;;サン＝ジャン＝ピエ＝ド＝ポル;;;;;Сен-Жан-Пье-де-Пор;;;圣让-皮耶德波尔
 3261;Montierchaume Bourg;montierchaume-bourg;8736087;87360875;1.7666670000;46.8666670000;2819;f;FR;t;Europe/Paris;t;FRGHY;;t;;f;8700462;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2733,7 +2733,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 3597;Les Hôpitaux-Neufs;les-hopitaux-neufs;8771551;87715516;6.373073;46.778488;;f;FR;f;Europe/Paris;t;FRGZH;;t;;f;8701278;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3598;Jougne;jougne;8771552;87715524;6.4000000000;46.7666670000;;f;FR;f;Europe/Paris;t;FRGZI;;t;;f;8701323;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3600;Vallorbe Frontière;vallorbe-frontiere;8771591;87715912;;;6367;f;CH;f;Europe/Paris;f;FRGZL;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-3601;Besançon Mouillère;besancon-mouillere;8771801;87718015;6.034036;47.240489;5029;f;FR;f;Europe/Paris;t;FRGZM;;t;;f;8702820;f;;f;;f;;f;;f;;f;;;;;;;;Besanzón;;ブザンソン;브장송;;;;Безансон;;;贝桑松
+3601;Besançon Mouillère;besancon-mouillere;8771801;87718015;6.034036;47.240489;5029;f;FR;f;Europe/Paris;t;FRGZM;;t;;f;8702820;f;;f;;f;;f;;f;;f;;;;;;Besanzón;;;;ブザンソン;브장송;;;;Безансон;;;贝桑松
 3602;Montferrand—Thoraise;montferrand-thoraise;8771810;87718106;5.907441;47.184693;;f;FR;f;Europe/Paris;t;FRGZN;;t;;f;8702544;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3603;Torpes—Boussières;torpes-boussieres;8771811;87718114;5.889121;47.16373;;f;FR;f;Europe/Paris;t;FRGZO;;t;;f;8702585;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3604;Byans;byans;8771812;87718122;5.8666670000;47.1166670000;;f;FR;f;Europe/Paris;t;FRGZP;;t;;f;8702485;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2779,7 +2779,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 3658;Quincieux;quincieux;8772129;87721290;4.7786664962768555;45.90673323808819;;f;FR;f;Europe/Paris;t;FRHCK;QUX;t;;f;8701826;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3659;Anse;anse;8772132;87721324;4.719754457473755;45.93929907870687;;f;FR;f;Europe/Paris;t;FRHCM;ANS;t;;f;8700614;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3660;St-Georges-de-Reneins;st-georges-de-reneins;8772134;87721340;4.7166670000;46.0666670000;;f;FR;f;Europe/Paris;t;FRHCN;SDI;t;;f;8701978;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-3661;Belleville-sur-Saône;belleville-sur-saone;8772135;87721357;4.729013442993164;46.11189093223572;;f;FR;f;Europe/Paris;t;FRHCO;BVL;t;;f;8702331;f;;f;;f;;f;;f;;f;;;;;;;;Belleville sobre Saona;;;;;;;;;;
+3661;Belleville-sur-Saône;belleville-sur-saone;8772135;87721357;4.729013442993164;46.11189093223572;;f;FR;f;Europe/Paris;t;FRHCO;BVL;t;;f;8702331;f;;f;;f;;f;;f;;f;;;;;;Belleville sobre Saona;;;;;;;;;;;;
 3663;Chazay—Marcilly;chazay-marcilly;8772141;87721415;4.725215;45.87296;;f;FR;f;Europe/Paris;t;FRHCQ;CZM;t;;f;8703081;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3664;St-Romain-de-Popey;st-romain-de-popey;8772145;87721456;4.5333330000;45.8500000000;;f;FR;f;Europe/Paris;t;FRHCR;SNP;t;;f;8704426;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3665;Pontcharra—St-Forgeux;pontcharra-st-forgeux;8772146;87721464;4.492772;45.871486;;f;FR;f;Europe/Paris;t;FRHCS;PNF;t;;f;8704278;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -2971,7 +2971,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 3884;Monceaux-le-Comte;monceaux-le-comte;8773497;87734970;3.6666670000;47.3333330000;;f;FR;f;Europe/Paris;t;FRHND;;t;;f;8704006;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3885;St-Loup Place de l’Église;st-loup-place-de-leglise;8773498;;3.3833330000;46.3500000000;;f;FR;f;Europe/Paris;t;FRHNE;;t;;f;8705673;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3887;Le Mans Viaduc;le-mans-viaduc;8746306;87463067;0.2000000000;48.0000000000;4661;f;FR;f;Europe/Paris;t;FRHNG;;t;;f;8706379;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-3889;La Place;la-place;8773986;87739862;2.333761;48.807857;;f;FR;f;Europe/Paris;t;FRHNI;;t;;f;8703593;f;;f;;f;;f;;f;;f;;;;;;;;Plaza;;;;;;;;;;
+3889;La Place;la-place;8773986;87739862;2.333761;48.807857;;f;FR;f;Europe/Paris;t;FRHNI;;t;;f;8703593;f;;f;;f;;f;;f;;f;;;;;;Plaza;;;;;;;;;;;;
 3890;Les Marguerons;les-marguerons;8773987;87739870;4.718177;46.739044;;f;FR;f;Europe/Paris;t;FRHNJ;;t;;f;8703772;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3891;Muse;muse;8773989;;7.297512888908385;47.74873112290638;;f;FR;f;Europe/Paris;t;FRHNK;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 3892;Pont-de-Cotte;pont-de-cotte;8773990;87739904;4.670723;46.463722;;f;FR;f;Europe/Paris;t;FRHNL;;t;;f;8704260;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3133,8 +3133,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4111;Malijai;malijai;8775145;87751453;6.0333330000;44.0500000000;;f;FR;f;Europe/Paris;t;FRHXR;;t;;f;8703893;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4112;Mallemoisson;mallemoisson;8775146;87751461;6.1333330000;44.0500000000;;f;FR;f;Europe/Paris;t;FRHXS;;t;;f;8703894;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4115;L’Ariane—La Trinité;lariane-la-trinite;8775152;87751529;7.302548;43.734228;;f;FR;f;Europe/Paris;t;FRHXV;;t;;f;8703528;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4116;Séon—St-Henry;seon-st-henry;8775163;87751636;5.339799;43.36239;4790;f;FR;f;Europe/Paris;t;FRHXW;;t;;f;8702037;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marseille;Marseille;Marsella;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
-4117;St-Louis-les-Aygalades;st-louis-les-aygalades;8775164;87751644;5.365175;43.345948;4790;f;FR;f;Europe/Paris;t;FRHXX;;t;;f;8701986;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marseille;Marseille;Marsella;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
+4116;Séon—St-Henry;seon-st-henry;8775163;87751636;5.339799;43.36239;4790;f;FR;f;Europe/Paris;t;FRHXW;;t;;f;8702037;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marsella;Marseille;Marseille;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
+4117;St-Louis-les-Aygalades;st-louis-les-aygalades;8775164;87751644;5.365175;43.345948;4790;f;FR;f;Europe/Paris;t;FRHXX;;t;;f;8701986;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marsella;Marseille;Marseille;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
 4120;St-Marcel;st-marcel;8775170;87751701;5.467086;43.288372;;f;FR;f;Europe/Paris;t;FRHYA;;t;;f;8704608;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4121;La Pomme;la-pomme;8775171;87751719;5.4415260000;43.2898660000;;f;FR;f;Europe/Paris;t;FRHYB;;t;;f;8703595;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4122;La Penne-sur-Huveaune;la-penne-sur-huveaune;8775174;87751743;5.5166670000;43.2833330000;;f;FR;f;Europe/Paris;t;FRHYC;;t;;f;8703592;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3349,7 +3349,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4468;Recoules;recoules;8778379;87783795;2.9666670000;44.3333330000;;f;FR;f;Europe/Paris;t;FRIOD;;t;;f;8704348;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4469;Salses;salses;8778415;87784157;2.9174870252609253;42.83551848686106;;f;FR;f;Europe/Paris;t;FRIOE;SAL;t;;f;8701991;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4470;Rivesaltes;rivesaltes;8778417;87784173;2.8677964210510254;42.76639100482349;;f;FR;f;Europe/Paris;t;FRIOF;RVT;t;;f;8700489;f;;f;;f;;f;;f;;f;;;;;;;;;;リヴサルト;;;;;;;;里韦萨尔泰
-4471;Elne;elne;8778420;87784207;2.963411808013916;42.597213117611076;;f;FR;f;Europe/Paris;t;FRIOG;ELN;t;;f;8701064;f;;f;;f;;f;;f;;f;;;Elna;Elna;Elna;;;Elna;;エルヌ;;;Elna;;;;;埃尔恩
+4471;Elne;elne;8778420;87784207;2.963411808013916;42.597213117611076;;f;FR;f;Europe/Paris;t;FRIOG;ELN;t;;f;8701064;f;;f;;f;;f;;f;;f;;;Elna;Elna;Elna;Elna;;;;エルヌ;;;Elna;;;;;埃尔恩
 4472;Port-Vendres;port-vendres;8778427;;3.1025648117065425;42.51356654935007;;f;FR;f;Europe/Paris;f;FRIOH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4473;Lalonquette;lalonquette;8746489;87464891;-0.3166670000;43.4833330000;5006;f;FR;f;Europe/Paris;t;FRIOI;;t;;f;8706400;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4474;Auriac;auriac;8746490;87464909;-0.323638;43.474036;5006;f;FR;f;Europe/Paris;t;FRIOK;;t;;f;8706401;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3466,7 +3466,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4621;Le Châtelard;le-chatelard;8501382;;6.1500000000;45.6833330000;;t;FR;f;Europe/Paris;f;FRLCT;;t;;f;8501382;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4622;Le Châtelard—Giétroz;le-chatelard-gietroz;8501566;;;;4621;f;CH;f;Europe/Zurich;f;CHABE;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4623;Le Côteau;le-coteau;8772682;87726828;4.086356163024902;46.02387633510588;;f;FR;f;Europe/Paris;t;FRLCU;LCU;t;;f;8703702;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4626;Lourdes;lourdes;8767133;87671339;-0.04214286804199219;43.10051285444798;;f;FR;f;Europe/Paris;t;FRLDE;LDS;t;;f;8700105;f;;f;;f;;f;;f;;f;;;;;;Lurdy;;;;ルルド;루르드;;;;Лурд;;;盧爾德
+4626;Lourdes;lourdes;8767133;87671339;-0.04214286804199219;43.10051285444798;;f;FR;f;Europe/Paris;t;FRLDE;LDS;t;;f;8700105;f;;f;;f;;f;;f;;f;;;;;;;Lurdy;;;ルルド;루르드;;;;Лурд;;;盧爾德
 4628;La Douzillère;la-douzillere;8700969;87009696;0.652976;47.338723;;f;FR;f;Europe/Paris;t;FRLDZ;;t;;f;8705012;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4629;Lesseux—Frapelle;lesseux-frapelle;8714432;87144329;7.076775;48.28998;;f;FR;f;Europe/Paris;t;FRLEF;;t;;f;8701380;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4630;Le Havre;le-havre;;;0.1076750000;49.4938040000;;t;FR;f;Europe/Paris;f;FRLEH;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3545,7 +3545,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4720;Meymac;meymac;;;2.1666670000;45.5333330000;;t;FR;f;Europe/Paris;f;FRMAY;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4721;Meymac;meymac;8759427;87594275;2.164099;45.530237;4720;f;FR;t;Europe/Paris;t;FRMYC;MYC;t;;f;8701641;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4722;Miramas;miramas;8775300;87753004;4.999444484710693;43.58090380891586;;f;FR;f;Europe/Paris;t;FRMAZ;MAS;t;;f;8700362;f;;f;;f;;f;;f;;f;;;;;;;;;;ミラマ;;;;;Мирамас;;;米拉马
-4723;Marseille Blancarde;marseille-blancarde;8775108;87751081;5.406861305236816;43.29630041886183;4790;f;FR;f;Europe/Paris;t;FRMBC;MBC;t;;f;8700464;f;;f;;f;;f;;f;;f;;;;;Marsiglia;;;Marsella;;マルセイユ;마르세유;;Marsylia;Marselha;Марсель;;Marsilya;马赛
+4723;Marseille Blancarde;marseille-blancarde;8775108;87751081;5.406861305236816;43.29630041886183;4790;f;FR;f;Europe/Paris;t;FRMBC;MBC;t;;f;8700464;f;;f;;f;;f;;f;;f;;;;;Marsiglia;Marsella;;;;マルセイユ;마르세유;;Marsylia;Marselha;Марсель;;Marsilya;马赛
 4725;Monbalen;monbalen;8713441;87134411;0.7166670000;44.3166670000;;f;FR;f;Europe/Paris;t;FRMBL;;t;;f;8706316;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4728;Mouchard;mouchard;8771883;87718833;5.79978883266449;46.97685588214904;;f;FR;f;Europe/Paris;t;FRMCD;MCD;t;;f;8700049;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4729;Montchanin;montchanin;8769430;87694307;4.481499195098877;46.75927531640082;;f;FR;f;Europe/Paris;t;FRMCH;MCH;t;;f;8700166;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3596,8 +3596,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4787;Paris-Gare-Montparnasse-3-Vaugirard;paris-gare-montparnasse-3-vaugirard;8739110;;2.315953;48.838384;4916;f;FR;f;Europe/Paris;f;FRMPV;;t;;f;8704045;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4788;Morée Salle des Fêtes;moree-salle-des-fetes;8745339;87453399;1.2333330000;47.9000000000;;f;FR;f;Europe/Paris;t;FRMRD;;t;;f;8706412;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4789;Margut;margut;;;5.2666670000;49.5833330000;;t;FR;f;Europe/Paris;f;FRMRG;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4790;Marseille;marseille;;;5.371000170707703;43.29640973957932;;t;FR;f;Europe/Paris;t;FRMRS;;t;;f;;f;;f;;f;;f;;f;;f;;;;;Marsiglia;;;Marsella;;マルセイユ;마르세유;;Marsylia;Marselha;Марсель;;Marsilya;马赛
-4791;Marseille St-Charles;marseille-st-charles;8775100;87751008;5.381949;43.303816;4790;f;FR;t;Europe/Paris;t;FRMSC;MSC;t;MSC;t;8700074;t;XRF;t;MSC;t;8775100;t;;f;;f;;;;;Marsiglia;;;Marsella;;マルセイユ;마르세유;;Marsylia;Marselha;Марсель;;Marsilya;马赛
+4790;Marseille;marseille;;;5.371000170707703;43.29640973957932;;t;FR;f;Europe/Paris;t;FRMRS;;t;;f;;f;;f;;f;;f;;f;;f;;;;;Marsiglia;Marsella;;;;マルセイユ;마르세유;;Marsylia;Marselha;Марсель;;Marsilya;马赛
+4791;Marseille St-Charles;marseille-st-charles;8775100;87751008;5.381949;43.303816;4790;f;FR;t;Europe/Paris;t;FRMSC;MSC;t;MSC;t;8700074;t;XRF;t;MSC;t;8775100;t;;f;;f;;;;;Marsiglia;Marsella;;;;マルセイユ;마르세유;;Marsylia;Marselha;Марсель;;Marsilya;马赛
 4793;Méreau;mereau;8730977;87309773;2.0500000000;47.1666670000;;f;FR;f;Europe/Paris;t;FRMRU;;t;;f;8705216;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4794;Merrey;merrey;8714240;87142406;5.6000000000;48.0500000000;;f;FR;f;Europe/Paris;t;FRMRY;;t;;f;8701596;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4795;Mouans-Sartoux;mouans-sartoux;8740132;87401323;6.974247694015503;43.62045799139486;;f;FR;f;Europe/Paris;t;FRMSE;MUU;t;;f;8705360;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3627,17 +3627,17 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4825;Méry-sur-Cher;mery-sur-cher;8731254;87312546;1.9833330000;47.2333330000;;f;FR;f;Europe/Paris;t;FRMYH;;t;;f;8700468;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4826;Méry-sur-Seine;mery-sur-seine;8713956;;3.8833330000;48.5000000000;;f;FR;f;Europe/Paris;t;FRMYS;;t;;f;8705061;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4827;Metz;metz;;;6.1726860000;49.1191080000;;t;FR;f;Europe/Paris;f;FRMZM;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4828;Metz Nord;metz-nord;8719207;87192070;6.167912;49.136871;4827;f;FR;f;Europe/Paris;t;FRMZN;;t;;f;8701651;f;;f;;f;;f;;f;;f;;;;;;Mety;;;;メス;메스;;;;Мец;;;梅斯
+4828;Metz Nord;metz-nord;8719207;87192070;6.167912;49.136871;4827;f;FR;f;Europe/Paris;t;FRMZN;;t;;f;8701651;f;;f;;f;;f;;f;;f;;;;;;;Mety;;;メス;메스;;;;Мец;;;梅斯
 4829;Castres;castres;8761546;87615468;2.230954170227051;43.59919628587348;10612;f;FR;f;Europe/Paris;t;FRMZQ;CTR;t;;f;8702984;f;;f;;f;;f;;f;;f;;;;;;;;;;カストル;;;;;Кастр;;;卡斯特爾
 4831;Finhaut Frontière;finhaut-frontiere;8774662;;;;6371;f;CH;f;Europe/Paris;f;FRNAA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4832;Château-du-Loir;chateau-du-loir;;;;;;t;FR;f;Europe/Paris;f;FRNAF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4833;St-Benoît-la-Forêt Hôpital;st-benoit-la-foret-hopital;8745337;87453373;0.3166670000;47.2166670000;;f;FR;f;Europe/Paris;t;FRNBM;;t;;f;8706317;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4834;Benet;benet;;;-0.6000000000;46.3666670000;;t;FR;f;Europe/Paris;f;FRNBT;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4836;Nice;nice;9921017;;7.2719407081603995;43.69664545590452;;t;FR;f;Europe/Paris;t;FRNCE;;t;;f;;f;;f;;f;;f;;f;;f;;;;Nizza;Nizza;;;Niza;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
-4837;Nice St-Augustin;nice-st-augustin;8775625;87756254;7.216351;43.670675;4836;f;FR;f;Europe/Paris;t;FRNSA;;t;;f;8701667;f;;f;;f;;f;;f;;f;;;;Nizza;Nizza;;;Niza;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
-4838;Nice Riquier;nice-riquier;8775635;87756353;7.290485;43.705832;4836;f;FR;f;Europe/Paris;t;FRNRI;;t;;f;8700481;f;;f;;f;;f;;f;;f;;;;Nizza;Nizza;;;Niza;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
-4839;Nice Ville;nice-ville;8775605;87756056;7.261764;43.704825;4836;f;FR;t;Europe/Paris;t;FRNIC;NIC;t;NIC;t;8700171;f;;f;;f;8775605;t;;f;;f;;;;Nizza;Nizza;;;Niza;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
-4840;Nice St-Roch;nice-st-roch;8775600;87756007;7.286673;43.715243;4836;f;FR;f;Europe/Paris;t;FRNSR;;t;;f;8704112;f;;f;;f;;f;;f;;f;;;;Nizza;Nizza;;;Niza;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
+4836;Nice;nice;9921017;;7.2719407081603995;43.69664545590452;;t;FR;f;Europe/Paris;t;FRNCE;;t;;f;;f;;f;;f;;f;;f;;f;;;;Nizza;Nizza;Niza;;;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
+4837;Nice St-Augustin;nice-st-augustin;8775625;87756254;7.216351;43.670675;4836;f;FR;f;Europe/Paris;t;FRNSA;;t;;f;8701667;f;;f;;f;;f;;f;;f;;;;Nizza;Nizza;Niza;;;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
+4838;Nice Riquier;nice-riquier;8775635;87756353;7.290485;43.705832;4836;f;FR;f;Europe/Paris;t;FRNRI;;t;;f;8700481;f;;f;;f;;f;;f;;f;;;;Nizza;Nizza;Niza;;;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
+4839;Nice Ville;nice-ville;8775605;87756056;7.261764;43.704825;4836;f;FR;t;Europe/Paris;t;FRNIC;NIC;t;NIC;t;8700171;f;;f;;f;8775605;t;;f;;f;;;;Nizza;Nizza;Niza;;;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
+4840;Nice St-Roch;nice-st-roch;8775600;87756007;7.286673;43.715243;4836;f;FR;f;Europe/Paris;t;FRNSR;;t;;f;8704112;f;;f;;f;;f;;f;;f;;;;Nizza;Nizza;Niza;;;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
 4842;Neufchâteau;neufchateau;8714129;87141291;5.690317153930664;48.35824518876885;;f;FR;f;Europe/Paris;t;FRNCH;NCH;t;;f;8700285;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4843;Annecy;annecy;8774600;87746008;6.121830940246581;45.90201488655895;;f;FR;f;Europe/Paris;t;FRNCY;ANY;t;NCY;f;8700135;f;;f;;f;;f;;f;;f;;;;;;;;;;アヌシー;안시;;;;Анси;;;阿讷西
 4845;Cenon;cenon;8742059;87420596;-0.5336630344390869;44.856313726970996;;f;FR;f;Europe/Paris;t;FRNEA;CBX;t;;f;8705754;f;;f;;f;;f;;f;;f;;;;;;;;;;スノン;;;;;Сенон;;;瑟农
@@ -3695,14 +3695,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4913;Oyonnax;oyonnax;8774353;87743534;5.6532275676727295;46.259548444849344;;f;FR;f;Europe/Paris;t;FROYO;OYO;t;;f;8704166;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4914;Port-d’Atelier-Amance;port-datelier-amance;8718510;87185108;6.0396;47.75922;;f;FR;f;Europe/Paris;t;FRPAA;;t;;f;8700054;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4915;Longchamp-sur-Aujon;longchamp-sur-aujon;8721557;87215574;4.8333330000;48.1500000000;;f;FR;f;Europe/Paris;t;FRPAJ;;t;;f;8705153;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4916;Paris;paris;9903001;;2.3488000000;48.8534100000;;t;FR;f;Europe/Paris;t;FRPAR;;t;PAR;t;8796001;t;;f;;f;;f;;f;;f;;;;;Parigi;Paříž;;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
-4917;Paris-Gare-de-Bercy;paris-gare-de-bercy;8768666;87686667;2.382887;48.839131;4916;f;FR;f;Europe/Paris;t;FRPBE;PBY;t;;f;8702455;t;XPB;t;;f;;f;;f;;f;;;;;Parigi;Paříž;;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
-4919;Paris-Gare-de-l’Est;paris-gare-de-lest;8711300;87113001;2.35912;48.876975;4916;f;FR;f;Europe/Paris;t;FRPST;PES;t;PST;f;8700011;t;;f;;f;;f;;f;;f;;;;;Parigi;Paříž;;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
-4920;Paris-Gare-Montparnasse;paris-gare-montparnasse;8739100;87391003;2.319576;48.840488;4916;f;FR;f;Europe/Paris;t;FRPMO;PMP;t;PMO;t;8700013;f;;f;;f;;f;;f;;f;;;;;Parigi;Paříž;;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
-4921;Paris-Austerlitz;paris-austerlitz;8754700;87547000;2.3665666580200195;48.84091003613604;4916;f;FR;f;Europe/Paris;t;FRPAZ;PAZ;t;;f;8700010;t;;f;;f;;f;;f;;f;;;;;Parigi;Paříž;;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
-4922;Paris-Gare-du-Nord;paris-gare-du-nord;8727100;87271007;2.354931;48.880885;4916;f;FR;f;Europe/Paris;t;FRPNO;PNO;t;;f;8700014;f;;f;;f;;f;;f;;f;;;;;Parigi;Paříž;;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
-4923;Paris-Gare-St-Lazare;paris-gare-st-lazare;8738400;87384008;2.325338;48.876328;4916;f;FR;f;Europe/Paris;t;FRPSL;PSL;t;;f;8700015;f;;f;;f;;f;;f;;f;;;;;Parigi;Paříž;;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
-4924;Paris-Gare-de-Lyon;paris-gare-de-lyon;8768600;87686006;2.374069;48.844839;4916;f;FR;f;Europe/Paris;t;FRPLY;PLY;t;PLY;t;8700012;f;;f;;f;8768600;t;;f;;f;;;;;Parigi;Paříž;;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
+4916;Paris;paris;9903001;;2.3488000000;48.8534100000;;t;FR;f;Europe/Paris;t;FRPAR;;t;PAR;t;8796001;t;;f;;f;;f;;f;;f;;;;;Parigi;;Paříž;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
+4917;Paris-Gare-de-Bercy;paris-gare-de-bercy;8768666;87686667;2.382887;48.839131;4916;f;FR;f;Europe/Paris;t;FRPBE;PBY;t;;f;8702455;t;XPB;t;;f;;f;;f;;f;;;;;Parigi;;Paříž;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
+4919;Paris-Gare-de-l’Est;paris-gare-de-lest;8711300;87113001;2.35912;48.876975;4916;f;FR;f;Europe/Paris;t;FRPST;PES;t;PST;f;8700011;t;;f;;f;;f;;f;;f;;;;;Parigi;;Paříž;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
+4920;Paris-Gare-Montparnasse;paris-gare-montparnasse;8739100;87391003;2.319576;48.840488;4916;f;FR;f;Europe/Paris;t;FRPMO;PMP;t;PMO;t;8700013;f;;f;;f;;f;;f;;f;;;;;Parigi;;Paříž;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
+4921;Paris-Austerlitz;paris-austerlitz;8754700;87547000;2.3665666580200195;48.84091003613604;4916;f;FR;f;Europe/Paris;t;FRPAZ;PAZ;t;;f;8700010;t;;f;;f;;f;;f;;f;;;;;Parigi;;Paříž;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
+4922;Paris-Gare-du-Nord;paris-gare-du-nord;8727100;87271007;2.354931;48.880885;4916;f;FR;f;Europe/Paris;t;FRPNO;PNO;t;;f;8700014;f;;f;;f;;f;;f;;f;;;;;Parigi;;Paříž;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
+4923;Paris-Gare-St-Lazare;paris-gare-st-lazare;8738400;87384008;2.325338;48.876328;4916;f;FR;f;Europe/Paris;t;FRPSL;PSL;t;;f;8700015;f;;f;;f;;f;;f;;f;;;;;Parigi;;Paříž;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
+4924;Paris-Gare-de-Lyon;paris-gare-de-lyon;8768600;87686006;2.374069;48.844839;4916;f;FR;f;Europe/Paris;t;FRPLY;PLY;t;PLY;t;8700012;f;;f;;f;8768600;t;;f;;f;;;;;Parigi;;Paříž;;Párizs;パリ;파리;Parijs;Paryż;;Париж;;;巴黎
 4926;Parthenay;parthenay;8748717;87487173;-0.24051904678344727;46.6482872235422;;f;FR;f;Europe/Paris;t;FRPAY;;t;;f;8704189;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4927;Largentière Garage des Rancs;largentiere-garage-des-rancs;8776482;87764829;4.292178;44.54448;;f;FR;f;Europe/Paris;t;FRPBI;;t;;f;8703656;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4929;Pouzauges Centre;pouzauges-centre;8733300;87333005;-0.8373051881790161;46.78237125977221;5018;f;FR;f;Europe/Paris;t;FRPBM;;t;;f;8704308;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3719,14 +3719,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 4943;Pontivy Douric;pontivy-douric;8741422;87414227;-2.9833330000;48.0666670000;9399;f;FR;f;Europe/Paris;t;FRPDI;;t;;f;8705625;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4945;Pont-de-Dore;pont-de-dore;8773445;87734459;3.5000000000;45.8333330000;;f;FR;f;Europe/Paris;t;FRPDO;PDO;t;;f;8704262;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4946;Persan—Beaumont;persan-beaumont;8727646;;2.278307;49.147919;;f;FR;f;Europe/Paris;t;FRPEB;;t;;f;8701755;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4947;Picon-Busserine;picon-busserine;8775929;87759290;5.393195;43.331224;4790;f;FR;f;Europe/Paris;t;FRPEI;XPC;t;;f;8706227;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marseille;Marseille;Marsella;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
-4948;Marseille St-Antoine;marseille-st-antoine;8775182;87751826;5.357409;43.36968;4790;f;FR;f;Europe/Paris;t;FRPEJ;SNT;t;;f;8706228;f;;f;;f;;f;;f;;f;;;;;Marsiglia;;;Marsella;;マルセイユ;마르세유;;Marsylia;Marselha;Марсель;;Marsilya;马赛
-4949;St-Joseph-le-Castellas;st-joseph-le-castellas;8775931;87759316;5.377248;43.351998;4790;f;FR;f;Europe/Paris;t;FRPEK;XJC;t;;f;8706229;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marseille;Marseille;Marsella;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
+4947;Picon-Busserine;picon-busserine;8775929;87759290;5.393195;43.331224;4790;f;FR;f;Europe/Paris;t;FRPEI;XPC;t;;f;8706227;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marsella;Marseille;Marseille;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
+4948;Marseille St-Antoine;marseille-st-antoine;8775182;87751826;5.357409;43.36968;4790;f;FR;f;Europe/Paris;t;FRPEJ;SNT;t;;f;8706228;f;;f;;f;;f;;f;;f;;;;;Marsiglia;Marsella;;;;マルセイユ;마르세유;;Marsylia;Marselha;Марсель;;Marsilya;马赛
+4949;St-Joseph-le-Castellas;st-joseph-le-castellas;8775931;87759316;5.377248;43.351998;4790;f;FR;f;Europe/Paris;t;FRPEK;XJC;t;;f;8706229;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marsella;Marseille;Marseille;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
 4951;Pierrefitte-Nestalas;pierrefitte-nestalas;8767175;87671750;-0.0666670000;42.9666670000;;f;FR;f;Europe/Paris;t;FRPFN;;t;;f;8704218;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4952;Le Puy-en-Velay Lafayette;le-puy-en-velay-lafayette;8702438;87024380;3.880283;45.04339;5009;f;FR;f;Europe/Paris;t;FRPFY;;t;;f;8705030;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4953;Dives;dives;;;;;;t;FR;f;Europe/Paris;f;FRPGE;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4954;Dives-sur-Mer—Port-Guillaume;dives-sur-mer-port-guillaume;8733737;87337378;-0.10087251663208008;49.291090802259674;4953;f;FR;f;Europe/Paris;t;FRPGU;;t;;f;8705264;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-4955;Perpignan;perpignan;8778400;87784009;2.87940502166748;42.69607053922139;;f;FR;f;Europe/Paris;t;FRPGF;PPN;t;PGF;t;8700164;f;;f;;f;;f;;f;;f;;;;;Perpignano;;;Perpiñán;;ペルピニャン;페르피냥;;;Perpinhã;Перпиньян;;;佩皮尼昂
+4955;Perpignan;perpignan;8778400;87784009;2.87940502166748;42.69607053922139;;f;FR;f;Europe/Paris;t;FRPGF;PPN;t;PGF;t;8700164;f;;f;;f;;f;;f;;f;;;;;Perpignano;Perpiñán;;;;ペルピニャン;페르피냥;;;Perpinhã;Перпиньян;;;佩皮尼昂
 4956;Poitiers Gare Routière;poitiers-gare-routiere;8720248;87202481;0.3333330000;46.5833330000;4964;f;FR;f;Europe/Paris;f;FRPGR;;t;;f;8705079;f;XOP;t;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4957;Périgueux;perigueux;;;0.7166670000;45.1833330000;;t;FR;f;Europe/Paris;f;FRPGX;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 4958;Perrigny-sur-Loire;perrigny-sur-loire;8728233;87282335;3.8333330000;46.5333330000;;f;FR;f;Europe/Paris;t;FRPGY;;t;;f;8705220;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3782,7 +3782,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5026;Miramont-d’Astarac;miramont-dastarac;8761716;87617167;0.421288;43.532403;;f;FR;f;Europe/Paris;t;FRQBE;;t;;f;8706175;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5027;Joyeuse;joyeuse;8755580;87555805;4.2333330000;44.4833330000;;f;FR;f;Europe/Paris;t;FRQBG;;t;;f;8703513;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5028;Bourg-St-Maurice;bourg-st-maurice;8774179;87741793;6.771526336669922;45.618765169916266;;f;FR;f;Europe/Paris;t;FRQBM;BSM;t;QBM;t;8700130;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бур-Сен-Морис;;;
-5029;Besançon;besancon;;;6.02432;47.23792;;t;FR;f;Europe/Paris;t;FRQBQ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;Besanzón;;ブザンソン;브장송;;;;Безансон;;;贝桑松
+5029;Besançon;besancon;;;6.02432;47.23792;;t;FR;f;Europe/Paris;t;FRQBQ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;Besanzón;;;;ブザンソン;브장송;;;;Безансон;;;贝桑松
 5030;La Courtine;la-courtine;8744525;87445254;2.2666670000;45.7000000000;;f;FR;f;Europe/Paris;t;FRQCD;;t;;f;8704913;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5031;Moutier-Rozeille;moutier-rozeille;8744504;87445049;2.19157;45.916477;;f;FR;f;Europe/Paris;t;FRQCE;;t;;f;8704069;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5032;Langres;langres;;;5.3333330000;47.8666670000;;t;FR;f;Europe/Paris;f;FRQGS;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3890,7 +3890,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5167;St-Dizier;st-dizier;;;4.8166670000;48.6500000000;;t;FR;f;Europe/Paris;f;FRSDZ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5168;St-Hilaire-le-Château;st-hilaire-le-chateau;8731595;87315952;1.9000000000;45.9833330000;;f;FR;f;Europe/Paris;t;FRSED;;t;;f;8704832;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5169;Seilhac;seilhac;8759406;87594069;1.7166670000;45.3666670000;;f;FR;f;Europe/Paris;t;FRSEI;;t;;f;8704472;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5170;Reims Franchet d’Esperey;reims-franchet-desperey;8741744;87417444;4.0138;49.242512;89;f;FR;f;Europe/Paris;t;FRSEP;;t;;f;8706275;f;;f;;f;;f;;f;;f;;;;;;Remeš;;;;ランス;兰斯;;;;Реймс;;;兰斯
+5170;Reims Franchet d’Esperey;reims-franchet-desperey;8741744;87417444;4.0138;49.242512;89;f;FR;f;Europe/Paris;t;FRSEP;;t;;f;8706275;f;;f;;f;;f;;f;;f;;;;;;;Remeš;;;ランス;兰斯;;;;Реймс;;;兰斯
 5171;Serqueux;serqueux;8741147;87411470;1.5395450592041016;49.631485170953525;;f;FR;f;Europe/Paris;t;FRSEQ;;t;;f;8700235;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5172;Serres Place de la Liberté;serres-place-de-la-liberte;8755619;;5.7166670000;44.4333330000;5239;f;FR;f;Europe/Paris;t;FRSER;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5173;St-Étienne-de-Boulogne;st-etienne-de-boulogne;8742048;87420489;4.4666670000;44.7000000000;;f;FR;f;Europe/Paris;t;FRSET;;t;;f;8705651;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3961,7 +3961,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5261;Cussy-les-Forges;cussy-les-forges;8720467;87204677;4.0333330000;47.4666670000;;f;FR;f;Europe/Paris;t;FRSYF;;t;;f;8705200;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5263;Saincaize;saincaize;8769626;87696260;3.0840680000;46.9076500000;;f;FR;f;Europe/Paris;t;FRSZE;SZE;t;;f;8700035;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5266;Gan;gan;8767261;87672618;-0.3833330000;43.2333330000;;f;FR;f;Europe/Paris;t;FRTAN;;t;;f;8704942;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5267;St-Cyprien Arènes;st-cyprien-arenes;8744617;87446179;1.4178425073623657;43.59399429710338;5306;f;FR;f;Europe/Paris;t;FRTAR;TEW;t;;f;;f;;f;;f;;f;;f;;f;;Toulouse;Toulouse;Toulouse;Tolosa;Toulouse;;Tolosa;Toulouse;トゥールーズ;툴루즈;Toulouse;Tuluza;Toulouse;Тулуза;;Toulouse;圖盧茲
+5267;St-Cyprien Arènes;st-cyprien-arenes;8744617;87446179;1.4178425073623657;43.59399429710338;5306;f;FR;f;Europe/Paris;t;FRTAR;TEW;t;;f;;f;;f;;f;;f;;f;;f;;Toulouse;Toulouse;Toulouse;Tolosa;Tolosa;Toulouse;;Toulouse;トゥールーズ;툴루즈;Toulouse;Tuluza;Toulouse;Тулуза;;Toulouse;圖盧茲
 5268;Tassin;tassin;8772151;87721514;4.758628;45.761647;;f;FR;f;Europe/Paris;t;FRTAS;TAS;t;;f;8704695;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5270;Montaulin Vallée Verte;montaulin-vallee-verte;8731976;87319764;4.2000000000;48.2500000000;;f;FR;f;Europe/Paris;t;FRTAU;;t;;f;8702588;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5272;Troyes Boulevard du 14 Juillet;troyes-boulevard-du-14-juillet;8721603;87216036;4.106146;48.264315;5342;f;FR;f;Europe/Paris;t;FRTBD;;t;;f;8705150;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -3989,7 +3989,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5298;Haute-Picardie TGV;haute-picardie-tgv;8731388;87313882;2.832198143005371;49.859082553758014;;f;FR;f;Europe/Paris;t;FRTHP;HPI;t;;f;8704957;f;;f;THP;t;;f;;f;;f;;à 40 km d’Amiens et Saint-Quentin;40km from Amiens and Saint-Quentin;40km von Amiens und Saint-Quentin entfernt;40km da Amiens e Saint-Quentin;;;;;;;;;;;;;
 5299;Thouars;thouars;8748700;87487009;-0.209799;46.985204;;f;FR;f;Europe/Paris;t;FRTHR;;t;;f;8704717;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Туар;;;圖阿爾
 5300;Thoiry;thoiry;;;;;;t;FR;f;Europe/Paris;f;FRTHV;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5304;Toulon;toulon;8775500;87755009;5.929599;43.128409;;f;FR;f;Europe/Paris;t;FRTLN;TLN;t;TLN;t;8700108;f;;f;;f;8775500;t;;f;;f;;;;;Tolone;;;Tolón;;トゥーロン;툴롱;;Tulon;;Тулон;;;土伦
+5304;Toulon;toulon;8775500;87755009;5.929599;43.128409;;f;FR;f;Europe/Paris;t;FRTLN;TLN;t;TLN;t;8700108;f;;f;;f;8775500;t;;f;;f;;;;;Tolone;Tolón;;;;トゥーロン;툴롱;;Tulon;;Тулон;;;土伦
 5306;Toulouse;toulouse;9900006;;1.444004774093628;43.60446386099808;;t;FR;f;Europe/Paris;t;FRTLS;;t;;f;;f;;f;;f;;f;;f;;f;;;;;Tolosa;;;;;トゥールーズ;툴루즈;;Tuluza;;Тулуза;;;圖盧茲
 5307;Toulouse St-Michel;toulouse-st-michel;8744372;87443721;1.447121500968933;43.586095272195166;5306;f;FR;f;Europe/Paris;t;FRUIC;;t;;f;8705995;f;;f;;f;;f;;f;;f;;;;;Tolosa;;;;;トゥールーズ;툴루즈;;Tuluza;;Тулуза;;;圖盧茲
 5308;Toulouse Langlade;toulouse-langlade;8744946;87449462;1.44302;43.572045;5306;f;FR;f;Europe/Paris;t;FRULK;;t;;f;8706103;f;;f;;f;;f;;f;;f;;;;;Tolosa;;;;;トゥールーズ;툴루즈;;Tuluza;;Тулуза;;;圖盧茲
@@ -4016,7 +4016,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5333;Toutry;toutry;8713999;87139998;4.115225;47.503253;;f;FR;f;Europe/Paris;t;FRTRY;;t;;f;8705104;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5334;Troyes Delestraint Belgique;troyes-delestraint-belgique;8713965;87139659;4.07392680644989;48.2883687684885;5342;f;FR;f;Europe/Paris;t;FRTSA;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5335;Genève;geneve;8585444;;;;;t;CH;f;Europe/Paris;f;FRTTX;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5336;Genève Cornavin;geneve-cornavin;8501008;85010082;6.142428;46.210208;5335;f;CH;t;Europe/Zurich;t;CHGVA;;t;;f;8501008;t;XGC;t;;f;8501008;t;;f;;f;;;Geneva Main station;Genf Hauptbahnhof;Ginevra Stazione centrale;Ženeva;;Ginebra;Genf;ジュネーヴ;제네바;;Genewa;Genebra;Женева;;Cenevre;日内瓦
+5336;Genève Cornavin;geneve-cornavin;8501008;85010082;6.142428;46.210208;5335;f;CH;t;Europe/Zurich;t;CHGVA;;t;;f;8501008;t;XGC;t;;f;8501008;t;;f;;f;;;Geneva Main station;Genf Hauptbahnhof;Ginevra Stazione centrale;Ginebra;Ženeva;;Genf;ジュネーヴ;제네바;;Genewa;Genebra;Женева;;Cenevre;日内瓦
 5337;Genève;geneve;8585440;;;;5335;f;CH;f;Europe/Zurich;f;CHAFH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5338;Tours;tours;;;;;;t;FR;f;Europe/Paris;f;FRTUF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5339;La Tuque;la-tuque;8713435;87134353;0.656392;44.139966;;f;FR;f;Europe/Paris;t;FRTUQ;;t;;f;8705049;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4260,8 +4260,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5596;La Toulzanie;la-toulzanie;8716805;87168054;1.75357;44.471452;;f;FR;f;Europe/Paris;t;FRUPP;;t;;f;8706277;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5597;Seuzac;seuzac;8716711;87167114;1.807919;44.474841;;f;FR;f;Europe/Paris;t;FRUPQ;;t;;f;8706278;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5598;Urt;urt;;;;;;t;FR;f;Europe/Paris;f;FRURC;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5599;Urt;urt;8767238;87672386;-1.300586;43.499385;5598;f;FR;t;Europe/Paris;t;FRURT;;t;;f;8702144;f;;f;;f;;f;;f;;f;;;;;;;;Ahurti;;;;;;;;;;于尔
-5601;Rouen Rive Droite;rouen-rive-droite;8741101;87411017;1.094113;49.44904;5603;f;FR;t;Europe/Paris;t;FRURD;RRD;t;;f;8700113;f;XRO;f;;f;;f;;f;;f;;;;;;;;Ruan;;ルーアン;루앙;;;Ruão;Руан;;;鲁昂
+5599;Urt;urt;8767238;87672386;-1.300586;43.499385;5598;f;FR;t;Europe/Paris;t;FRURT;;t;;f;8702144;f;;f;;f;;f;;f;;f;;;;;;Ahurti;;;;;;;;;;;;于尔
+5601;Rouen Rive Droite;rouen-rive-droite;8741101;87411017;1.094113;49.44904;5603;f;FR;t;Europe/Paris;t;FRURD;RRD;t;;f;8700113;f;XRO;f;;f;;f;;f;;f;;;;;;Ruan;;;;ルーアン;루앙;;;Ruão;Руан;;;鲁昂
 5602;Rouen Gare Routière;rouen-gare-routiere;8740189;87401893;1.0993190000;49.4431290000;5601;f;FR;f;Europe/Paris;f;FRURG;;f;;f;8705355;f;XRN;t;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5603;Rouen;rouen;9919002;;1.0993190000;49.4431290000;;t;FR;f;Europe/Paris;f;FRURL;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5604;Aubusson;aubusson;;;2.1666670000;45.9500000000;;t;FR;f;Europe/Paris;f;FRUSO;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4366,7 +4366,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5744;Agde;agde;8778127;87781278;3.4661972522735596;43.31732542255665;;f;FR;f;Europe/Paris;t;FRXAG;AGD;t;;f;8700145;f;;f;;f;;f;;f;;f;;;;;;;;;;アグド;;;;;Агд;;;阿格德
 5745;Aix-les-Bains—Le Revard;aix-les-bains-le-revard;8774113;87741132;5.909056663513184;45.68809730934939;;f;FR;f;Europe/Paris;t;FRXAI;AIX;t;XAI;f;8700048;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5746;Amboise;amboise;8757434;87574343;0.9812164306640625;47.42146734975387;;f;FR;f;Europe/Paris;t;FRXAM;AMQ;t;;f;8700607;f;;f;;f;;f;;f;;f;;;;;;;;;;アンボワーズ;;;;;Амбуаз;;;昂布瓦斯
-5747;Alençon;alencon;8744471;87444711;0.0984;48.4339;;f;FR;f;Europe/Paris;t;FRXAN;ALN;t;;f;8700141;f;;f;;f;;f;;f;;f;;;;;;;;Alenzón;;アランソン;;;;;Алансон;;;阿朗松
+5747;Alençon;alencon;8744471;87444711;0.0984;48.4339;;f;FR;f;Europe/Paris;t;FRXAN;ALN;t;;f;8700141;f;;f;;f;;f;;f;;f;;;;;;Alenzón;;;;アランソン;;;;;Алансон;;;阿朗松
 5748;Alès;ales;8777528;87775288;4.085025787353515;44.12793673360334;;f;FR;f;Europe/Paris;t;FRXAS;ALS;t;;f;8700126;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5749;Antibes;antibes;8775767;87757674;7.119462490081787;43.58569116237965;;f;FR;f;Europe/Paris;t;FRXAT;ATB;t;;f;8700146;f;;f;;f;8775767;t;;f;;f;;;;;;;;;;アンティーブ;앙티브;;;;Антиб;;;昂蒂布
 5750;Albertville;albertville;8774164;87741645;6.383163928985596;45.67309824794535;;f;FR;f;Europe/Paris;t;FRXAV;ALV;t;XAV;t;8700128;f;;f;;f;;f;;f;;f;;;;;;;;;;アルベールヴィル;알베르빌;;;;Альбервиль;;;阿尔贝维尔
@@ -4381,7 +4381,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5759;Banyuls-sur-Mer;banyuls-sur-mer;8778429;87784298;3.124839;42.482948;;f;FR;f;Europe/Paris;t;FRXBU;BAN;t;;f;8700485;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5760;Beaune;beaune;8771354;87713545;4.848489761352539;47.023041133284266;;f;FR;f;Europe/Paris;t;FRXBV;BEA;t;;f;8700550;f;;f;;f;;f;;f;;f;;;;;;;;;;ボーヌ;;;;;Бон;;;博恩拉罗朗德
 5761;Bernay;bernay;8744429;87444299;0.5957293510437012;49.08697196091214;;f;FR;f;Europe/Paris;t;FRXBX;BEY;t;;f;8700221;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5762;Bayonne;bayonne;8767300;87673004;-1.4703547954559326;43.49709463180589;;f;FR;f;Europe/Paris;t;FRXBY;BYE;t;XBY;t;8700257;f;;f;;f;;f;;f;;f;;;;;;;;Baiona;;バイヨンヌ;바욘;;Bajonna;Baiona;Байонна;;;巴约讷
+5762;Bayonne;bayonne;8767300;87673004;-1.4703547954559326;43.49709463180589;;f;FR;f;Europe/Paris;t;FRXBY;BYE;t;XBY;t;8700257;f;;f;;f;;f;;f;;f;;;;;;Baiona;;;;バイヨンヌ;바욘;;Bajonna;Baiona;Байонна;;;巴约讷
 5763;Bandol;bandol;8775522;87755223;5.750162601470947;43.14046747767621;;f;FR;f;Europe/Paris;t;FRXBZ;;t;;f;8700665;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бандоль;;;邦多
 5764;Le Creusot TGV;le-creusot-tgv;8769410;87694109;4.500071;46.765364;;f;FR;f;Europe/Paris;t;FRXCC;LCM;t;;f;8700167;f;;f;;f;;f;;f;;f;;;;;;;;;;ル＝クルーゾ;;;;;Ле-Крёзо;;;
 5765;Chalon-sur-Saône;chalon-sur-saone;8772500;87725002;4.84371542930603;46.781034125625254;;f;FR;f;Europe/Paris;t;FRXCD;CSS;t;;f;8700091;t;;f;;f;;f;;f;;f;;;;;;;;;;シャロン＝シュル＝ソーヌ;;;;;Шалон-сюр-Сон;;;索恩河畔沙隆
@@ -4390,7 +4390,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5768;Cagnes-sur-Mer;cagnes-sur-mer;;;7.1500000000;43.6666670000;;t;FR;f;Europe/Paris;f;FRXCG;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5769;Compiègne;compiegne;8727669;87276691;2.823502421379089;49.42230471648786;;f;FR;f;Europe/Paris;t;FRXCP;CPE;t;;f;8700246;f;;f;;f;;f;;f;;f;;;;;;;;;;コンピエーニュ;콩피에뉴;;;;Компьень;;;贡比涅
 5770;La Ciotat;la-ciotat;8775178;87751784;5.632821321487426;43.19962313634956;;f;FR;f;Europe/Paris;t;FRXCT;;t;;f;8700885;f;;f;;f;;f;;f;;f;;;;;;;;;;ラ・シオタ;;;;;Ла-Сьота;;;拉西奥塔
-5771;Collioure;collioure;8778425;87784256;3.078077;42.526905;;f;FR;f;Europe/Paris;t;FRXCU;COX;t;;f;8700486;f;;f;;f;;f;;f;;f;;;;;;;;Colliure;;コリウール;;;;;Коллиур;;;科利乌尔
+5771;Collioure;collioure;8778425;87784256;3.078077;42.526905;;f;FR;f;Europe/Paris;t;FRXCU;COX;t;;f;8700486;f;;f;;f;;f;;f;;f;;;;;;Colliure;;;;コリウール;;;;;Коллиур;;;科利乌尔
 5772;Chantilly—Gouvieux;chantilly-gouvieux;8727611;87276113;2.459565;49.187624;;f;FR;f;Europe/Paris;t;FRXCV;CLY;t;;f;8700820;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5773;Châtellerault;chatellerault;8757514;87575142;0.5497026443481445;46.818611837291904;;f;FR;f;Europe/Paris;t;FRXCX;CRT;t;;f;8700553;f;;f;;f;;f;;f;;f;;;;;;;;;;シャテルロー;;;;;Шательро;;;沙泰勒罗
 5774;Château-Thierry;chateau-thierry;8711658;87116582;3.4095382690429683;49.037924212467836;;f;FR;f;Europe/Paris;t;FRXCY;CTH;t;;f;8700261;f;;f;;f;;f;;f;;f;;;;;;;;;;シャトー＝ティエリ;;;;;Шато-Тьерри;;;蒂耶里堡
@@ -4423,7 +4423,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5803;Moulins-sur-Allier;moulins-sur-allier;8769632;87696328;3.339267;46.561255;;f;FR;f;Europe/Paris;t;FRXMU;MSA;t;;f;8700041;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5804;Montauban Ville Bourbon;montauban-ville-bourbon;8761124;87611244;1.341281533241272;44.014287656042015;;f;FR;f;Europe/Paris;t;FRXMW;MBN;t;;f;8700057;f;;f;;f;;f;;f;;f;;;;;;;;;;モントーバン;;;;;Монтобан;;;蒙托邦
 5805;Mazamet;mazamet;8761554;87615542;2.374849319458008;43.49782621031005;9221;f;FR;t;Europe/Paris;t;FRXMZ;;t;;f;8703960;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5806;Narbonne;narbonne;8778110;87781104;3.0056780576705933;43.19059308540353;;f;FR;f;Europe/Paris;t;FRXNA;NBN;t;;f;8700073;f;;f;;f;;f;;f;;f;;;;;Narbona;;;Narbona;;ナルボンヌ;나르본;;Narbona;Narbona;Нарбонна;;;纳博讷
+5806;Narbonne;narbonne;8778110;87781104;3.0056780576705933;43.19059308540353;;f;FR;f;Europe/Paris;t;FRXNA;NBN;t;;f;8700073;f;;f;;f;;f;;f;;f;;;;;Narbona;Narbona;;;;ナルボンヌ;나르본;;Narbona;Narbona;Нарбонна;;;纳博讷
 5807;Le Blanc;le-blanc;8720160;87201608;1.0635709762573242;46.630784969862106;;f;FR;f;Europe/Paris;t;FRXNC;;t;;f;8705084;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5808;Orange;orange;8776510;87765107;4.819436073303223;44.1375314225196;;f;FR;f;Europe/Paris;t;FRXOG;OGE;t;;f;8700433;f;;f;;f;;f;;f;;f;;;;;;;;;;オランジュ;;;;;Оранж;;;
 5809;Aulnoye-Aymeries;aulnoye-aymeries;8729560;87295600;3.843551874160766;50.19718374384137;;f;FR;f;Europe/Paris;t;FRXOY;AYE;t;;f;8700017;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4463,7 +4463,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5844;Tulle;tulle;8759449;87594499;1.756384;45.258565;9098;f;FR;t;Europe/Paris;t;FRXTU;TUL;t;;f;8700204;f;;f;;f;;f;;f;;f;;;;;;;;;;チュール;튈;;;;Тюль;Tyll;;蒂勒
 5845;Auray;auray;8747620;87476200;-2.999417781829834;47.68021184001663;;f;FR;f;Europe/Paris;t;FRXUY;ARY;t;XUY;t;8700206;f;;f;;f;;f;;f;;f;;;;;;;;;;オーレー;오레;;;;Оре;;;
 5846;Vendôme;vendome;;;;;;t;FR;f;Europe/Paris;f;FRXVD;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5847;Villefranche-sur-Saône;villefranche-sur-saone;8772133;87721332;4.721143;45.98448;;f;FR;f;Europe/Paris;t;FRXVF;VIS;t;;f;8702170;f;;f;;f;;f;;f;;f;;;;;;;;Villefranche sobre Saona;;ヴィルフランシュ＝シュル＝ソーヌ;;;;;Вильфранш-сюр-Сон;;;
+5847;Villefranche-sur-Saône;villefranche-sur-saone;8772133;87721332;4.721143;45.98448;;f;FR;f;Europe/Paris;t;FRXVF;VIS;t;;f;8702170;f;;f;;f;;f;;f;;f;;;;;;Villefranche sobre Saona;;;;ヴィルフランシュ＝シュル＝ソーヌ;;;;;Вильфранш-сюр-Сон;;;
 5848;Vienne;vienne;8772258;87722587;4.8744;45.521023;;f;FR;f;Europe/Paris;t;FRXVI;VIE;t;;f;8700095;f;;f;;f;;f;;f;;f;;France;France;Frankreich;Francia;;;;;;;;;;Вьенн;;;
 5849;Buxières-Les-Villiers;buxieres-les-villiers;8721522;87215228;5.0333330000;48.1000000000;;f;FR;f;Europe/Paris;t;FRXVL;;t;;f;8705159;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5850;Verdun;verdun;8717577;87175778;5.379163;49.165475;;f;FR;f;Europe/Paris;t;FRXVN;;t;;f;8700523;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4484,16 +4484,16 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5874;La Bresse Place Champtel;la-bresse-place-champtel;8740581;87405811;6.8833330000;48.0000000000;;f;FR;f;Europe/Paris;t;FRZBF;;t;;f;8705394;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5875;Remiremont Cora;remiremont-cora;8740591;87405910;6.612616181373596;48.00471475041776;;f;FR;f;Europe/Paris;t;FRZBQ;;t;;f;8705403;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5876;Lexy Providence Usine;lexy-providence-usine;8740668;87406686;5.7333330000;49.5000000000;8749;f;FR;f;Europe/Paris;t;FRZCB;;t;;f;8705410;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5877;Basel;basel;;;7.583;47.567;;t;CH;f;Europe/Paris;t;FRZDH;;t;;f;;f;;f;;f;;f;;f;;f;;Bâle;;;Basilea;Basilej;;Basilea;Bázel;バーゼル;바젤;Bazel;Bazylea;Basileia;Базель;;;巴塞尔
-5878;Basel SBB;basel-sbb;8500010;85000109;7.5891699960;47.5470755094;5877;f;CH;t;Europe/Zurich;t;CHAJP;;t;;f;8500010;t;;f;;f;8500010;t;;f;;f;;Bâle;;;Basilea;Basilej;;Basilea;Bázel;バーゼル;바젤;Bazel;Bazylea;Basileia;Базель;;;巴塞尔
+5877;Basel;basel;;;7.583;47.567;;t;CH;f;Europe/Paris;t;FRZDH;;t;;f;;f;;f;;f;;f;;f;;f;;Bâle;;;Basilea;Basilea;Basilej;;Bázel;バーゼル;바젤;Bazel;Bazylea;Basileia;Базель;;;巴塞尔
+5878;Basel SBB;basel-sbb;8500010;85000109;7.5891699960;47.5470755094;5877;f;CH;t;Europe/Zurich;t;CHAJP;;t;;f;8500010;t;;f;;f;8500010;t;;f;;f;;Bâle;;;Basilea;Basilea;Basilej;;Bázel;バーゼル;바젤;Bazel;Bazylea;Basileia;Базель;;;巴塞尔
 5880;Hommarting Tilleuls;hommarting-tilleuls;8746360;87463604;7.1500000000;48.7333330000;;f;FR;f;Europe/Paris;t;FRZGX;;t;;f;8706463;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5881;Arzviller Fontaines;arzviller-fontaines;8746362;87463620;7.16807;48.718639;;f;FR;f;Europe/Paris;f;FRZGY;;t;;f;8706464;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5882;St-Louis (Moselle) Plan Incliné;st-louis-moselle-plan-incline;8746363;87463638;7.189221;48.716419;;f;FR;f;Europe/Paris;f;FRZGZ;;t;;f;8706465;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5883;Guntzviller;guntzviller;8746361;87463612;7.158083;48.712077;;f;FR;f;Europe/Paris;t;FRZHA;;t;;f;8706466;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5884;Berthelming Mairie;berthelming-mairie;8747756;;7.0000000000;48.8166670000;;f;FR;f;Europe/Paris;t;FRZHB;;t;;f;8706467;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5890;Zornhoff;zornhoff;;;;;;t;FR;f;Europe/Paris;f;FRZNF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5892;London St-Pancras;london-st-pancras;7015400;70154005;-0.1263610000;51.5319210000;8267;f;GB;t;Europe/London;t;GBSPX;;t;;f;7004428;t;;f;;f;;f;;f;;f;;Londres;;;Londra;Londýn;;Londres;;ロンドン;런던;Londen;Londyn;Londres;Лондон;;Londra;伦敦
-5893;Bruxelles-Midi;bruxelles-midi;8814001;88140010;4.335695;50.835374;5974;f;BE;t;Europe/Brussels;t;BEBMI;;t;;f;8800004;t;ZYR;t;;f;;f;;f;;f;;;Brussels South Station;Brüssel Südbahnhof;Stazione Sud;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+5892;London St-Pancras;london-st-pancras;7015400;70154005;-0.1263610000;51.5319210000;8267;f;GB;t;Europe/London;t;GBSPX;;t;;f;7004428;t;;f;;f;;f;;f;;f;;Londres;;;Londra;Londres;Londýn;;;ロンドン;런던;Londen;Londyn;Londres;Лондон;;Londra;伦敦
+5893;Bruxelles-Midi;bruxelles-midi;8814001;88140010;4.335695;50.835374;5974;f;BE;t;Europe/Brussels;t;BEBMI;;t;;f;8800004;t;ZYR;t;;f;;f;;f;;f;;;Brussels South Station;Brüssel Südbahnhof;Stazione Sud;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 5894;Amsterdam-Centraal;amsterdam-centraal;8400058;84000588;4.899426;52.37919;8657;f;NL;t;Europe/Amsterdam;t;NLAMA;;t;;f;8400058;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;;;;Amszterdam;アムステルダム;암스테르담;;;Amesterdão;Амстердам;;;阿姆斯特丹
 5901;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5902;Soignies;soignies;8883113;;4.069281;50.573177;;f;BE;f;Europe/Brussels;f;BEAAB;;f;;f;8800144;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4503,7 +4503,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5906;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5907;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5908;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5909;Leuven;leuven;8833001;;4.7123880000;50.8790890000;;f;BE;f;Europe/Brussels;t;BEAAI;;f;;f;8800011;t;;f;;f;;f;;f;;f;;Louvain;;Löwen;Lovanio;Lovaň;;Lovaina;;レーヴェン;;;;Lovaina;Лёвен;;;鲁汶
+5909;Leuven;leuven;8833001;;4.7123880000;50.8790890000;;f;BE;f;Europe/Brussels;t;BEAAI;;f;;f;8800011;t;;f;;f;;f;;f;;f;;Louvain;;Löwen;Lovanio;Lovaina;Lovaň;;;レーヴェン;;;;Lovaina;Лёвен;;;鲁汶
 5910;Sterpenich;sterpenich;8866068;;;;;f;BE;f;Europe/Brussels;f;BEAAJ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5911;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5912;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4539,7 +4539,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5942;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5943;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5944;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5945;Bruxelles-National-Aéroport;bruxelles-national-aeroport;8819406;;4.483022689819336;50.8985400058829;5974;f;BE;f;Europe/Brussels;t;BEABT;;t;;f;8800043;t;;f;;f;;f;;f;;f;;;Brussels Airport;Brüssel Flughafen;Aeroporto;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+5945;Bruxelles-National-Aéroport;bruxelles-national-aeroport;8819406;;4.483022689819336;50.8985400058829;5974;f;BE;f;Europe/Brussels;t;BEABT;;t;;f;8800043;t;;f;;f;;f;;f;;f;;;Brussels Airport;Brüssel Flughafen;Aeroporto;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 5946;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5947;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5948;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4565,10 +4565,10 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5968;;;;;;;5974;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5969;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5970;Blandain Ville;blandain-ville;;;;;;t;BE;f;Europe/Brussels;f;BEBDN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5971;Bruxelles-Nord;bruxelles-nord;8812005;;4.3614580000;50.8602380000;5974;f;BE;f;Europe/Brussels;t;BEBNO;;t;;f;8800002;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+5971;Bruxelles-Nord;bruxelles-nord;8812005;;4.3614580000;50.8602380000;5974;f;BE;f;Europe/Brussels;t;BEBNO;;t;;f;8800002;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 5972;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5973;Brugge;brugge;8891009;;3.217062950134277;51.19722998626312;;f;BE;f;Europe/Brussels;t;BEBRG;;t;;f;8800029;t;;f;;f;;f;;f;;f;;Bruges;Bruges;;Bruges;Bruggy;;Brujas;;ブルッヘ;브뤼허;;Brugia;Bruges;Брюгге;Brygge;;布鲁日
-5974;Bruxelles;bruxelles;9900009;;4.351739287376404;50.84651957961837;;t;BE;f;Europe/Brussels;t;BEBRU;;t;;f;;f;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+5973;Brugge;brugge;8891009;;3.217062950134277;51.19722998626312;;f;BE;f;Europe/Brussels;t;BEBRG;;t;;f;8800029;t;;f;;f;;f;;f;;f;;Bruges;Bruges;;Bruges;Brujas;Bruggy;;;ブルッヘ;브뤼허;;Brugia;Bruges;Брюгге;Brygge;;布鲁日
+5974;Bruxelles;bruxelles;9900009;;4.351739287376404;50.84651957961837;;t;BE;f;Europe/Brussels;t;BEBRU;;t;;f;;f;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 5975;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5976;Charleroi;charleroi;8872009;;4.4387740000;50.4044220000;;f;BE;f;Europe/Brussels;t;BECRL;;t;;f;8800024;t;;f;;f;;f;;f;;f;;;;;;;;;;シャルルロワ;샤를루아;;;;Шарлеруа;;;沙勒罗瓦
 5977;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4589,7 +4589,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 5992;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5993;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5994;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-5995;Liège-Guillemins;liege-guillemins;8841004;88410040;5.5666670000;50.6242970000;23044;f;BE;t;Europe/Brussels;t;BELGG;;t;;f;8800012;t;;f;;f;;f;;f;;f;;;;Lüttich;Liegi;Lutych;;Lieja;;リエージュ;리에주;Luik;;;Льеж;;;列日
+5995;Liège-Guillemins;liege-guillemins;8841004;88410040;5.5666670000;50.6242970000;23044;f;BE;t;Europe/Brussels;t;BELGG;;t;;f;8800012;t;;f;;f;;f;;f;;f;;;;Lüttich;Liegi;Lieja;Lutych;;;リエージュ;리에주;Luik;;;Льеж;;;列日
 5996;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5997;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 5998;Oostende;oostende;8891702;;2.9268240000;51.2284900000;;f;BE;f;Europe/Brussels;t;BEOST;;t;;f;8800030;t;;f;;f;;f;;f;;f;;Ostende;Ostend;Ostende;Ostenda;Ostende;Ostende;Ostende;;オーステンデ;오스텐더;;Ostenda;Ostende;Остенде;;;奥斯滕德
@@ -4664,7 +4664,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6067;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6068;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6069;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6070;Solothurn;solothurn;8500207;;7.5426860000;47.2041720000;;f;CH;f;Europe/Zurich;t;CHACH;;f;;f;8500207;t;;f;;f;;f;;f;;f;;Soleure;;;Soletta;;;Soleura;;ゾロトゥルン;졸로투른;;Solura;Soleura;Золотурн;;;索洛图恩
+6070;Solothurn;solothurn;8500207;;7.5426860000;47.2041720000;;f;CH;f;Europe/Zurich;t;CHACH;;f;;f;8500207;t;;f;;f;;f;;f;;f;;Soleure;;;Soletta;Soleura;;;;ゾロトゥルン;졸로투른;;Solura;Soleura;Золотурн;;;索洛图恩
 6071;Montana vermala;montana-vermala;8501596;;;;;f;CH;f;Europe/Zurich;f;CHACI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6072;Wildegg;wildegg;8502115;;8.162978;47.415284;;f;CH;f;Europe/Zurich;f;CHACJ;;f;;f;8502115;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6073;Bassecourt;bassecourt;8500122;;7.24686;47.336691;;f;CH;f;Europe/Zurich;f;CHACK;;f;;f;8500122;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4839,9 +4839,9 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6242;Muri;muri;8502215;;;;;f;CH;f;Europe/Zurich;f;CHAJA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6243;Raefis;raefis;8509405;;;;;f;CH;f;Europe/Zurich;f;CHAJB;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6244;Othmarsingen;othmarsingen;8502105;;8.214783;47.407446;;f;CH;f;Europe/Zurich;f;CHAJC;;f;;f;8502105;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6245;Zürich HB;zurich-hb;8503000;85030007;8.539203;47.378186;6401;f;CH;f;Europe/Zurich;t;CHAJD;;t;;f;8503000;t;;f;;f;8503000;t;;f;;f;;;;;Zurigo;Curych;;Zúrich;;チューリッヒ;취리히;;Zurych;Zurique;Цюрих;;Zürih;
+6245;Zürich HB;zurich-hb;8503000;85030007;8.539203;47.378186;6401;f;CH;f;Europe/Zurich;t;CHAJD;;t;;f;8503000;t;;f;;f;8503000;t;;f;;f;;;;;Zurigo;Zúrich;Curych;;;チューリッヒ;취리히;;Zurych;Zurique;Цюрих;;Zürih;
 6246;Vernayaz;vernayaz;;;;;;t;CH;f;Europe/Zurich;f;CHAJE;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6247;Lausanne;lausanne;8501120;85011205;6.6290500000;46.5167040000;6354;f;CH;t;Europe/Zurich;t;CHAJF;;t;;f;8501120;t;;f;;f;8501120;t;;f;;f;;;;;Losanna;;;Lausana;;ローザンヌ;;;Lozanna;Lausana;Лозанна;;Lozan;洛桑
+6247;Lausanne;lausanne;8501120;85011205;6.6290500000;46.5167040000;6354;f;CH;t;Europe/Zurich;t;CHAJF;;t;;f;8501120;t;;f;;f;8501120;t;;f;;f;;;;;Losanna;Lausana;;;;ローザンヌ;;;Lozanna;Lausana;Лозанна;;Lozan;洛桑
 6248;Grenchen Nord;grenchen-nord;8500159;;7.3894560000;47.1918210000;6325;f;CH;f;Europe/Zurich;t;CHAJG;;f;;f;8500159;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6249;Leukerbad;leukerbad;8501656;;7.626457;46.379781;;f;CH;f;Europe/Zurich;f;CHAJH;;f;;f;8501656;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6251;Lausanne—Ouchy;lausanne-ouchy;8585555;;;;6354;f;CH;f;Europe/Zurich;f;CHAJJ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4893,7 +4893,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6297;Brügg;brugg;8500309;;8.2088320000;47.4808510000;;f;CH;f;Europe/Zurich;t;CHBGG;;f;;f;8500309;t;;f;;f;;f;;f;;f;;;;;;;;;;;브루그;;;;Брюгг;;;布魯格
 6298;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6299;Braunwald;braunwald;8503261;;8.998597;46.938685;;f;CH;f;Europe/Zurich;f;CHBNW;;f;;f;8503261;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6300;Bern;bern;8507000;85070003;7.4384830000;46.9491130000;;f;CH;f;Europe/Zurich;t;CHBRN;;t;;f;8507000;t;;f;;f;8507000;t;;f;;f;;Berne, Suisse;Switzerland;Schweiz;Berna, Svizzera;;;Berna;;ベルン;베른;;Berno;Berna;Берн;;;伯恩
+6300;Bern;bern;8507000;85070003;7.4384830000;46.9491130000;;f;CH;f;Europe/Zurich;t;CHBRN;;t;;f;8507000;t;;f;;f;8507000;t;;f;;f;;Berne, Suisse;Switzerland;Schweiz;Berna, Svizzera;Berna;;;;ベルン;베른;;Berno;Berna;Берн;;;伯恩
 6301;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6302;Chandolin Poste;chandolin-poste;8501755;;;;;f;CH;f;Europe/Zurich;f;CHCHA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6303;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4925,7 +4925,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6332;Gruyères;gruyeres;8504077;;;;;f;CH;f;Europe/Zurich;f;CHGYR;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6333;Haute-Nendaz Village;haute-nendaz-village;8501772;;;;;f;CH;f;Europe/Zurich;f;CHHTN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6334;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6335;Interlaken West;interlaken-west;8507493;;7.8514390000;46.6826270000;;f;CH;f;Europe/Zurich;t;CHIKW;;t;;f;8507493;t;;f;;f;;f;;f;;f;;;;;;;;Entrelagos;;インターラーケン;인터라켄;;;;Интерлакен;;;因特拉肯
+6335;Interlaken West;interlaken-west;8507493;;7.8514390000;46.6826270000;;f;CH;f;Europe/Zurich;t;CHIKW;;t;;f;8507493;t;;f;;f;;f;;f;;f;;;;;;Entrelagos;;;;インターラーケン;인터라켄;;;;Интерлакен;;;因特拉肯
 6336;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6337;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6338;Klosters;klosters;;;;;;t;CH;f;Europe/Zurich;f;CHKLT;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4940,7 +4940,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6350;Neuchâtel;neuchatel;;;;;;t;CH;f;Europe/Zurich;f;CHNLO;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6351;Neuchâtel (Suisse);neuchatel-suisse;8504221;;6.935914;46.996513;6350;f;CH;f;Europe/Zurich;f;CHQNC;;t;;f;8530791;f;;f;;f;;f;;f;;f;6349;;;;;;;;;;;;;;;;;
 6352;St-Gallen;st-gallen;8506302;;9.369303;47.423276;6358;f;CH;f;Europe/Zurich;t;CHQGL;;f;;f;8506302;t;;f;;f;;f;;f;;f;;Saint-Gall;;;San Gallo;;;;;;;;;;Санкт-Галлен;;;
-6353;Luzern;luzern;8505000;;8.31068;47.050142;;f;CH;f;Europe/Zurich;t;CHQLJ;;f;;f;8505000;t;;f;;f;8505000;t;;f;;f;;Lucerne;Lucerne;;Lucerna;Lucern;;Lucerna;;ルツェルン;루체른;;Lucerna;Lucerna;Люцерн;;;卢塞恩
+6353;Luzern;luzern;8505000;;8.31068;47.050142;;f;CH;f;Europe/Zurich;t;CHQLJ;;f;;f;8505000;t;;f;;f;8505000;t;;f;;f;;Lucerne;Lucerne;;Lucerna;Lucerna;Lucern;;;ルツェルン;루체른;;Lucerna;Lucerna;Люцерн;;;卢塞恩
 6354;Lausanne;lausanne;;;;;;t;CH;f;Europe/Zurich;f;CHQLS;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6355;Arolla poste;arolla-poste;8501750;;;;;f;CH;f;Europe/Zurich;f;CHRLA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6356;Rorschach;rorschach;;;;;;t;CH;f;Europe/Zurich;f;CHRSH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -4965,11 +4965,11 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6375;Brigue;brigue;8500324;;;;;f;CH;f;Europe/Zurich;f;CHZDL;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6376;Buchs;buchs;8500271;;;;;f;CH;f;Europe/Zurich;f;CHZDO;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6377;Chiasso;chiasso;8500321;;;;;f;CH;f;Europe/Zurich;f;CHZDS;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6378;Chur;chur;8509000;;9.528475;46.85344;;f;CH;f;Europe/Zurich;t;CHZDT;;f;;f;8509000;t;;f;;f;;f;;f;;f;;Coire;;;Coira;;;Coira;;クール;쿠어;;;Coira;Кур;;;庫爾
+6378;Chur;chur;8509000;;9.528475;46.85344;;f;CH;f;Europe/Zurich;t;CHZDT;;f;;f;8509000;t;;f;;f;;f;;f;;f;;Coire;;;Coira;Coira;;;;クール;쿠어;;;Coira;Кур;;;庫爾
 6379;Delemont;delemont;8500109;;7.3500470000;47.3619960000;;f;CH;f;Europe/Zurich;t;CHZDW;;f;;f;8500109;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6380;Einsiedeln;einsiedeln;8503283;;8.7457220000;47.1303350000;;f;CH;f;Europe/Zurich;t;CHZDZ;;f;;f;8503283;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6381;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6382;Fribourg;fribourg;8504100;85041004;7.1510260000;46.8031460000;;f;CH;f;Europe/Zurich;t;CHZHF;;t;;f;8504100;t;;f;;f;;f;;f;;f;;;;Freiburg;Friburgo;;;Friburgo;;フリブール;;;Fryburg;Friburgo;Фрибур;;;
+6382;Fribourg;fribourg;8504100;85041004;7.1510260000;46.8031460000;;f;CH;f;Europe/Zurich;t;CHZHF;;t;;f;8504100;t;;f;;f;;f;;f;;f;;;;Freiburg;Friburgo;Friburgo;;;;フリブール;;;Fryburg;Friburgo;Фрибур;;;
 6383;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6384;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6385;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5285,11 +5285,11 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6695;Blankenheim (Wald);blankenheim-wald;8015631;;6.593506;50.441871;;f;DE;f;Europe/Berlin;t;DEAAE;;f;;f;8001008;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6696;Bodenheim;bodenheim;8019058;;8.311651;49.930088;;f;DE;f;Europe/Berlin;t;DEAAF;;f;;f;8000359;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6697;Neckarsulm;neckarsulm;8029635;;9.220064;49.188973;;f;DE;f;Europe/Berlin;t;DEAAG;;f;;f;8004220;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6698;Aachen;aachen;;;6.08378;50.77607;;t;DE;f;Europe/Berlin;t;DEAAH;;t;;f;;f;;f;;f;;f;;f;;f;;Aix-la-Chapelle;;;Aquisgrana;Cáchy;;Aquisgrán;;アーヘン;아헨;Aken;Akwizgran;Aquisgrano;Ахен;;;亚琛
-6699;Aachen-Rothe Erde;aachen-rothe-erde;8015342;;6.116476;50.770202;6698;f;DE;f;Europe/Berlin;t;DEACP;;f;;f;8000406;t;;f;;f;;f;;f;;f;;Aix-la-Chapelle;;;Aquisgrana;Cáchy;;Aquisgrán;;アーヘン;아헨;Aken;Akwizgran;Aquisgrano;Ахен;;;亚琛
-6700;Aachen Hbf;aachen-hbf;8015345;;6.091495;50.767802;6698;f;DE;t;Europe/Berlin;t;DEBDY;;t;;f;8000001;t;;f;;f;;f;;f;;f;;Aix-la-Chapelle Gare centrale;Main station;;Aquisgrana Stazione centrale;Cáchy;;Aquisgrán;;アーヘン;아헨;Aken;Akwizgran;Aquisgrano;Ахен;;;亚琛
+6698;Aachen;aachen;;;6.08378;50.77607;;t;DE;f;Europe/Berlin;t;DEAAH;;t;;f;;f;;f;;f;;f;;f;;f;;Aix-la-Chapelle;;;Aquisgrana;Aquisgrán;Cáchy;;;アーヘン;아헨;Aken;Akwizgran;Aquisgrano;Ахен;;;亚琛
+6699;Aachen-Rothe Erde;aachen-rothe-erde;8015342;;6.116476;50.770202;6698;f;DE;f;Europe/Berlin;t;DEACP;;f;;f;8000406;t;;f;;f;;f;;f;;f;;Aix-la-Chapelle;;;Aquisgrana;Aquisgrán;Cáchy;;;アーヘン;아헨;Aken;Akwizgran;Aquisgrano;Ахен;;;亚琛
+6700;Aachen Hbf;aachen-hbf;8015345;;6.091495;50.767802;6698;f;DE;t;Europe/Berlin;t;DEBDY;;t;;f;8000001;t;;f;;f;;f;;f;;f;;Aix-la-Chapelle Gare centrale;Main station;;Aquisgrana Stazione centrale;Aquisgrán;Cáchy;;;アーヘン;아헨;Aken;Akwizgran;Aquisgrano;Ахен;;;亚琛
 6701;Aachen Süd (Gr);aachen-sud-gr;8000452;;6.045407;50.731917;6698;f;DE;f;Europe/Berlin;f;DEAQK;;f;;f;8000403;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6702;Aachen West;aachen-west;8015199;;6.070712;50.78036;6698;f;DE;f;Europe/Berlin;t;DEAAW;;f;;f;8000404;t;XAC;f;;f;;f;;f;;f;;Aix-la-Chapelle;;;Aquisgrana;Cáchy;;Aquisgrán;;アーヘン;아헨;Aken;Akwizgran;Aquisgrano;Ахен;;;亚琛
+6702;Aachen West;aachen-west;8015199;;6.070712;50.78036;6698;f;DE;f;Europe/Berlin;t;DEAAW;;f;;f;8000404;t;XAC;f;;f;;f;;f;;f;;Aix-la-Chapelle;;;Aquisgrana;Aquisgrán;Cáchy;;;アーヘン;아헨;Aken;Akwizgran;Aquisgrano;Ахен;;;亚琛
 6703;Buxtehude;buxtehude;8001188;;9.688313;53.47049;;f;DE;f;Europe/Berlin;t;DEAAI;;f;;f;8001315;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6704;Ebelsbach-Eltmann;ebelsbach-eltmann;8022412;;10.669611;49.982675;;f;DE;f;Europe/Berlin;t;DEAAJ;;f;;f;8001619;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6705;Efringen-Kirchen;efringen-kirchen;8014422;;7.563919;47.65562;;f;DE;f;Europe/Berlin;t;DEAAK;;f;;f;8001671;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5392,7 +5392,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6802;Bad Teinach-Neubulach;bad-teinach-neubulach;8029474;;8.72715;48.678466;;f;DE;f;Europe/Berlin;t;DEAEF;;f;;f;8000757;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6803;Bad Zwischenahn;bad-zwischenahn;8021229;;8.002916;53.182547;;f;DE;f;Europe/Berlin;t;DEAEG;;f;;f;8000770;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6804;Baiersbronn Bf;baiersbronn-bf;8014271;;8.371869;48.504103;;f;DE;f;Europe/Berlin;t;DEAEH;;f;;f;8000782;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6805;Bamberg;bamberg;8022090;;10.899492;49.900757;;f;DE;f;Europe/Berlin;t;DEAEI;;f;;f;8000025;t;;f;;f;;f;;f;;f;;;;;Bamberga;Bamberk;;;;バンベルク;밤베르크;;;;Бамберг;;;巴姆贝格
+6805;Bamberg;bamberg;8022090;;10.899492;49.900757;;f;DE;f;Europe/Berlin;t;DEAEI;;f;;f;8000025;t;;f;;f;;f;;f;;f;;;;;Bamberga;;Bamberk;;;バンベルク;밤베르크;;;;Бамберг;;;巴姆贝格
 6806;Bayerisch Eisenstein;bayerisch-eisenstein;8026482;;13.209819;49.121859;;f;DE;f;Europe/Berlin;t;DEAEJ;;f;;f;8000830;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6807;Bayerisch Gmain;bayerisch-gmain;8020103;;12.89507;47.720378;;f;DE;f;Europe/Berlin;t;DEAEK;;f;;f;8000831;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6808;Blaufelden;blaufelden;8029722;;9.967679;49.296232;;f;DE;f;Europe/Berlin;t;DEAEL;;f;;f;8001014;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5432,12 +5432,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6842;Fehmarn-Burg;fehmarn-burg;8001662;;11.189709;54.443069;;f;DE;f;Europe/Berlin;t;DEAFT;;f;;f;8001274;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6843;;;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6844;Bergen (Oberbay);bergen-oberbay;8020143;;12.592844;47.825273;;f;DE;f;Europe/Berlin;t;DEAFV;;f;;f;8000888;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6845;Coburg;coburg;8022803;;10.957374;50.263094;;f;DE;f;Europe/Berlin;t;DEAFW;;f;;f;8001338;t;;f;;f;;f;;f;;f;;Cobourg;;;Coburgo;;;Coburgo;;コーブルク;;;Powiat Coburg;Coburgo;Кобург;;;科堡
+6845;Coburg;coburg;8022803;;10.957374;50.263094;;f;DE;f;Europe/Berlin;t;DEAFW;;f;;f;8001338;t;;f;;f;;f;;f;;f;;Cobourg;;;Coburgo;Coburgo;;;;コーブルク;;;Powiat Coburg;Coburgo;Кобург;;;科堡
 6846;Calw;calw;8029473;;8.742027;48.714729;;f;DE;f;Europe/Berlin;t;DEAFX;;f;;f;8000063;t;;f;;f;;f;;f;;f;;;;;;;;;;カルフ;;;;;Кальв;;;卡尔夫
 6847;Castrop-Rauxel Hbf;castrop-rauxel-hbf;8010036;;7.304562;51.573694;;f;DE;f;Europe/Berlin;t;DEAFY;;f;;f;8001327;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
 6848;Calmbach Bahnhof;calmbach-bahnhof;8029457;;8.571133;48.776485;;f;DE;f;Europe/Berlin;t;DEAFZ;;f;;f;8001320;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6849;Cham (Oberpf);cham-oberpf;8026249;;12.656829;49.221864;;f;DE;f;Europe/Berlin;t;DEAGA;;f;;f;8001330;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6850;Augsburg Hbf;augsburg-hbf;8002140;;10.885568;48.365444;;f;DE;f;Europe/Berlin;t;DEAGB;;t;;f;8000013;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Augsburgo;;アウクスブルク;아우크스부르크;;;Augsburgo;Аугсбург;;;奥格斯堡
+6850;Augsburg Hbf;augsburg-hbf;8002140;;10.885568;48.365444;;f;DE;f;Europe/Berlin;t;DEAGB;;t;;f;8000013;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Augsburgo;;;;アウクスブルク;아우크스부르크;;;Augsburgo;Аугсбург;;;奥格斯堡
 6851;Öhringen-Cappel;ohringen-cappel;8001594;;9.526686;49.201917;;f;DE;f;Europe/Berlin;t;DEAGC;;f;;f;8004620;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6852;Deggendorf Hbf;deggendorf-hbf;8026450;;12.949725;48.839436;;f;DE;f;Europe/Berlin;t;DEAGD;;f;;f;8001397;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Деггендорф;;;德根多尔夫
 6853;Derneburg (Han);derneburg-han;8013377;;10.143715;52.096848;;f;DE;f;Europe/Berlin;t;DEAGE;;f;;f;8000071;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5458,7 +5458,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6868;Bad Rappenau;bad-rappenau;8014196;;9.101308;49.237721;;f;DE;f;Europe/Berlin;t;DEAGT;;f;;f;8000736;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6869;Bad Wimpfen;bad-wimpfen;8014198;;9.167226;49.229748;;f;DE;f;Europe/Berlin;t;DEAGU;;f;;f;8000765;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6870;Dornstetten;dornstetten;8029490;;8.494959;48.47211;;f;DE;f;Europe/Berlin;t;DEAGV;;f;;f;8001512;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6871;Eckernförde;eckernforde;8001392;;9.835115;54.4676;;f;DE;f;Europe/Berlin;t;DEAGW;;f;;f;8001654;t;;f;;f;;f;;f;;f;;;;;;;Egernførde;;;;;;;;Эккернфёрде;;;埃克尔恩弗尔德
+6871;Eckernförde;eckernforde;8001392;;9.835115;54.4676;;f;DE;f;Europe/Berlin;t;DEAGW;;f;;f;8001654;t;;f;;f;;f;;f;;f;;;;;;;;Egernførde;;;;;;;Эккернфёрде;;;埃克尔恩弗尔德
 6872;Eichstätt Bahnhof;eichstatt-bahnhof;8020381;;11.163649;48.869883;;f;DE;f;Europe/Berlin;t;DEAGX;;f;;f;8001708;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Айхштет;;;艾希斯特
 6873;Eimelrod;eimelrod;8005264;;;;;f;DE;f;Europe/Berlin;f;DEAGY;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6874;Elfershausen-Trimberg;elfershausen-trimberg;8022553;;9.969109;50.140481;;f;DE;f;Europe/Berlin;t;DEAGZ;;f;;f;8001742;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5490,11 +5490,11 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6900;Flörsheim (Main);florsheim-main;8011120;;8.431009;50.017212;;f;DE;f;Europe/Berlin;t;DEAHZ;;f;;f;8002013;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6901;Finnentrop;finnentrop;8008267;;7.964703;51.172631;;f;DE;f;Europe/Berlin;t;DEAIA;;f;;f;8000102;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6902;Fischen;fischen;8002379;;10.271712;47.45659;;f;DE;f;Europe/Berlin;t;DEAIB;;f;;f;8001995;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6903;Flensburg;flensburg;8001427;;9.436884;54.774088;;f;DE;f;Europe/Berlin;t;DEAIC;;f;;f;8000103;t;;f;;f;;f;;f;;f;;Flensbourg;;;Flensburgo;;Flensborg;Flensburgo;;フレンスブルク;플렌스부르크;;;;Фленсбург;;;弗伦斯堡
-6904;Freising;freising;8020487;;11.744541;48.395198;;f;DE;f;Europe/Berlin;t;DEAID;;f;;f;8002078;t;;f;;f;;f;;f;;f;;;;;Frisinga;;;Frisinga;;フライジング;프라이징;;Fryzynga;Frisinga;Фрайзинг;;;弗赖辛
+6903;Flensburg;flensburg;8001427;;9.436884;54.774088;;f;DE;f;Europe/Berlin;t;DEAIC;;f;;f;8000103;t;;f;;f;;f;;f;;f;;Flensbourg;;;Flensburgo;Flensburgo;;Flensborg;;フレンスブルク;플렌스부르크;;;;Фленсбург;;;弗伦斯堡
+6904;Freising;freising;8020487;;11.744541;48.395198;;f;DE;f;Europe/Berlin;t;DEAID;;f;;f;8002078;t;;f;;f;;f;;f;;f;;;;;Frisinga;Frisinga;;;;フライジング;프라이징;;Fryzynga;Frisinga;Фрайзинг;;;弗赖辛
 6906;Frankenthal Hbf;frankenthal-hbf;8019073;;8.349702;49.53557;;f;DE;f;Europe/Berlin;t;DEAIF;;f;;f;8000332;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Франкенталь;;;弗兰肯塔尔
 6907;Fröndenberg;frondenberg;8008205;;7.763039;51.47119;;f;DE;f;Europe/Berlin;t;DEAIG;;f;;f;8000113;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6908;Sigmaringen;sigmaringen;8029254;;9.221853;48.086985;;f;DE;f;Europe/Berlin;t;DEAIH;;f;;f;8000069;t;;f;;f;;f;;f;;f;;;;;;;;Sigmaringa;;;;;;;Зигмаринген;;;西格马林根
+6908;Sigmaringen;sigmaringen;8029254;;9.221853;48.086985;;f;DE;f;Europe/Berlin;t;DEAIH;;f;;f;8000069;t;;f;;f;;f;;f;;f;;;;;;Sigmaringa;;;;;;;;;Зигмаринген;;;西格马林根
 6909;Friedrichssegen;friedrichssegen;8019599;;7.650665;50.311869;;f;DE;f;Europe/Berlin;t;DEAII;;f;;f;8002114;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6910;Freudenstadt Hbf;freudenstadt-hbf;8029492;;8.428807;48.460325;7606;f;DE;f;Europe/Berlin;t;DEAIJ;;f;;f;8000110;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
 6911;Freudenstadt Stadt;freudenstadt-stadt;8029493;;8.410649;48.467777;7606;f;DE;f;Europe/Berlin;t;DEAIK;;f;;f;8002091;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5504,10 +5504,10 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6915;Freienohl;freienohl;8008197;;8.169486;51.366421;;f;DE;f;Europe/Berlin;t;DEAIO;;f;;f;8002073;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6916;Furth i Wald;furth-i-wald;8026267;;12.838807;49.309815;;f;DE;f;Europe/Berlin;t;DEAIP;;f;;f;8002159;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6917;Freiburg-Littenweiler;freiburg-littenweiler;8014365;;7.895135;47.981667;;f;DE;f;Europe/Berlin;t;DEAIQ;;f;;f;8002068;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6918;Frankfurt (Main) West;frankfurt-main-west;8011124;;8.639334;50.118862;;f;DE;f;Europe/Berlin;t;DEAIR;;f;;f;8002042;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+6918;Frankfurt (Main) West;frankfurt-main-west;8011124;;8.639334;50.118862;;f;DE;f;Europe/Berlin;t;DEAIR;;f;;f;8002042;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 6919;Gaggenau Bf;gaggenau-bf;8014254;;8.319975;48.805772;;f;DE;f;Europe/Berlin;t;DEAIS;;f;;f;8002167;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6920;Geldern;geldern;8015025;;6.319335;51.513287;;f;DE;f;Europe/Berlin;t;DEAIT;;f;;f;8002222;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6921;Hannover Hbf;hannover-hbf;8013547;;9.741016;52.376763;7623;f;DE;f;Europe/Berlin;t;DEAIU;;f;;f;8000152;t;;f;;f;;f;;f;;f;;Hanovre Gare centrale;Hanover Main station;;Stazione centrale;;;Hanóver;;ハノーファー;하노버;;Hanower;Hanôver;Ганновер;;;汉诺威
+6921;Hannover Hbf;hannover-hbf;8013547;;9.741016;52.376763;7623;f;DE;f;Europe/Berlin;t;DEAIU;;f;;f;8000152;t;;f;;f;;f;;f;;f;;Hanovre Gare centrale;Hanover Main station;;Stazione centrale;Hanóver;;;;ハノーファー;하노버;;Hanower;Hanôver;Ганновер;;;汉诺威
 6922;Gerolstein;gerolstein;8025037;;6.660368;50.224009;;f;DE;f;Europe/Berlin;t;DEAIV;;f;;f;8000123;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6923;Gernsbach Bf;gernsbach-bf;8014256;;8.336712;48.768305;;f;DE;f;Europe/Berlin;t;DEAIW;;f;;f;8002248;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6924;Geseke;geseke;8010363;;8.510294;51.64523;;f;DE;f;Europe/Berlin;t;DEAIX;;f;;f;8002262;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гезеке;;;格塞克
@@ -5534,7 +5534,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6945;Haffkrug;haffkrug;8001642;;10.742675;54.054079;;f;DE;f;Europe/Berlin;t;DEAJS;;f;;f;8002504;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6946;Hallthurm;hallthurm;8020102;;;;;f;DE;f;Europe/Berlin;f;DEAJT;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6947;Haltern am See;haltern-am-see;8021002;;7.184367;51.737666;;f;DE;f;Europe/Berlin;t;DEAJU;;f;;f;8000145;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6948;Hameln;hameln;8013427;;9.375901;52.101846;;f;DE;f;Europe/Berlin;t;DEAJV;;f;;f;8000148;t;;f;;f;;f;;f;;f;;Hamelin;Hamelin;;Hamelin;;;Hamelín;;ハーメルン;하멜른;Hamelen;;Hamelin;Хамельн;;;哈默爾恩
+6948;Hameln;hameln;8013427;;9.375901;52.101846;;f;DE;f;Europe/Berlin;t;DEAJV;;f;;f;8000148;t;;f;;f;;f;;f;;f;;Hamelin;Hamelin;;Hamelin;Hamelín;;;;ハーメルン;하멜른;Hamelen;;Hamelin;Хамельн;;;哈默爾恩
 6949;Hammelburg;hammelburg;8022555;;9.882983;50.120066;;f;DE;f;Europe/Berlin;t;DEAJW;;f;;f;8002567;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6950;Hammerau;hammerau;8020107;;12.946129;47.795878;;f;DE;f;Europe/Berlin;t;DEAJX;;f;;f;8002570;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6951;Hannover-Kleefeld;hannover-kleefeld;8013546;;9.79061;52.373608;7623;f;DE;f;Europe/Berlin;t;DEAJY;;f;;f;8002584;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5578,7 +5578,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 6989;Ingolstadt Hbf;ingolstadt-hbf;8020424;;11.437335;48.744537;;f;DE;f;Europe/Berlin;t;DEALK;;f;;f;8000183;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;インゴルシュタット;;;;;Ингольштадт;;;
 6990;Itzehoe;itzehoe;8001494;;9.510389;53.923384;;f;DE;f;Europe/Berlin;t;DEALL;;f;;f;8003102;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6991;Immensen-Arpke;immensen-arpke;8013028;;10.084476;52.391353;;f;DE;f;Europe/Berlin;t;DEALM;;f;;f;8003064;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-6992;Passau Hbf;passau-hbf;8000460;;13.450775;48.573634;;f;DE;f;Europe/Berlin;t;DEALN;;f;;f;8000298;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Pasov;;;;パッサウ;파사우;;Pasawa;;Пассау;;;帕绍
+6992;Passau Hbf;passau-hbf;8000460;;13.450775;48.573634;;f;DE;f;Europe/Berlin;t;DEALN;;f;;f;8000298;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Pasov;;;パッサウ;파사우;;Pasawa;;Пассау;;;帕绍
 6993;Jever;jever;8021669;;7.892978;53.568715;;f;DE;f;Europe/Berlin;t;DEALO;;f;;f;8003124;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6994;Salzburg;salzburg;8020060;;;;;f;DE;f;Europe/Berlin;f;DEALP;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 6995;Jodbad sulzbrunn;jodbad-sulzbrunn;8002315;;;;;f;DE;f;Europe/Berlin;f;DEALQ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5601,13 +5601,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7012;Kirn;kirn;8025273;;7.464588;49.785767;;f;DE;f;Europe/Berlin;t;DEAMH;;f;;f;8003295;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7013;Kißlegg;kisslegg;8029204;;9.881922;47.793532;;f;DE;f;Europe/Berlin;t;DEAMI;;f;;f;8000203;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7014;Klais;klais;8020292;;11.238592;47.483036;;f;DE;f;Europe/Berlin;t;DEAMJ;;f;;f;8003302;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7015;Kleve;kleve;8015004;;6.146221;51.789732;;f;DE;f;Europe/Berlin;t;DEAMK;;f;;f;8000205;t;;f;;f;;f;;f;;f;;Clèves;;;;;;Cléveris;;クレーフェ;;Kleef;;Cleves;Клеве;;;
+7015;Kleve;kleve;8015004;;6.146221;51.789732;;f;DE;f;Europe/Berlin;t;DEAMK;;f;;f;8000205;t;;f;;f;;f;;f;;f;;Clèves;;;;Cléveris;;;;クレーフェ;;Kleef;;Cleves;Клеве;;;
 7016;Kaub;kaub;8019510;;7.768199;50.083633;;f;DE;f;Europe/Berlin;t;DEAML;;f;;f;8003216;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7017;Königswinter;konigswinter;8015582;;7.19359;50.678638;;f;DE;f;Europe/Berlin;t;DEAMM;;f;;f;8003386;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Кёнигсвинтер;;;克尼格斯温特尔
 7018;Kamen;kamen;8010027;;7.661002;51.585227;;f;DE;f;Europe/Berlin;t;DEAMN;;f;;f;8003168;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7019;Köln kalk;koln-kalk;8015564;;;;;f;DE;f;Europe/Berlin;f;DEAMO;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7020;Königshofen (Baden);konigshofen-baden;8029753;;9.724665;49.546024;;f;DE;f;Europe/Berlin;t;DEAMP;;f;;f;8003381;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7021;Köln Süd;koln-sud;8015469;;6.938063;50.927298;;f;DE;f;Europe/Berlin;t;DEAMQ;;f;;f;8003361;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Kolín nad Rýnem;;Colonia;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
+7021;Köln Süd;koln-sud;8015469;;6.938063;50.927298;;f;DE;f;Europe/Berlin;t;DEAMQ;;f;;f;8003361;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
 7022;Köln-Ehrenfeld;koln-ehrenfeld;8015321;;6.91728;50.951533;;f;DE;f;Europe/Berlin;t;DEAMR;;f;;f;8000208;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7023;Korbach;korbach;8005301;;8.873297;51.278803;;f;DE;f;Europe/Berlin;t;DEAMS;;f;;f;8000210;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7024;Kranenburg;kranenburg;8015009;;;;;f;DE;f;Europe/Berlin;f;DEAMT;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5653,7 +5653,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7064;Lörrach Hbf;lorrach-hbf;8014441;;7.665416;47.614054;;f;DE;f;Europe/Berlin;t;DEAOH;;f;;f;8003729;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Лёррах;;;罗拉赫
 7065;Lohr Bahnhof;lohr-bahnhof;8022602;;9.580712;50.004411;;f;DE;f;Europe/Berlin;t;DEAOI;;f;;f;8003740;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7066;Lorch (Rhein);lorch-rhein;8011003;;7.812839;50.040296;;f;DE;f;Europe/Berlin;t;DEAOJ;;f;;f;8003751;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7067;Ludwigsburg;ludwigsburg;8029017;;9.18542;48.891861;;f;DE;f;Europe/Berlin;t;DEAOK;;f;;f;8000235;t;;f;;f;;f;;f;;f;;Ludwigsbourg;;;;;;Luisburgo;;ルートヴィヒスブルク;;;;Ludwigsburgo;Людвигсбург;;;路德维希堡
+7067;Ludwigsburg;ludwigsburg;8029017;;9.18542;48.891861;;f;DE;f;Europe/Berlin;t;DEAOK;;f;;f;8000235;t;;f;;f;;f;;f;;f;;Ludwigsbourg;;;;Luisburgo;;;;ルートヴィヒスブルク;;;;Ludwigsburgo;Людвигсбург;;;路德维希堡
 7068;Ludwigsstadt;ludwigsstadt;8022023;;11.382986;50.486584;;f;DE;f;Europe/Berlin;t;DEAOL;;f;;f;8003770;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7069;Ludwigsthal;ludwigsthal;8026481;;13.237811;49.0596;;f;DE;f;Europe/Berlin;t;DEAOM;;f;;f;8003771;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7070;Landstuhl;landstuhl;8019714;;7.565932;49.416283;;f;DE;f;Europe/Berlin;t;DEAON;;f;;f;8003515;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5665,7 +5665,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7076;Lübeck-Travemünde Hafen;lubeck-travemunde-hafen;8001676;;10.866744;53.958802;;f;DE;f;Europe/Berlin;t;DEAOT;;f;;f;8003777;t;;f;;f;;f;;f;;f;;;Travemünde;;;;;;;トラフェミュンデ;;;Travemünde;;Травемюнде;;;
 7077;Lübeck-Travemünde Strand;lubeck-travemunde-strand;8001677;;10.875931;53.964636;;f;DE;f;Europe/Berlin;t;DEAOU;;f;;f;8003778;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7078;Löwental;lowental;8029159;;9.499242;47.6614;;f;DE;f;Europe/Berlin;t;DEAOV;;f;;f;8003733;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7079;Lüneburg;luneburg;8001173;;10.419891;53.249652;;f;DE;f;Europe/Berlin;t;DEAOW;;f;;f;8000238;t;;f;;f;;f;;f;;f;;Lunebourg;;;Luneburgo;;;Luneburgo;;リューネブルク;뤼네부르크;;;Luneburgo;Люнебург;;;吕讷堡
+7079;Lüneburg;luneburg;8001173;;10.419891;53.249652;;f;DE;f;Europe/Berlin;t;DEAOW;;f;;f;8000238;t;;f;;f;;f;;f;;f;;Lunebourg;;;Luneburgo;Luneburgo;;;;リューネブルク;뤼네부르크;;;Luneburgo;Люнебург;;;吕讷堡
 7080;Lünen Hbf;lunen-hbf;8010098;;7.529481;51.61713;;f;DE;f;Europe/Berlin;t;DEAOX;;f;;f;8000239;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;リューネン;뤼넨;;;;Люнен;;;吕嫩
 7081;Ludwigshafen (Bodensee);ludwigshafen-bodensee;8014597;;9.053189;47.815655;;f;DE;f;Europe/Berlin;t;DEAOY;;f;;f;8003764;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7082;Leverkusen-Schlebusch;leverkusen-schlebusch;8008187;;7.015127;51.031618;;f;DE;f;Europe/Berlin;t;DEAOZ;;f;;f;8003669;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5677,7 +5677,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7088;Bad Malente-Gremsmühlen;bad-malente-gremsmuhlen;8001355;;10.551583;54.166848;;f;DE;f;Europe/Berlin;t;DEAPF;;f;;f;8003829;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7089;Malsfeld;malsfeld;8005461;;9.534831;51.097607;;f;DE;f;Europe/Berlin;t;DEAPG;;f;;f;8000243;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7090;Mannheim-Friedrichsfeld;mannheim-friedrichsfeld;8014018;;8.580122;49.448671;;f;DE;f;Europe/Berlin;t;DEAPH;;f;;f;8000631;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7091;Marburg (Lahn);marburg-lahn;8005386;;8.775017;50.819274;;f;DE;f;Europe/Berlin;t;DEAPI;;f;;f;8000337;t;;f;;f;;f;;f;;f;;Marbourg;;;;;;Marburgo;;マールブルク;;;;Marburgo;Марбург;;;
+7091;Marburg (Lahn);marburg-lahn;8005386;;8.775017;50.819274;;f;DE;f;Europe/Berlin;t;DEAPI;;f;;f;8000337;t;;f;;f;;f;;f;;f;;Marbourg;;;;Marburgo;;;;マールブルク;;;;Marburgo;Марбург;;;
 7092;Markdorf (Baden);markdorf-baden;8014625;;9.388639;47.716818;;f;DE;f;Europe/Berlin;t;DEAPJ;;f;;f;8003871;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7093;Markelfingen;markelfingen;8014580;;9.002768;47.739363;;f;DE;f;Europe/Berlin;t;DEAPK;;f;;f;8003872;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7094;Markt Bibart;markt-bibart;8022520;;10.425464;49.646092;;f;DE;f;Europe/Berlin;t;DEAPL;;f;;f;8003876;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5730,7 +5730,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7141;Neustadt (Holst);neustadt-holst;8001644;;10.80827;54.104499;;f;DE;f;Europe/Berlin;t;DEARH;;f;;f;8004327;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7142;Neustadt am Rübenberge;neustadt-am-rubenberge;8013728;;9.455276;52.503511;;f;DE;f;Europe/Berlin;t;DEARI;;f;;f;8004322;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Нойштадт-ам-Рюбенберге;;;吕本山麓诺伊施塔特
 7143;Neustadt (Schwarzw);neustadt-schwarzw;8014384;;8.210881;47.910194;;f;DE;f;Europe/Berlin;t;DEARJ;;f;;f;8004331;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7145;Neu-Ulm;neu-ulm;8002089;;10.004823;48.393041;;f;DE;f;Europe/Berlin;t;DEARL;;f;;f;8006730;t;;f;;f;;f;;f;;f;;;;;Nuova Ulma;;;Nuevo Ulm;;ノイウルム;노이울름;;;;Ной-Ульм;;;新乌尔姆
+7145;Neu-Ulm;neu-ulm;8002089;;10.004823;48.393041;;f;DE;f;Europe/Berlin;t;DEARL;;f;;f;8006730;t;;f;;f;;f;;f;;f;;;;;Nuova Ulma;Nuevo Ulm;;;;ノイウルム;노이울름;;;;Ной-Ульм;;;新乌尔姆
 7146;Neukirchen (b Sulzb);neukirchen-b-sulzb;8026224;;11.619537;49.524324;;f;DE;f;Europe/Berlin;t;DEARM;;f;;f;8000269;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Нойкирхен-Зульцбах-Розенберг;;;苏尔茨巴赫-罗森贝格附近新基兴
 7147;Achern;achern;8014283;;8.065319;48.633988;;f;DE;f;Europe/Berlin;t;DEARN;;f;;f;8000412;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Ахерн;;;阿赫恩
 7148;Nassau (Lahn);nassau-lahn;8019606;;7.800695;50.311483;;f;DE;f;Europe/Berlin;t;DEARO;;f;;f;8004206;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5745,7 +5745,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7157;Northeim (Han);northeim-han;8013055;;9.98662;51.703139;;f;DE;f;Europe/Berlin;t;DEARX;;f;;f;8000283;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7158;Nortorf;nortorf;8001405;;9.852581;54.166633;;f;DE;f;Europe/Berlin;t;DEARY;;f;;f;8004466;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7159;Niederlahnstein;niederlahnstein;8019501;;7.599498;50.316391;;f;DE;f;Europe/Berlin;t;DEARZ;;f;;f;8000278;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7160;Niebüll;niebull;8001572;;8.834571;54.789603;;f;DE;f;Europe/Berlin;t;DEASA;;f;;f;8004343;t;;f;;f;;f;;f;;f;;;;;;;Nibøl;;;;;;;;Нибюлль;;;尼比尔
+7160;Niebüll;niebull;8001572;;8.834571;54.789603;;f;DE;f;Europe/Berlin;t;DEASA;;f;;f;8004343;t;;f;;f;;f;;f;;f;;;;;;;;Nibøl;;;;;;;Нибюлль;;;尼比尔
 7161;Neustadt (Waldnaab);neustadt-waldnaab;8026114;;12.168337;49.725916;;f;DE;f;Europe/Berlin;t;DEASB;;f;;f;8004332;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7162;Neuhaus (Pegnitz);neuhaus-pegnitz;8022304;;11.551704;49.626649;;f;DE;f;Europe/Berlin;t;DEASC;;f;;f;8004284;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7163;Nierstein;nierstein;8019060;;8.342735;49.872135;;f;DE;f;Europe/Berlin;t;DEASD;;f;;f;8004432;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5763,7 +5763,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7175;Oberstdorf;oberstdorf;8002381;;10.278095;47.411032;;f;DE;f;Europe/Berlin;t;DEASP;;f;;f;8004585;t;;f;;f;;f;;f;;f;;;;;;;;;;オーベルストドルフ;;;;;Оберстдорф;;;奥伯斯多夫
 7176;Westerstede-Ocholt;westerstede-ocholt;8021232;;7.88647;53.202162;;f;DE;f;Europe/Berlin;t;DEASQ;;f;;f;8004610;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7177;Offenbach (Main) Hbf;offenbach-main-hbf;8011059;;8.760743;50.099265;;f;DE;f;Europe/Berlin;t;DEASR;;f;;f;8000349;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
-7178;Oldenburg (Oldb);oldenburg-oldb;8021204;;8.22246;53.144343;;f;DE;f;Europe/Berlin;t;DEASS;;f;;f;8000291;t;;f;;f;;f;;f;;f;;Oldenbourg;;;;;;Oldenburgo;;オルデンブルク;올덴부르크;;;Oldemburgo;Ольденбург;;;霍尔斯泰因地区奥尔登堡
+7178;Oldenburg (Oldb);oldenburg-oldb;8021204;;8.22246;53.144343;;f;DE;f;Europe/Berlin;t;DEASS;;f;;f;8000291;t;;f;;f;;f;;f;;f;;Oldenbourg;;;;Oldenburgo;;;;オルデンブルク;올덴부르크;;;Oldemburgo;Ольденбург;;;霍尔斯泰因地区奥尔登堡
 7179;Olsberg;olsberg;8008515;;8.484207;51.360497;;f;DE;f;Europe/Berlin;t;DEAST;;f;;f;8004676;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7180;Opladen;opladen;8008186;;7.008772;51.066172;;f;DE;f;Europe/Berlin;t;DEASU;;f;;f;8000853;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7181;Osterburken;osterburken;8029743;;9.422663;49.429956;;f;DE;f;Europe/Berlin;t;DEASV;;f;;f;8000295;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5771,7 +5771,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7183;Oberammergau;oberammergau;8020532;;11.057073;47.599545;;f;DE;f;Europe/Berlin;t;DEASX;;f;;f;8004503;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7184;Oppenheim;oppenheim;8019061;;8.35808;49.857563;;f;DE;f;Europe/Berlin;t;DEASY;;f;;f;8004680;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7185;Oy-Mittelberg;oy-mittelberg;8002318;;10.458131;47.646154;;f;DE;f;Europe/Berlin;t;DEASZ;;f;;f;8004742;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7186;Oldenburg (Holst);oldenburg-holst;8001650;;10.883222;54.283573;;f;DE;f;Europe/Berlin;t;DEATA;;f;;f;8004669;t;;f;;f;;f;;f;;f;;Oldenbourg;;;;;;Oldenburgo;;オルデンブルク;올덴부르크;;;Oldemburgo;Ольденбург;;;霍尔斯泰因地区奥尔登堡
+7186;Oldenburg (Holst);oldenburg-holst;8001650;;10.883222;54.283573;;f;DE;f;Europe/Berlin;t;DEATA;;f;;f;8004669;t;;f;;f;;f;;f;;f;;Oldenbourg;;;;Oldenburgo;;;;オルデンブルク;올덴부르크;;;Oldemburgo;Ольденбург;;;霍尔斯泰因地区奥尔登堡
 7187;Obernburg-Elsenfeld;obernburg-elsenfeld;8022629;;9.154218;49.840736;;f;DE;f;Europe/Berlin;t;DEATB;;f;;f;8004560;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7188;Osterhofen (Oberbay);osterhofen-oberbay;8053415;;11.986881;47.687657;;f;DE;f;Europe/Berlin;t;DEATC;;f;;f;8004701;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7189;Osnabrück Hbf;osnabruck-hbf;8021025;;8.061777;52.272848;;f;DE;f;Europe/Berlin;t;DEATD;;f;;f;8000294;t;;f;;f;;f;;f;108021025;t;;Gare centrale;Main station;;Stazione centrale;;;;;オスナブリュック;오스나브뤼크;;;;Оснабрюк;;;奥斯纳布吕克
@@ -5808,7 +5808,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7220;Remagen;remagen;8019001;;7.229781;50.577213;;f;DE;f;Europe/Berlin;t;DEAUI;;f;;f;8000310;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7221;Remscheid Hbf;remscheid-hbf;8008453;;7.199622;51.17727;7705;f;DE;f;Europe/Berlin;t;DEAUJ;;f;;f;8005033;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;レムシャイト;렘샤이트;;;;Ремшайд;;;雷姆沙伊德
 7222;Remscheid-Lennep;remscheid-lennep;8008452;;7.252829;51.190727;7705;f;DE;f;Europe/Berlin;t;DEAUK;;f;;f;8000311;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7223;Rendsburg;rendsburg;8001409;;9.670712;54.302594;;f;DE;f;Europe/Berlin;t;DEAUL;;f;;f;8000312;t;;f;;f;;f;;f;;f;;Rendsbourg;;;;;Rendsborg;;;;;;;;Рендсбург;;;伦茨堡
+7223;Rendsburg;rendsburg;8001409;;9.670712;54.302594;;f;DE;f;Europe/Berlin;t;DEAUL;;f;;f;8000312;t;;f;;f;;f;;f;;f;;Rendsbourg;;;;;;Rendsborg;;;;;;;Рендсбург;;;伦茨堡
 7224;Retzbach-Zellingen;retzbach-zellingen;8022544;;9.814215;49.905152;;f;DE;f;Europe/Berlin;t;DEAUM;;f;;f;8005049;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7225;Rheine;rheine;8021065;;7.434258;52.2763;;f;DE;f;Europe/Berlin;t;DEAUN;;f;;f;8000316;t;;f;;f;;f;;f;;f;;;;;;;;;;;라이네;;;;Райне;;;赖内
 7226;Rheinfelden (Baden);rheinfelden-baden;8014462;;7.784208;47.556918;;f;DE;f;Europe/Berlin;t;DEAUO;;f;;f;8005064;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5818,7 +5818,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7230;Röthenbach (Allgäu);rothenbach-allgau;8002349;;9.953539;47.620616;;f;DE;f;Europe/Berlin;t;DEAUS;;f;;f;8005138;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7231;Rosenheim;rosenheim;8020174;;12.119113;47.850128;;f;DE;f;Europe/Berlin;t;DEAUT;;f;;f;8000320;t;;f;;f;;f;;f;;f;;;;;;;;;;ローゼンハイム;로젠하임;;;;Розенхайм;;;罗森海姆
 7232;Rot am See;rot-am-see;8029720;;10.030388;49.249398;;f;DE;f;Europe/Berlin;t;DEAUU;;f;;f;8005179;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7233;Regensburg Hbf;regensburg-hbf;8026294;;12.099615;49.011669;;f;DE;f;Europe/Berlin;t;DEAUV;;f;;f;8000309;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Řezno;;Ratisbona;;レーゲンスブルク;레겐스부르크;;Ratyzbona;Regensburgo;Регенсбург;;;雷根斯堡
+7233;Regensburg Hbf;regensburg-hbf;8026294;;12.099615;49.011669;;f;DE;f;Europe/Berlin;t;DEAUV;;f;;f;8000309;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Ratisbona;Řezno;;;レーゲンスブルク;레겐스부르크;;Ratyzbona;Regensburgo;Регенсбург;;;雷根斯堡
 7234;Bad Schwartau;bad-schwartau;8001672;;10.702727;53.916148;;f;DE;f;Europe/Berlin;t;DEAUW;;f;;f;8000749;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7235;Rotenburg a.d. Fulda;rotenburg-a-d-fulda;8005412;;9.733339;50.997854;;f;DE;f;Europe/Berlin;t;DEAUX;;f;;f;8005182;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7236;Rotenburg (Wümme);rotenburg-wumme;8001239;;9.390095;53.112351;;f;DE;f;Europe/Berlin;t;DEAUY;;f;;f;8000321;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Ротенбург-на-Фульде;;;
@@ -5884,7 +5884,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7296;Sontheim-Brenz;sontheim-brenz;8029709;;10.284738;48.560159;;f;DE;f;Europe/Berlin;t;DEAXG;;f;;f;8005608;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7297;Solingen Hbf;solingen-hbf;8008179;;7.004241;51.160909;7711;f;DE;f;Europe/Berlin;t;DEAXH;;f;;f;8000087;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ゾーリンゲン;졸링겐;;;;Золинген;;;索林根
 7298;Schwelm;schwelm;8008136;;7.289685;51.290525;;f;DE;f;Europe/Berlin;t;DEAXI;;f;;f;8000033;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7299;Speyer Hbf;speyer-hbf;8019092;;8.427953;49.324117;;f;DE;f;Europe/Berlin;t;DEAXJ;;f;;f;8005628;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Špýr;;Espira;;シュパイアー;슈파이어;;Spira;;Шпайер;;;施派尔
+7299;Speyer Hbf;speyer-hbf;8019092;;8.427953;49.324117;;f;DE;f;Europe/Berlin;t;DEAXJ;;f;;f;8005628;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Espira;Špýr;;;シュパイアー;슈파이어;;Spira;;Шпайер;;;施派尔
 7300;Stadthagen;stadthagen;8013572;;9.188836;52.332375;;f;DE;f;Europe/Berlin;t;DEAXK;;f;;f;8005662;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7301;Steinach (b Rothenburg);steinach-b-rothenburg;8022693;;10.273537;49.45322;;f;DE;f;Europe/Berlin;t;DEAXL;;f;;f;8000091;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7302;Stolberg (Rheinland) Hbf;stolberg-rheinland-hbf;8015338;;6.218431;50.794914;;f;DE;f;Europe/Berlin;t;DEAXM;;f;;f;8000348;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
@@ -5928,7 +5928,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7340;Tauberbischofsheim;tauberbischofsheim;8029766;;9.658298;49.623628;;f;DE;f;Europe/Berlin;t;DEAYY;;f;;f;8005827;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7341;Timmdorf;timmdorf;8001363;;;;;f;DE;f;Europe/Berlin;f;DEAYZ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7342;Tarp;tarp;8001422;;9.398177;54.664374;;f;DE;f;Europe/Berlin;t;DEAZA;;f;;f;8005825;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7343;Tübingen Hbf;tubingen-hbf;8029317;;9.055409;48.515807;;f;DE;f;Europe/Berlin;t;DEAZB;;f;;f;8000141;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Tubinga;;テュービンゲン;튀빙겐;;Tybinga;Tubinga;Тюбинген;;;蒂宾根
+7343;Tübingen Hbf;tubingen-hbf;8029317;;9.055409;48.515807;;f;DE;f;Europe/Berlin;t;DEAZB;;f;;f;8000141;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Tubinga;;;;テュービンゲン;튀빙겐;;Tybinga;Tubinga;Тюбинген;;;蒂宾根
 7344;Untergrainau;untergrainau;8020288;;11.042816;47.481112;;f;DE;f;Europe/Berlin;t;DEAZC;;f;;f;8017042;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7345;Trebgast;trebgast;8022244;;11.552073;50.066311;;f;DE;f;Europe/Berlin;t;DEAZD;;f;;f;8005895;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7346;Tutting;tutting;8026573;;;;;f;DE;f;Europe/Berlin;f;DEAZE;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5974,12 +5974,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7386;Weißenburg (Bay);weissenburg-bay;8022404;;10.965392;49.029675;;f;DE;f;Europe/Berlin;t;DEBAS;;f;;f;8006298;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Вайсенбург;;;拜恩州魏森堡
 7388;Wernfeld;wernfeld;8022548;;9.725528;50.026066;;f;DE;f;Europe/Berlin;t;DEBAU;;f;;f;8006349;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7389;Weilburg;weilburg;8011441;;8.267945;50.486368;;f;DE;f;Europe/Berlin;t;DEBAV;;f;;f;8000218;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7390;Westerland (Sylt);westerland-sylt;8001583;;8.310311;54.90729;;f;DE;f;Europe/Berlin;t;DEBAW;;f;;f;8006369;t;;f;;f;;f;;f;;f;;;;;;;Vesterland;;;;;;;;Вестерланд;;;
+7390;Westerland (Sylt);westerland-sylt;8001583;;8.310311;54.90729;;f;DE;f;Europe/Berlin;t;DEBAW;;f;;f;8006369;t;;f;;f;;f;;f;;f;;;;;;;;Vesterland;;;;;;;Вестерланд;;;
 7391;Westheim-Langendorf;westheim-langendorf;8022554;;9.932747;50.125775;;f;DE;f;Europe/Berlin;t;DEBAX;;f;;f;8006380;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7392;Wetter (Ruhr);wetter-ruhr;8008067;;7.385968;51.386458;;f;DE;f;Europe/Berlin;t;DEBAY;;f;;f;8006386;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7393;Welschingen-Neuhausen;welschingen-neuhausen;8014555;;8.769219;47.834029;;f;DE;f;Europe/Berlin;t;DEBAZ;;f;;f;8006321;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7394;Wiesau (Oberpf);wiesau-oberpf;8026094;;12.191287;49.911013;;f;DE;f;Europe/Berlin;t;DEBBA;;f;;f;8006403;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7395;Basel Badischer Bahnhof;basel-badischer-bahnhof;8000491;;7.607804;47.567292;5877;f;CH;f;Europe/Berlin;t;DEBBB;;f;;f;8000026;t;;f;;f;;f;;f;;f;;Bâle;;;Basilea;Basilej;;Basilea;Bázel;バーゼル;바젤;Bazel;Bazylea;Basileia;Базель;;;巴塞尔
+7395;Basel Badischer Bahnhof;basel-badischer-bahnhof;8000491;;7.607804;47.567292;5877;f;CH;f;Europe/Berlin;t;DEBBB;;f;;f;8000026;t;;f;;f;;f;;f;;f;;Bâle;;;Basilea;Basilea;Basilej;;Bázel;バーゼル;바젤;Bazel;Bazylea;Basileia;Базель;;;巴塞尔
 7396;Bad Wildbad Bf;bad-wildbad-bf;8029456;;8.551087;48.75572;;f;DE;f;Europe/Berlin;t;DEBBC;;f;;f;8006431;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7397;Wilhelmshaven Hbf;wilhelmshaven-hbf;8021222;;8.115641;53.518717;;f;DE;f;Europe/Berlin;t;DEBBD;;f;;f;8006445;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ヴィルヘルムスハーフェン;빌헬름스하펜;;;;Вильгельмсхафен;;;威廉港
 7398;Bonn-Beuel;bonn-beuel;8015577;;7.127654;50.738479;;f;DE;f;Europe/Berlin;t;DEBBE;;f;;f;8001083;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -5994,7 +5994,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7407;Witzenhausen Nord;witzenhausen-nord;8005493;;9.863081;51.351553;;f;DE;f;Europe/Berlin;t;DEBBN;;f;;f;8006524;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7408;Wörth (Rhein);worth-rhein;8019103;;8.27315;49.045676;;f;DE;f;Europe/Berlin;t;DEBBO;;f;;f;8000254;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7409;Wolfenbüttel;wolfenbuttel;8013344;;10.53231;52.159126;;f;DE;f;Europe/Berlin;t;DEBBP;;f;;f;8000255;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Вольфенбюттель;;;沃爾芬比特爾
-7410;Wolfsburg Hbf;wolfsburg-hbf;8013017;;10.788197;52.429494;;f;DE;f;Europe/Berlin;t;DEBBQ;;f;;f;8006552;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Wolfsburgo;;ヴォルフスブルク;볼프스부르크;;;;Вольфсбург;;;沃尔夫斯堡
+7410;Wolfsburg Hbf;wolfsburg-hbf;8013017;;10.788197;52.429494;;f;DE;f;Europe/Berlin;t;DEBBQ;;f;;f;8006552;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Wolfsburgo;;;;ヴォルフスブルク;볼프스부르크;;;;Вольфсбург;;;沃尔夫斯堡
 7411;Bad Breisig;bad-breisig;8019006;;7.304562;50.50422;;f;DE;f;Europe/Berlin;t;DEBBR;;f;;f;8000694;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7412;Wolfsmünster;wolfsmunster;8022560;;9.734895;50.09451;;f;DE;f;Europe/Berlin;t;DEBBS;;f;;f;8006554;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7413;Worms Hbf;worms-hbf;8019066;;8.356633;49.634748;;f;DE;f;Europe/Berlin;t;DEBBT;;f;;f;8000257;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ヴォルムス;보름스;;Wormacja;;Вормс;;;沃尔姆斯
@@ -6017,7 +6017,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7430;Weißenau;weissenau;8029154;;9.594384;47.765971;;f;DE;f;Europe/Berlin;t;DEBCK;;f;;f;8006296;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7431;Werne a d Lippe;werne-a-d-lippe;8021548;;7.622933;51.669249;;f;DE;f;Europe/Berlin;t;DEBCL;;f;;f;8006348;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7432;Werdohl;werdohl;8008284;;7.757573;51.25944;;f;DE;f;Europe/Berlin;t;DEBCM;;f;;f;8006339;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7433;Zweibrücken Hbf;zweibrucken-hbf;8019778;;7.356646;49.2468;;f;DE;f;Europe/Berlin;t;DEBCN;;f;;f;8006680;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Dos Puentes;;ツヴァイブリュッケン;;;;;Цвайбрюккен;;;茨魏布吕肯
+7433;Zweibrücken Hbf;zweibrucken-hbf;8019778;;7.356646;49.2468;;f;DE;f;Europe/Berlin;t;DEBCN;;f;;f;8006680;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Dos Puentes;;;;ツヴァイブリュッケン;;;;;Цвайбрюккен;;;茨魏布吕肯
 7434;Zwiesel (Bay);zwiesel-bay;8026467;;13.226377;49.020937;;f;DE;f;Europe/Berlin;t;DEBCO;;f;;f;8006684;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7435;Zollhaus;zollhaus;8019550;;;;;f;DE;f;Europe/Berlin;f;DEBCP;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7436;Hedemünden;hedemunden;8005491;;9.762141;51.392166;;f;DE;f;Europe/Berlin;t;DEBCQ;;f;;f;8002677;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6058,13 +6058,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7471;Bochum-Langendreer;bochum-langendreer;8010114;;7.323727;51.478031;7470;f;DE;f;Europe/Berlin;t;DEBLA;;f;;f;8000358;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7472;Bochum Hbf;bochum-hbf;8010179;;7.224109;51.478651;7470;f;DE;f;Europe/Berlin;t;DEQBO;;f;;f;8000041;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ボーフム;보훔;;;;Бохум;;;波鸿
 7473;Bonn Hbf;bonn-hbf;8015485;;7.097136;50.732007;7545;f;DE;f;Europe/Berlin;t;DEBEA;;f;;f;8000044;t;;f;;f;;f;;f;108000044;t;;Gare centrale;Main station;;Stazione centrale;;;;;ボン;본;;;Bona;Бонн;;;波恩
-7474;Hamburg Hbf;hamburg-hbf;8001071;;10.006908;53.552732;7626;f;DE;f;Europe/Berlin;t;DEBEB;;f;;f;8002549;t;;f;;f;;f;;f;108001071;t;;Hambourg Gare centrale;Main station;;Amburgo Stazione centrale;Hamburk;Hamborg;Hamburgo;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
+7474;Hamburg Hbf;hamburg-hbf;8001071;;10.006908;53.552732;7626;f;DE;f;Europe/Berlin;t;DEBEB;;f;;f;8002549;t;;f;;f;;f;;f;108001071;t;;Hambourg Gare centrale;Main station;;Amburgo Stazione centrale;Hamburgo;Hamburk;Hamborg;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
 7475;Düsseldorf Hbf;dusseldorf-hbf;8008094;;6.794316;51.21996;7578;f;DE;f;Europe/Berlin;t;DEBEC;;t;;f;8000085;t;;f;;f;;f;;f;108008094;t;;Gare centrale;Main station;;Stazione centrale;;;;;デュッセルドルフ;뒤셀도르프;;;;Дюссельдорф;;;
 7476;Lindau reutin;lindau-reutin;8000467;;;;;f;DE;f;Europe/Berlin;f;DEBED;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7477;Mittenwald (Gr);mittenwald-gr;8000464;;11.267439;47.39807;7685;f;DE;f;Europe/Berlin;f;DEBEE;;f;;f;8004044;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7478;Mannheim;mannheim;;;;;;t;DE;f;Europe/Berlin;f;DEBEF;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7479;Mannheim Hbf;mannheim-hbf;8014008;;8.469530940055847;49.479295999056305;7478;f;DE;t;Europe/Berlin;t;DEMHG;;t;;f;8000244;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;マンハイム;만하임;;;;Мангейм;;;曼海姆
-7480;München Hbf;munchen-hbf;8020347;;11.558338;48.140228;;f;DE;f;Europe/Berlin;t;DEBEG;;t;;f;8000261;t;;f;;f;;f;;f;;f;;Munich Gare centrale;Munich Main station;;Monaco di Baviera Stazione centrale;Mnichov;;Múnich;;ミュンヘン;뮌헨;;Monachium;Munique;Мюнхен;;Münih;慕尼黑
+7480;München Hbf;munchen-hbf;8020347;;11.558338;48.140228;;f;DE;f;Europe/Berlin;t;DEBEG;;t;;f;8000261;t;;f;;f;;f;;f;;f;;Munich Gare centrale;Munich Main station;;Monaco di Baviera Stazione centrale;Múnich;Mnichov;;;ミュンヘン;뮌헨;;Monachium;Munique;Мюнхен;;Münih;慕尼黑
 7481;Neustadt;neustadt;;;;;;t;DE;f;Europe/Berlin;f;DEBEH;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7482;Neustadt (Weinstr) Hbf;neustadt-weinstr-hbf;8019403;;8.140379;49.34961;7481;f;DE;f;Europe/Berlin;t;DEQNL;;f;;f;8000275;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ノイシュタット・バイ・コーブルク;;;;;Нойштадт-ам-Ренштайг;;;伦斯泰希地区诺伊斯塔特
 7483;Wuppertal;wuppertal;;;;;;t;DE;f;Europe/Berlin;f;DEBEI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6079,9 +6079,9 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7492;Ebersbach (Fils);ebersbach-fils;8029062;;9.526543;48.716194;;f;DE;f;Europe/Berlin;t;DEBEQ;;f;;f;8001632;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7493;Warendorf;warendorf;8021464;;7.985252;51.949992;;f;DE;f;Europe/Berlin;t;DEBER;;f;;f;8006206;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7494;Marienborn;marienborn;8024036;;11.122299;52.198435;;f;DE;f;Europe/Berlin;t;DEBES;;f;;f;8012302;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7495;Löbau (Sachs);lobau-sachs;8006094;;14.671923;51.099396;;f;DE;f;Europe/Berlin;t;DEBET;;f;;f;8010212;t;;f;;f;;f;;f;;f;;;;;;Lobava;;;;;;;;;Лёбау;;;勒鲍
-7496;Weimar;weimar;8016019;;11.326462;50.99149;;f;DE;f;Europe/Berlin;t;DEBEU;;f;;f;8010366;t;;f;;f;;f;;f;;f;;;;;;Výmar;;;;ヴァイマル;바이마르;;;;Веймар;;;魏玛
-7497;Naumburg (Saale) Hbf;naumburg-saale-hbf;8016011;;11.796984;51.163067;;f;DE;f;Europe/Berlin;t;DEBEW;;f;;f;8010240;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Naumburgo;;ナウムブルク;나움부르크;;;;Наумбург;;;瑙姆堡
+7495;Löbau (Sachs);lobau-sachs;8006094;;14.671923;51.099396;;f;DE;f;Europe/Berlin;t;DEBET;;f;;f;8010212;t;;f;;f;;f;;f;;f;;;;;;;Lobava;;;;;;;;Лёбау;;;勒鲍
+7496;Weimar;weimar;8016019;;11.326462;50.99149;;f;DE;f;Europe/Berlin;t;DEBEU;;f;;f;8010366;t;;f;;f;;f;;f;;f;;;;;;;Výmar;;;ヴァイマル;바이마르;;;;Веймар;;;魏玛
+7497;Naumburg (Saale) Hbf;naumburg-saale-hbf;8016011;;11.796984;51.163067;;f;DE;f;Europe/Berlin;t;DEBEW;;f;;f;8010240;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Naumburgo;;;;ナウムブルク;나움부르크;;;;Наумбург;;;瑙姆堡
 7498;Weißenfels;weissenfels;8016008;;11.9708;51.204831;;f;DE;f;Europe/Berlin;t;DEBEY;;f;;f;8010368;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7499;Wurzen;wurzen;8023481;;12.738973;51.364416;;f;DE;f;Europe/Berlin;t;DEBEZ;;f;;f;8013361;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7500;Berlin-Lichtenberg;berlin-lichtenberg;8003231;;13.496925;52.509894;7527;f;DE;f;Europe/Berlin;t;DEBFC;;f;;f;8010036;t;;f;;f;;f;;f;;f;;;;;Berlino;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
@@ -6100,10 +6100,10 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7513;Berlin Zoologischer Garten;berlin-zoologischer-garten;8003036;;13.331991;52.507278;7527;f;DE;f;Europe/Berlin;t;DEBFW;;f;;f;8010406;t;;f;;f;;f;;f;;f;;;;;Berlino;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
 7514;Bad Kleinen;bad-kleinen;8027016;;11.466927;53.766972;;f;DE;f;Europe/Berlin;t;DEBFX;;f;;f;8010018;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7515;Bitterfeld;bitterfeld;8023148;;12.316704;51.623108;;f;DE;f;Europe/Berlin;t;DEBFZ;;f;;f;8010050;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7516;Bautzen;bautzen;8006099;;14.428738;51.173099;;f;DE;f;Europe/Berlin;t;DEBHA;;f;;f;8010026;t;;f;;f;;f;;f;;f;;;;;;Budyšín;;;;バウツェン;;;Budziszyn;;Баутцен;;;包岑
+7516;Bautzen;bautzen;8006099;;14.428738;51.173099;;f;DE;f;Europe/Berlin;t;DEBHA;;f;;f;8010026;t;;f;;f;;f;;f;;f;;;;;;;Budyšín;;;バウツェン;;;Budziszyn;;Баутцен;;;包岑
 7517;Bühl (Baden);buhl-baden;8014281;;8.129295;48.696678;;f;DE;f;Europe/Berlin;t;DEBHB;;f;;f;8001252;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бюль;;;
 7518;Dresde;dresde;;;;;;t;DE;f;Europe/Berlin;f;DEBHD;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7519;Dresden Hbf;dresden-hbf;8006050;;13.732038;51.040562;7518;f;DE;f;Europe/Berlin;t;DEDRS;;f;;f;8010085;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Drážďany;;Dresde;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
+7519;Dresden Hbf;dresden-hbf;8006050;;13.732038;51.040562;7518;f;DE;f;Europe/Berlin;t;DEDRS;;f;;f;8010085;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Dresde;Drážďany;;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
 7520;Bad Hersfeld;bad-hersfeld;8005647;;9.716179;50.869632;;f;DE;f;Europe/Berlin;t;DEBHF;;f;;f;8000020;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7521;Eisenach;eisenach;8016077;;10.332147;50.977089;;f;DE;f;Europe/Berlin;t;DEBHG;;f;;f;8010097;t;;f;;f;;f;;f;;f;;;;;;;;;;アイゼナハ;아이제나흐;;;;Айзенах;;;艾森纳赫
 7522;Buchholz (Nordheide);buchholz-nordheide;8001233;;9.876592;53.324568;;f;DE;f;Europe/Berlin;t;DEBHH;;f;;f;8000056;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6132,7 +6132,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7545;Bonn;bonn;;;;;;t;DE;f;Europe/Berlin;f;DEBNJ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7546;Buchloe;buchloe;8002181;;10.71622;48.033724;;f;DE;f;Europe/Berlin;t;DEBOE;;f;;f;8000057;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7547;Boppard Hbf;boppard-hbf;8019029;;7.586104;50.231416;;f;DE;f;Europe/Berlin;t;DEBPP;;f;;f;8000045;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
-7548;Bremen Hbf;bremen-hbf;8013750;;8.813833;53.083477;;f;DE;f;Europe/Berlin;t;DEBRE;;f;;f;8000050;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Brémy;;;Bréma;ブレーメン;브레멘;;Brema;;Бремен;;;不来梅
+7548;Bremen Hbf;bremen-hbf;8013750;;8.813833;53.083477;;f;DE;f;Europe/Berlin;t;DEBRE;;f;;f;8000050;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Brémy;;Bréma;ブレーメン;브레멘;;Brema;;Бремен;;;不来梅
 7549;Bensheim;bensheim;8011306;;8.616978;49.681231;;f;DE;f;Europe/Berlin;t;DEBSH;;f;;f;8000031;t;;f;;f;;f;;f;;f;;;;;;;;;;ベンスハイム;;;;;Бенсхайм;;;本斯海姆
 7550;Berlin-Spandau;berlin-spandau;8003025;;13.19753;52.53447;7527;f;DE;f;Europe/Berlin;t;DEBSP;;f;;f;8010404;t;;f;;f;;f;;f;;f;;;;;Berlino;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
 7551;Brunswick;brunswick;8013241;;;;;f;DE;f;Europe/Berlin;f;DEBSW;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6141,17 +6141,17 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7554;Bayreuth Hbf;bayreuth-hbf;8022248;;11.579985;49.949613;;f;DE;f;Europe/Berlin;t;DEBYU;;f;;f;8000028;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;バイロイト;바이로이트;;;;Байройт;;;拜罗伊特
 7555;Butzbach;butzbach;8011407;;8.66952;50.431156;;f;DE;f;Europe/Berlin;t;DEBZB;;f;;f;8001312;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7556;Bützow;butzow;8027021;;11.997749;53.836809;;f;DE;f;Europe/Berlin;t;DEBZW;;f;;f;8010066;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бютцов;;;比措
-7557;Cottbus;cottbus;8004019;;14.324158;51.750952;;f;DE;f;Europe/Berlin;t;DECBU;;f;;f;8010073;t;;f;;f;;f;;f;;f;;;;;;Chotěbuz;;;;コトブス;콧부스;;Chociebuż;;Котбус;;;科特布斯
-7558;Köln;koln;;;6.967206;50.941312;;t;DE;f;Europe/Berlin;t;DECGN;;t;;f;8096022;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Kolín nad Rýnem;;Colonia;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
-7559;Köln-Mülheim;koln-mulheim;8015541;;7.013294;50.957987;7558;f;DE;f;Europe/Berlin;t;DEKOM;;f;;f;8000209;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Kolín nad Rýnem;;Colonia;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
-7560;Köln Messe/Deutz;koln-messe-deutz;8015561;;6.975;50.940871;7558;f;DE;f;Europe/Berlin;t;DEKOD;;f;;f;8003368;t;QKU;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Kolín nad Rýnem;;Colonia;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
-7561;Köln Hbf;koln-hbf;8015458;80154583;6.958729;50.943029;7558;f;DE;t;Europe/Berlin;t;DEKOH;;t;;f;8000207;t;;f;;f;;f;;f;108015458;t;;Cologne Gare centrale;Cologne Main station;;Colonia Stazione centrale;Kolín nad Rýnem;;Colonia;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
+7557;Cottbus;cottbus;8004019;;14.324158;51.750952;;f;DE;f;Europe/Berlin;t;DECBU;;f;;f;8010073;t;;f;;f;;f;;f;;f;;;;;;;Chotěbuz;;;コトブス;콧부스;;Chociebuż;;Котбус;;;科特布斯
+7558;Köln;koln;;;6.967206;50.941312;;t;DE;f;Europe/Berlin;t;DECGN;;t;;f;8096022;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
+7559;Köln-Mülheim;koln-mulheim;8015541;;7.013294;50.957987;7558;f;DE;f;Europe/Berlin;t;DEKOM;;f;;f;8000209;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
+7560;Köln Messe/Deutz;koln-messe-deutz;8015561;;6.975;50.940871;7558;f;DE;f;Europe/Berlin;t;DEKOD;;f;;f;8003368;t;QKU;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
+7561;Köln Hbf;koln-hbf;8015458;80154583;6.958729;50.943029;7558;f;DE;t;Europe/Berlin;t;DEKOH;;t;;f;8000207;t;;f;;f;;f;;f;108015458;t;;Cologne Gare centrale;Cologne Main station;;Colonia Stazione centrale;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
 7562;Celle;celle;8013631;;10.062704;52.621171;;f;DE;f;Europe/Berlin;t;DECLL;;f;;f;8000064;t;;f;;f;;f;;f;;f;;Allemagne;Germany;Deutschland;Germania;;;;;ツェレ;첼레;;;;Целле;;;策勒
 7563;Cochem (Mosel);cochem-mosel;8025107;;7.166739;50.153093;;f;DE;f;Europe/Berlin;t;DECMO;;f;;f;8001340;t;;f;;f;;f;;f;;f;;;;;;;;;;コッヘム;;;;;Кохем;;;科赫姆
 7564;Crailsheim;crailsheim;8029685;;10.064322;49.137869;;f;DE;f;Europe/Berlin;t;DECRH;;f;;f;8000067;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7565;Creußen (Oberfr);creussen-oberfr;8022296;;11.628445;49.849473;;f;DE;f;Europe/Berlin;t;DECSS;;f;;f;8001348;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7566;Cuxhaven;cuxhaven;8001205;;8.703706;53.861008;;f;DE;f;Europe/Berlin;t;DECUX;;f;;f;8001352;t;;f;;f;;f;;f;;f;;;;;;;;;;;쿡스하펜;;;;Куксхафен;;;库克斯港
-7567;Brandenburg Hbf;brandenburg-hbf;8024019;;12.566245;52.400765;;f;DE;f;Europe/Berlin;t;DEDBG;;f;;f;8010060;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Brandeburgo;;ブランデンブルク・アン・デア・ハーフェル;브란덴부르크안데어하펠;;;;Бранденбург-на-Хафеле;;;哈弗尔河畔勃兰登堡
+7567;Brandenburg Hbf;brandenburg-hbf;8024019;;12.566245;52.400765;;f;DE;f;Europe/Berlin;t;DEDBG;;f;;f;8010060;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Brandeburgo;;;;ブランデンブルク・アン・デア・ハーフェル;브란덴부르크안데어하펠;;;;Бранденбург-на-Хафеле;;;哈弗尔河畔勃兰登堡
 7568;Dombühl;dombuhl;8022742;;10.298518;49.252113;;f;DE;f;Europe/Berlin;t;DEDMB;;f;;f;8000365;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7569;Delmenhorst;delmenhorst;8013828;;8.629761;53.052788;;f;DE;f;Europe/Berlin;t;DEDMH;;f;;f;8000070;t;;f;;f;;f;;f;;f;;;;;;;;;;デルメンホルスト;;;;;Дельменхорст;;;代尔门霍斯特
 7570;Donaueschingen;donaueschingen;8014529;;8.498923;47.947787;;f;DE;f;Europe/Berlin;t;DEDNE;;f;;f;8000077;t;;f;;f;;f;;f;;f;;;;;;;;;;ドナウエッシンゲン;;;;;Донауэшинген;;;多瑙艾辛根
@@ -6160,7 +6160,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7573;Dortmund Hbf;dortmund-hbf;8010053;;7.459293;51.517898;;f;DE;f;Europe/Berlin;t;DEDTM;;f;;f;8000080;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ドルトムント;도르트문트;;;;Дортмунд;;;多特蒙德
 7574;Düsseldorf-Benrath;dusseldorf-benrath;8008117;;6.87904;51.162375;7578;f;DE;f;Europe/Berlin;t;DEDUB;;f;;f;8001584;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Дюссельдорф-Бенрат;;;
 7575;Düsseldorf Flughafen;dusseldorf-flughafen;8039904;;6.786837;51.292008;7578;f;DE;f;Europe/Berlin;t;DEDUF;;t;;f;8000082;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;デュッセルドルフ;뒤셀도르프;;;;Дюссельдорф;;;
-7576;Duisburg Hbf;duisburg-hbf;8010316;;6.775906;51.429786;;f;DE;f;Europe/Berlin;t;DEDUI;;t;;f;8000086;t;;f;;f;;f;;f;108010316;t;;Duisbourg Gare centrale;Main station;;Stazione centrale;;;Duisburgo;;デュイスブルク;뒤스부르크;;;Duisburgo;Дуйсбург;;;杜伊斯堡
+7576;Duisburg Hbf;duisburg-hbf;8010316;;6.775906;51.429786;;f;DE;f;Europe/Berlin;t;DEDUI;;t;;f;8000086;t;;f;;f;;f;;f;108010316;t;;Duisbourg Gare centrale;Main station;;Stazione centrale;Duisburgo;;;;デュイスブルク;뒤스부르크;;;Duisburgo;Дуйсбург;;;杜伊斯堡
 7577;Düren;duren;8015330;;6.482031;50.809395;;f;DE;f;Europe/Berlin;t;DEDUR;;f;;f;8000084;t;;f;;f;;f;;f;;f;;;;;;;;;;;뒤렌;;;;Дюрен;;;迪伦
 7578;Düsseldorf;dusseldorf;8080260;;;;;t;DE;f;Europe/Berlin;f;DEDUS;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7579;Eberbach;eberbach;8014121;;8.984152;49.465769;;f;DE;f;Europe/Berlin;t;DEEBB;;f;;f;8000369;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6172,23 +6172,23 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7585;Ellwangen;ellwangen;8029693;;10.129683;48.964117;;f;DE;f;Europe/Berlin;t;DEELW;;f;;f;8001751;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7586;Emden Hbf;emden-hbf;8021099;;7.19501;53.369011;;f;DE;f;Europe/Berlin;t;DEEME;;f;;f;8001768;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;エムデン;엠덴;;;;Эмден;;;埃姆登
 7587;Engen;engen;8014554;;8.772788;47.856349;;f;DE;f;Europe/Berlin;t;DEENG;;f;;f;8001790;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7588;Erfurt Hbf;erfurt-hbf;8016043;;11.038501;50.972549;;f;DE;f;Europe/Berlin;t;DEERF;;f;;f;8010101;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Érfurt;;エアフルト;에르푸르트;;;;Эрфурт;;;埃尔福特
+7588;Erfurt Hbf;erfurt-hbf;8016043;;11.038501;50.972549;;f;DE;f;Europe/Berlin;t;DEERF;;f;;f;8010101;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Érfurt;;;;エアフルト;에르푸르트;;;;Эрфурт;;;埃尔福特
 7589;Erkelenz;erkelenz;8015183;;6.321717;51.076564;;f;DE;f;Europe/Berlin;t;DEERK;;f;;f;8001839;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7590;Esslingen-am-Neckar;esslingen-am-neckar;8029054;;;;;f;DE;f;Europe/Berlin;f;DEESN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7591;Essen Hbf;essen-hbf;8010184;;7.014795;51.451351;;f;DE;f;Europe/Berlin;t;DEESS;;t;;f;8000098;t;ESX;t;;f;;f;;f;108010184;t;;Gare centrale;Main station;;Stazione centrale;;;;;エッセン;에센;;;;Эссен;;;埃森
 7592;Fürth (Bay) Hbf;furth-bay-hbf;8022187;;10.989987;49.469706;;f;DE;f;Europe/Berlin;t;DEFBH;;f;;f;8000114;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;フュルト;퓌르트;;;;Фюрт;;;菲尔特
 7593;Plauen (Vogtl) ob Bf;plauen-vogtl-ob-bf;8006712;;12.12954;50.505937;;f;DE;f;Europe/Berlin;t;DEFBS;;f;;f;8010275;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7594;Friedrichshafen Stadt;friedrichshafen-stadt;8029162;;9.473902;47.65322;;f;DE;f;Europe/Berlin;t;DEFDH;;f;;f;8000112;t;;f;;f;;f;;f;;f;;;;;;;;;;フリードリヒスハーフェン;;;;;Фридрихсхафен;;;腓特烈港
-7596;Frankfurt (M) Flughafen Fernbf;frankfurt-m-flughafen-fernbf;8061676;;8.569872379302979;50.05290581298199;;f;DE;f;Europe/Berlin;t;DEFFF;;t;;f;8070003;t;;f;;f;;f;;f;;f;;Francfort Aéroport;Airport;;Francoforte Aeroporto;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-7597;Freiburg (Breisgau) Hbf;freiburg-breisgau-hbf;8014350;80143503;7.841593623161316;47.997690269936264;7692;f;DE;t;Europe/Berlin;t;DEFGB;;t;;f;8000107;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Freiberg;;フライベルク;;Freiberg;Freiberg;Freiberga;Фрайбург;Freiberg;;弗莱贝格
+7596;Frankfurt (M) Flughafen Fernbf;frankfurt-m-flughafen-fernbf;8061676;;8.569872379302979;50.05290581298199;;f;DE;f;Europe/Berlin;t;DEFFF;;t;;f;8070003;t;;f;;f;;f;;f;;f;;Francfort Aéroport;Airport;;Francoforte Aeroporto;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+7597;Freiburg (Breisgau) Hbf;freiburg-breisgau-hbf;8014350;80143503;7.841593623161316;47.997690269936264;7692;f;DE;t;Europe/Berlin;t;DEFGB;;t;;f;8000107;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Freiberg;;;;フライベルク;;Freiberg;Freiberg;Freiberga;Фрайбург;Freiberg;;弗莱贝格
 7598;Bergen auf Rügen;bergen-auf-rugen;8028496;;13.41782;54.420497;;f;DE;f;Europe/Berlin;t;DEFGV;;f;;f;8010033;t;;f;;f;;f;;f;;f;;;;;;;;;;;베르겐아우프뤼겐;;;;Берген-на-Рюгене;;;贝尔根奥夫吕根
 7599;Binz LB;binz-lb;8028951;;13.609947;54.392783;;f;DE;f;Europe/Berlin;t;DEFHA;;f;;f;8011193;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7600;Freilassing;freilassing;8000462;;12.977196;47.836914;;f;DE;f;Europe/Berlin;t;DEFLS;;f;;f;8000108;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7601;Reichenbach (Vogtl) ob Bf;reichenbach-vogtl-ob-bf;8006704;;12.293117;50.627777;;f;DE;f;Europe/Berlin;t;DEFLW;;f;;f;8012739;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7602;Frankfurt (Main);frankfurt-main;;;8.663785;50.107149;;t;DE;f;Europe/Berlin;t;DEFRA;;t;;f;8096021;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-7603;Frankfurt (Main) Süd;frankfurt-main-sud;8011065;;8.686303;50.09958;7602;f;DE;f;Europe/Berlin;t;DEFRS;;f;;f;8002041;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-7604;Frankfurt (Main) Hbf;frankfurt-main-hbf;8011068;;8.663785;50.107149;7602;f;DE;t;Europe/Berlin;t;DEFRH;;t;;f;8000105;t;;f;;f;;f;;f;108000105;t;;Francfort Gare centrale;Main station;;Francoforte Stazione centrale;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-7605;Frankfurt-Höchst;frankfurt-hochst;8011100;;8.542368;50.102636;7602;f;DE;f;Europe/Berlin;t;DEFRO;;f;;f;8000106;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+7602;Frankfurt (Main);frankfurt-main;;;8.663785;50.107149;;t;DE;f;Europe/Berlin;t;DEFRA;;t;;f;8096021;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+7603;Frankfurt (Main) Süd;frankfurt-main-sud;8011065;;8.686303;50.09958;7602;f;DE;f;Europe/Berlin;t;DEFRS;;f;;f;8002041;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+7604;Frankfurt (Main) Hbf;frankfurt-main-hbf;8011068;;8.663785;50.107149;7602;f;DE;t;Europe/Berlin;t;DEFRH;;t;;f;8000105;t;;f;;f;;f;;f;108000105;t;;Francfort Gare centrale;Main station;;Francoforte Stazione centrale;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+7605;Frankfurt-Höchst;frankfurt-hochst;8011100;;8.542368;50.102636;7602;f;DE;f;Europe/Berlin;t;DEFRO;;f;;f;8000106;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 7606;Freudenstadt;freudenstadt;;;;;;t;DE;f;Europe/Berlin;f;DEFRE;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7607;Gengenbach;gengenbach;8014497;;8.010188;48.404655;;f;DE;f;Europe/Berlin;t;DEGGB;;f;;f;8002235;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7608;Gießen;giessen;8011033;;8.661466;50.579056;;f;DE;f;Europe/Berlin;t;DEGIE;;f;;f;8000124;t;;f;;f;;f;;f;;f;;;;;;;;;;ギーセン;기센;;;;Гиссен;;;吉森
@@ -6196,7 +6196,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7610;Gelnhausen;gelnhausen;8011044;;9.189276;50.19634;;f;DE;f;Europe/Berlin;t;DEGLN;;f;;f;8000117;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7611;Gelsenkirchen Hbf;gelsenkirchen-hbf;8010143;;7.102583;51.505016;;f;DE;f;Europe/Berlin;t;DEGLS;;f;;f;8000118;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ゲルゼンキルヒェン;겔젠키르헨;;;;Гельзенкирхен;;;盖尔森基兴
 7612;Gemünden (Main);gemunden-main;8022549;;9.699891;50.050013;;f;DE;f;Europe/Berlin;t;DEGMM;;f;;f;8000120;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7613;Göttingen;gottingen;8013050;;9.925682;51.536614;;f;DE;f;Europe/Berlin;t;DEGOE;;f;;f;8000128;t;;f;;f;;f;;f;;f;;Gœttingue;;;Gottinga;;;Gotinga;;ゲッティンゲン;괴팅겐;;Getynga;Gotinga;Гёттинген;;;哥廷根
+7613;Göttingen;gottingen;8013050;;9.925682;51.536614;;f;DE;f;Europe/Berlin;t;DEGOE;;f;;f;8000128;t;;f;;f;;f;;f;;f;;Gœttingue;;;Gottinga;Gotinga;;;;ゲッティンゲン;괴팅겐;;Getynga;Gotinga;Гёттинген;;;哥廷根
 7614;Göppingen;goppingen;8029065;;9.651969;48.700022;;f;DE;f;Europe/Berlin;t;DEGPG;;f;;f;8000127;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гёппинген;;;格平根
 7615;Graben-Neudorf;graben-neudorf;8014068;;8.490545;49.162284;;f;DE;f;Europe/Berlin;t;DEGRN;;f;;f;8000131;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7616;Großkorbetha;grosskorbetha;8023011;;12.022173;51.267315;;f;DE;f;Europe/Berlin;t;DEGRO;;f;;f;8010146;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6205,13 +6205,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7619;Geislingen (Steige);geislingen-steige;8029086;;9.841821;48.61947;;f;DE;f;Europe/Berlin;t;DEGSS;;f;;f;8002218;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7620;Gutach schwarzwaldb;gutach-schwarzwaldb;8014510;;;;;f;DE;f;Europe/Berlin;f;DEGTC;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7621;Baunatal-Guntershausen;baunatal-guntershausen;8005369;;9.466998;51.22992;;f;DE;f;Europe/Berlin;t;DEGTH;;f;;f;8000140;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7622;Günzburg;gunzburg;8002084;;10.278652;48.460334;;f;DE;f;Europe/Berlin;t;DEGZB;;f;;f;8000139;t;;f;;f;;f;;f;;f;;Guntzbourg;;;;;;Gunzburgo;;ギュンツブルク;;;;;Гюнцбург;;;金茨堡
+7622;Günzburg;gunzburg;8002084;;10.278652;48.460334;;f;DE;f;Europe/Berlin;t;DEGZB;;f;;f;8000139;t;;f;;f;;f;;f;;f;;Guntzbourg;;;;Gunzburgo;;;;ギュンツブルク;;;;;Гюнцбург;;;金茨堡
 7623;Hannover;hannover;;;;;;t;DE;f;Europe/Berlin;f;DEHAJ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7624;Hannover Messe/Laatzen;hannover-messe-laatzen;8013555;;9.792866;52.316895;7623;f;DE;f;Europe/Berlin;t;DELAA;;f;;f;8003487;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7625;Hamburg-Altona;hamburg-altona;8001093;;9.935174;53.552696;7626;f;DE;f;Europe/Berlin;t;DEHAL;;f;;f;8002553;t;;f;;f;;f;;f;108001093;t;;Hambourg;;;Amburgo;Hamburk;Hamborg;Hamburgo;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
-7626;Hamburg;hamburg;8001083;;9.965836;53.563816;;t;DE;f;Europe/Berlin;t;DEHAM;;f;;f;8096009;t;;f;;f;;f;;f;;f;;Hambourg;;;Amburgo;Hamburk;Hamborg;Hamburgo;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
-7627;Hamburg Dammtor;hamburg-dammtor;8001089;;9.989568;53.560751;7626;f;DE;f;Europe/Berlin;t;DEHDA;;f;;f;8002548;t;;f;;f;;f;;f;;f;;Hambourg;;;Amburgo;Hamburk;Hamborg;Hamburgo;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
-7628;Hamburg-Harburg;hamburg-harburg;8001134;;9.991591;53.456296;7626;f;DE;f;Europe/Berlin;t;DEHHA;;f;;f;8000147;t;;f;;f;;f;;f;108001134;t;;Hambourg;;;Amburgo;Hamburk;Hamborg;Hamburgo;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
+7625;Hamburg-Altona;hamburg-altona;8001093;;9.935174;53.552696;7626;f;DE;f;Europe/Berlin;t;DEHAL;;f;;f;8002553;t;;f;;f;;f;;f;108001093;t;;Hambourg;;;Amburgo;Hamburgo;Hamburk;Hamborg;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
+7626;Hamburg;hamburg;8001083;;9.965836;53.563816;;t;DE;f;Europe/Berlin;t;DEHAM;;f;;f;8096009;t;;f;;f;;f;;f;;f;;Hambourg;;;Amburgo;Hamburgo;Hamburk;Hamborg;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
+7627;Hamburg Dammtor;hamburg-dammtor;8001089;;9.989568;53.560751;7626;f;DE;f;Europe/Berlin;t;DEHDA;;f;;f;8002548;t;;f;;f;;f;;f;;f;;Hambourg;;;Amburgo;Hamburgo;Hamburk;Hamborg;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
+7628;Hamburg-Harburg;hamburg-harburg;8001134;;9.991591;53.456296;7626;f;DE;f;Europe/Berlin;t;DEHHA;;f;;f;8000147;t;;f;;f;;f;;f;108001134;t;;Hambourg;;;Amburgo;Hamburgo;Hamburk;Hamborg;;ハンブルク;함부르크;;;Hamburgo;Гамбург;;;汉堡市
 7629;Hanau Hbf;hanau-hbf;8011051;;8.929165;50.12128;;f;DE;f;Europe/Berlin;t;DEHAU;;f;;f;8000150;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ハーナウ;;;;;;;;
 7630;Berlin Hbf;berlin-hbf;8033452;80334524;13.369548;52.525589;7527;f;DE;t;Europe/Berlin;t;DEHBF;;f;;f;8011160;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Berlino Stazione centrale;;;;;ベルリン;베를린;Berlijn;;Berlim;Берлин;;;柏林
 7631;Heilbronn Hbf;heilbronn-hbf;8029629;;9.207713;49.143308;;f;DE;f;Europe/Berlin;t;DEHBN;;f;;f;8000157;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ハイルブロン;하일브론;;;;Хайльбронн;;;海尔布隆
@@ -6257,16 +6257,16 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7671;Kassel Hbf;kassel-hbf;8005361;;9.489498;51.318257;16766;f;DE;f;Europe/Berlin;t;DEKSF;;f;;f;8000193;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;カッセル;카셀;;;;Кассель;;;卡塞尔
 7672;Karlstadt (Main);karlstadt-main;8022546;;9.768146;49.962899;;f;DE;f;Europe/Berlin;t;DEKST;;f;;f;8003189;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7673;Konstanz;konstanz;8014586;;;;;t;DE;f;Europe/Berlin;f;DEKSZ;;f;;f;;f;;f;;f;;f;;f;;f;7674;;;;;;;;;;;;;;;;;
-7674;Konstanz;konstanz;8000495;;9.177312;47.658757;7673;f;DE;f;Europe/Berlin;t;DEQKZ;;f;;f;8003400;t;;f;;f;;f;;f;;f;;Constance;;;Costanza;Kostnice;;Constanza;;コンスタンツ;콘스탄츠;;Konstancja;Constança;Констанц;;;康斯坦茨
+7674;Konstanz;konstanz;8000495;;9.177312;47.658757;7673;f;DE;f;Europe/Berlin;t;DEQKZ;;f;;f;8003400;t;;f;;f;;f;;f;;f;;Constance;;;Costanza;Constanza;Kostnice;;;コンスタンツ;콘스탄츠;;Konstancja;Constança;Констанц;;;康斯坦茨
 7675;Kitzingen;kitzingen;8022525;;10.155212;49.732497;;f;DE;f;Europe/Berlin;t;DEKTZ;;f;;f;8000479;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7676;Lübeck Hbf;lubeck-hbf;8000630;;10.670348;53.867768;;f;DE;f;Europe/Berlin;t;DELBC;;f;;f;8000237;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Lubeca;;リューベック;뤼베크;;Lubeka;;Любек;;;吕贝克
+7676;Lübeck Hbf;lubeck-hbf;8000630;;10.670348;53.867768;;f;DE;f;Europe/Berlin;t;DELBC;;f;;f;8000237;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Lubeca;;;;リューベック;뤼베크;;Lubeka;;Любек;;;吕贝克
 7677;Lubeck;lubeck;;;;;;t;DE;f;Europe/Berlin;f;DELBK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7678;Leipzig Hbf;leipzig-hbf;8023179;;12.383333;51.346546;16756;f;DE;t;Europe/Berlin;t;DELEJ;;f;;f;8010205;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Lipsko;;;Lipcse;ライプツィヒ;라이프치히;;Lipsk;Lípsia;Лейпциг;;;莱比锡
+7678;Leipzig Hbf;leipzig-hbf;8023179;;12.383333;51.346546;16756;f;DE;t;Europe/Berlin;t;DELEJ;;f;;f;8010205;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Lipsko;;Lipcse;ライプツィヒ;라이프치히;;Lipsk;Lípsia;Лейпциг;;;莱比锡
 7679;Lindau Hbf;lindau-hbf;8002371;;9.680303;47.544738;;f;DE;f;Europe/Berlin;t;DELIN;;f;;f;8000230;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;リンダウ;;;;;Линдау;;;林道
 7680;Leverkusen;leverkusen;;;;;;t;DE;f;Europe/Berlin;f;DELVK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7681;München Flughafen Terminal;munchen-flughafen-terminal;8020658;;11.785972;48.353731;;f;DE;f;Europe/Berlin;t;DEMIG;;f;;f;8004168;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;;;;;;;;;;;
 7682;Marktredwitz;marktredwitz;8026071;;12.08258;50.0046;;f;DE;f;Europe/Berlin;t;DEMKZ;;f;;f;8000247;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7683;München Ost;munchen-ost;8020234;;11.604975;48.127437;;f;DE;f;Europe/Berlin;t;DEMOS;;f;;f;8000262;t;;f;;f;;f;;f;;f;;Munich;Munich;;Monaco di Baviera;Mnichov;;Múnich;;ミュンヘン;뮌헨;;Monachium;Munique;Мюнхен;;Münih;慕尼黑
+7683;München Ost;munchen-ost;8020234;;11.604975;48.127437;;f;DE;f;Europe/Berlin;t;DEMOS;;f;;f;8000262;t;;f;;f;;f;;f;;f;;Munich;Munich;;Monaco di Baviera;Múnich;Mnichov;;;ミュンヘン;뮌헨;;Monachium;Munique;Мюнхен;;Münih;慕尼黑
 7684;München-Pasing;munchen-pasing;8020286;;11.461489;48.149892;;f;DE;f;Europe/Berlin;t;DEMPS;;f;;f;8004158;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7685;Mittenwald;mittenwald;8103332;;;;;t;DE;f;Europe/Berlin;f;DEMTW;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7686;München;munchen;;;;;;t;DE;f;Europe/Berlin;f;DEMUC;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6274,7 +6274,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7688;Neuburg (Donau);neuburg-donau;8002047;;11.178373;48.727215;;f;DE;f;Europe/Berlin;t;DENBG;;f;;f;8004254;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7689;Neu Isenburg;neu-isenburg;8011092;;8.66561;50.053052;;f;DE;f;Europe/Berlin;t;DENEI;;f;;f;8004246;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7690;Neuenmarkt-Wirsberg;neuenmarkt-wirsberg;8022006;;11.581306;50.093746;;f;DE;f;Europe/Berlin;t;DENEM;;f;;f;8000267;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7691;Nürnberg Hbf;nurnberg-hbf;8022193;;11.082989;49.445615;;f;DE;f;Europe/Berlin;t;DENUE;;f;;f;8000284;t;;f;;f;;f;;f;;f;;Nuremberg Gare centrale;Nuremberg Main station;;Norimberga Stazione centrale;Norimberk;;Núremberg;;ニュルンベルク;뉘른베르크;Neurenberg;Norymberga;Nuremberga;Нюрнберг;;Nuremberg;纽伦堡
+7691;Nürnberg Hbf;nurnberg-hbf;8022193;;11.082989;49.445615;;f;DE;f;Europe/Berlin;t;DENUE;;f;;f;8000284;t;;f;;f;;f;;f;;f;;Nuremberg Gare centrale;Nuremberg Main station;;Norimberga Stazione centrale;Núremberg;Norimberk;;;ニュルンベルク;뉘른베르크;Neurenberg;Norymberga;Nuremberga;Нюрнберг;;Nuremberg;纽伦堡
 7692;Fribourg-en-Brisgau;fribourg-en-brisgau;;;;;;t;DE;f;Europe/Berlin;f;DEOFB;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7693;Oschatz;oschatz;8006237;;13.105742;51.311739;;f;DE;f;Europe/Berlin;t;DEOSC;;f;;f;8013461;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7694;Pfronten;pfronten;;;;;;t;DE;f;Europe/Berlin;f;DEPFT;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6284,14 +6284,14 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7698;Pegnitz;pegnitz;8022298;;11.547542;49.75834;;f;DE;f;Europe/Berlin;t;DEPGN;;f;;f;8004759;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7699;Mayen Ost;mayen-ost;8025074;;7.238968;50.329263;;f;DE;f;Europe/Berlin;t;DEQMZ;;f;;f;8000248;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7700;Ulm Hbf;ulm-hbf;8029103;;9.982224;48.399432;;f;DE;f;Europe/Berlin;t;DEQUL;;t;;f;8000170;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ウルム;울름;;;;Ульм;;;乌尔姆
-7701;Würzburg Hbf;wurzburg-hbf;8022534;;9.935777;49.801794;;f;DE;f;Europe/Berlin;t;DEQWU;;f;;f;8000260;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Wurzburgo;;ヴュルツブルク;뷔르츠부르크;;;Wurtzburgo;Вюрцбург;;;维尔茨堡
+7701;Würzburg Hbf;wurzburg-hbf;8022534;;9.935777;49.801794;;f;DE;f;Europe/Berlin;t;DEQWU;;f;;f;8000260;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Wurzburgo;;;;ヴュルツブルク;뷔르츠부르크;;;Wurtzburgo;Вюрцбург;;;维尔茨堡
 7702;Radolfzell;radolfzell;8014571;;8.968987;47.735875;;f;DE;f;Europe/Berlin;t;DERAD;;f;;f;8000880;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7703;Rastatt;rastatt;8014245;;8.215745;48.860579;;f;DE;f;Europe/Berlin;t;DERAS;;f;;f;8000306;t;;f;;f;;f;;f;;f;;;;;;;;;;ラシュタット;;;;;Раштатт;;;拉施塔特
 7704;Bad-Reichenhall;bad-reichenhall;;;;;;t;DE;f;Europe/Berlin;f;DEREI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7705;Remscheid;remscheid;;;;;;t;DE;f;Europe/Berlin;f;DEREM;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7706;Ribnitz-Damgarten West;ribnitz-damgarten-west;8027064;;12.436962;54.239175;;f;DE;f;Europe/Berlin;t;DERIB;;f;;f;8012763;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7707;Salzgitter;salzgitter;8033859;;10.390649;52.106134;;t;DE;f;Europe/Berlin;t;DESAL;;f;;f;8096006;t;;f;;f;;f;;f;;f;;;;;;;;;;ザルツギッター;잘츠기터;;;;Зальцгиттер;;;薩爾茨吉特
-7708;Saarbrücken Hbf;saarbrucken-hbf;8025391;80253914;6.990984678268433;49.24115221039208;;f;DE;f;Europe/Berlin;t;DESBK;;t;;f;8000323;t;;f;;f;;f;;f;;f;;Sarrebruck Gare centrale;Main station;;Stazione centrale;;;Sarrebruck;;ザールブリュッケン;자르브뤼켄;;;;Саарбрюккен;;;萨尔布吕肯
+7708;Saarbrücken Hbf;saarbrucken-hbf;8025391;80253914;6.990984678268433;49.24115221039208;;f;DE;f;Europe/Berlin;t;DESBK;;t;;f;8000323;t;;f;;f;;f;;f;;f;;Sarrebruck Gare centrale;Main station;;Stazione centrale;Sarrebruck;;;;ザールブリュッケン;자르브뤼켄;;;;Саарбрюккен;;;萨尔布吕肯
 7709;Schirnding;schirnding;8000644;;12.228745;50.077296;;f;DE;f;Europe/Berlin;t;DESCH;;f;;f;8005352;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7710;Stuttgart Hbf;stuttgart-hbf;8029034;80290346;9.181636;48.784081;7714;f;DE;f;Europe/Berlin;t;DESGT;;t;;f;8000096;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;シュトゥットガルト;슈투트가르트;;;Estugarda;Штутгарт;;;斯图加特
 7711;Solingen;solingen;;;;;;t;DE;f;Europe/Berlin;f;DESLG;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6307,25 +6307,25 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7721;Wiesbaden;wiesbaden;;;;;;t;DE;f;Europe/Berlin;f;DEWBD;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7722;Potsdam;potsdam;;;;;;t;DE;f;Europe/Berlin;f;DEXXN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7723;Potsdam stadt;potsdam-stadt;;;;;7722;f;DE;f;Europe/Berlin;f;DEXXO;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7724;Potsdam Hbf;potsdam-hbf;8003479;;13.066782;52.391703;7722;f;DE;f;Europe/Berlin;t;DEXXP;;f;;f;8012666;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Postupim;;;;ポツダム;포츠담;;Poczdam;;Потсдам;;;波茨坦
+7724;Potsdam Hbf;potsdam-hbf;8003479;;13.066782;52.391703;7722;f;DE;f;Europe/Berlin;t;DEXXP;;f;;f;8012666;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Postupim;;;ポツダム;포츠담;;Poczdam;;Потсдам;;;波茨坦
 7725;Arenshausen;arenshausen;8016543;;9.968641;51.375167;;f;DE;f;Europe/Berlin;t;DEZAS;;f;;f;8011054;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7726;Baden-Baden;baden-baden;8014277;;8.190467;48.790085;;f;DE;f;Europe/Berlin;t;DEZCC;;t;;f;8000774;t;;f;;f;;f;;f;;f;;;;;;;;;;バーデン＝バーデン;바덴바덴;;;;Баден-Баден;;;巴登-巴登
 7727;Fulda;fulda;8005637;;9.68398;50.554722;;f;DE;f;Europe/Berlin;t;DEZEE;;f;;f;8000115;t;;f;;f;;f;;f;;f;;;;;;;;;;フルダ;풀다;;;;Фульда;;;富尔达
 7728;Garmisch-Partenkirchen;garmisch-partenkirchen;8020295;;11.097012;47.49145;;f;DE;f;Europe/Berlin;t;DEZEI;;f;;f;8002187;t;;f;;f;;f;;f;;f;;;;;;;;;;ガルミッシュ＝パルテンキルヒェン;가르미슈파르텐키르헨;;;;Гармиш-Партенкирхен;;;加爾米施-帕滕基興
 7729;Hagen Hbf;hagen-hbf;8008073;;7.460246;51.362744;;f;DE;f;Europe/Berlin;t;DEZEY;;f;;f;8000142;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ハーゲン;;;;;Хаген;;;哈根伊姆布雷米申
-7730;Frankfurt (Oder);frankfurt-oder;8053610;;14.546506;52.336159;;f;DE;f;Europe/Berlin;t;DEZFR;;f;;f;8010113;t;;f;;f;;f;;f;;f;;Francfort-sur-l’Oder;;;Francoforte sull’Oder;Frankfurt nad Mohanem;;Fráncfort del Óder;Frankfurt an der Oder;フランクフルト・アン・デア・オーダー;프랑크푸르트;Frankfurt an der Oder;Frankfurt nad Odrą;Frankfurt an der Oder;Франкфурт-на-Одере;;;
+7730;Frankfurt (Oder);frankfurt-oder;8053610;;14.546506;52.336159;;f;DE;f;Europe/Berlin;t;DEZFR;;f;;f;8010113;t;;f;;f;;f;;f;;f;;Francfort-sur-l’Oder;;;Francoforte sull’Oder;Fráncfort del Óder;Frankfurt nad Mohanem;;Frankfurt an der Oder;フランクフルト・アン・デア・オーダー;프랑크푸르트;Frankfurt an der Oder;Frankfurt nad Odrą;Frankfurt an der Oder;Франкфурт-на-Одере;;;
 7731;Gera Hbf;gera-hbf;8016705;;12.077088;50.883421;;f;DE;f;Europe/Berlin;t;DEZGA;;f;;f;8010125;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ゲーラ;게라;;;;Гера;;;格拉
 7732;Görlitz;gorlitz;8006085;;14.979076;51.146769;;f;DE;f;Europe/Berlin;t;DEZGE;;f;;f;8010131;t;;f;;f;;f;;f;;f;;;;;;;;;;ゲルリッツ;괴를리츠;;;;Гёрлиц;;;格尔利茨
 7733;Gutenfürst;gutenfurst;8006718;;11.96075;50.41912;;f;DE;f;Europe/Berlin;t;DEZGN;;f;;f;8011790;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7734;Gotha;gotha;8016051;;10.712849;50.939029;;f;DE;f;Europe/Berlin;t;DEZGO;;f;;f;8010136;t;;f;;f;;f;;f;;f;;;;;;;;;;ゴータ;고타;;;Gota;Гота;;;哥達
 7735;Gerstungen;gerstungen;8016084;;10.065041;50.964666;;f;DE;f;Europe/Berlin;t;DEZGT;;f;;f;8011629;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7736;Halle (Saale) Hbf;halle-saale-hbf;8023002;;11.987088;51.477509;;f;DE;f;Europe/Berlin;t;DEZHZ;;f;;f;8010159;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ハレ;;;;Halle an der Saale;Галле;;;
-7737;Zittau;zittau;8006113;;14.8058;50.904348;;f;DE;f;Europe/Berlin;t;DEZIT;;f;;f;8010393;t;;f;;f;;f;;f;;f;;;;;;Žitava;;;;ツィッタウの;;;Żytawa;;Циттау;;;齐陶
+7737;Zittau;zittau;8006113;;14.8058;50.904348;;f;DE;f;Europe/Berlin;t;DEZIT;;f;;f;8010393;t;;f;;f;;f;;f;;f;;;;;;;Žitava;;;ツィッタウの;;;Żytawa;;Циттау;;;齐陶
 7738;Jena Saalbf;jena-saalbf;8016319;;11.593918;50.937096;;f;DE;f;Europe/Berlin;t;DEZJS;;f;;f;8011058;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7739;Ludwigslust;ludwigslust;8027327;;11.494488;53.334672;;f;DE;f;Europe/Berlin;t;DEZLU;;f;;f;8010216;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-7740;Magdeburg Hbf;magdeburg-hbf;8024001;;11.62689;52.130351;;f;DE;f;Europe/Berlin;t;DEZMG;;f;;f;8010224;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Magdeburk;;Magdeburgo;;マクデブルク;마그데부르크;Maagdenburg;;Magdeburgo;Магдебург;;;马格德堡
+7740;Magdeburg Hbf;magdeburg-hbf;8024001;;11.62689;52.130351;;f;DE;f;Europe/Berlin;t;DEZMG;;f;;f;8010224;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Magdeburgo;Magdeburk;;;マクデブルク;마그데부르크;Maagdenburg;;Magdeburgo;Магдебург;;;马格德堡
 7741;Hamm (Westf);hamm-westf;8010002;;7.807823;51.678077;;f;DE;f;Europe/Berlin;t;DEZNB;;f;;f;8000149;t;;f;;f;;f;;f;;f;;;;;;;;;;ハム;함;;;;Хамм;;;哈姆
-7742;Koblenz Hbf;koblenz-hbf;8019021;;7.588648;50.35108;;f;DE;f;Europe/Berlin;t;DEZNV;;f;;f;8000206;t;;f;;f;;f;;f;108000206;t;;Coblence Gare centrale;Main station;;Coblenza Stazione centrale;;;Coblenza;;コブレンツ;코블렌츠;;Koblencja;Coblença;Кобленц;;;科布倫茨
+7742;Koblenz Hbf;koblenz-hbf;8019021;;7.588648;50.35108;;f;DE;f;Europe/Berlin;t;DEZNV;;f;;f;8000206;t;;f;;f;;f;;f;108000206;t;;Coblence Gare centrale;Main station;;Coblenza Stazione centrale;Coblenza;;;;コブレンツ;코블렌츠;;Koblencja;Coblença;Кобленц;;;科布倫茨
 7743;Ludwigshafen (Rh) Hbf;ludwigshafen-rh-hbf;8019082;;8.4334;49.477985;;f;DE;f;Europe/Berlin;t;DEZOE;;f;;f;8000236;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ルートヴィヒスハーフェン;루트비히스하펜;;;;Людвигсхафен-на-Рейне;;;路德维希港
 7744;Minden (Westf);minden-westf;8013577;;8.934729;52.290134;;f;DE;f;Europe/Berlin;t;DEZOM;;f;;f;8000252;t;;f;;f;;f;;f;;f;;;;;;;;;;ミンデン;;;;;Минден;;;明登
 7745;Mülheim (Ruhr) Hbf;mulheim-ruhr-hbf;8010217;;6.88668;51.431323;;f;DE;f;Europe/Berlin;t;DEZOO;;f;;f;8000259;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Мюльхайм-на-Руре;;;
@@ -6339,7 +6339,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 7753;Schwerin Hbf;schwerin-hbf;8027359;;11.407553;53.63466;;f;DE;f;Europe/Berlin;t;DEZSR;;f;;f;8010324;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;シュヴェリーン;슈베린;;;;Шверин;;;什未林
 7754;Dessau Hbf;dessau-hbf;8023723;;12.234948;51.839865;;f;DE;f;Europe/Berlin;t;DEZSU;;f;;f;8010077;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;デッサウ;데사우;;;;Дессау;;;德绍
 7755;Stralsund Hbf;stralsund-hbf;8028504;;13.077318;54.308626;;f;DE;f;Europe/Berlin;t;DEZSX;;f;;f;8010338;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;シュトラールズント;슈트랄준트;;;;Штральзунд;;;施特拉爾松德
-7756;Chemnitz Hbf;chemnitz-hbf;8006377;;12.930299;50.839266;;f;DE;f;Europe/Berlin;t;DEZTZ;;f;;f;8010184;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Saská Kamenice;;;;ケムニッツ;켐니츠;;;;Хемниц;;;开姆尼茨
+7756;Chemnitz Hbf;chemnitz-hbf;8006377;;12.930299;50.839266;;f;DE;f;Europe/Berlin;t;DEZTZ;;f;;f;8010184;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Saská Kamenice;;;ケムニッツ;켐니츠;;;;Хемниц;;;开姆尼茨
 7757;Warnemünde;warnemunde;8027098;;12.091273;54.176853;;f;DE;f;Europe/Berlin;t;DEZWD;;f;;f;8013236;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7758;Wittenberge;wittenberge;8027316;;11.763023;53.002233;;f;DE;f;Europe/Berlin;t;DEZWN;;f;;f;8010382;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 7759;Southampton;southampton;7059320;;;;;f;GB;f;Europe/London;f;GBAAA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -6850,9 +6850,9 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8264;Liverpool lime street;liverpool-lime-street;7022460;;;;;f;GB;f;Europe/London;f;GBLIV;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8265;London King’s Cross;london-kings-cross;7061210;;;;8267;f;GB;f;Europe/London;f;GBLKC;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8266;London Kensington Olympia;london-kensington-olympia;7030920;;;;8267;f;GB;f;Europe/London;f;GBLKO;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8267;London;london;9999984;;-0.0784599781036377;51.50469232881583;;t;GB;f;Europe/London;t;GBLON;;t;;f;7096001;t;;f;;f;;f;;f;;f;;Londres;;;Londra;Londýn;;Londres;;ロンドン;런던;Londen;Londyn;Londres;Лондон;;Londra;伦敦
+8267;London;london;9999984;;-0.0784599781036377;51.50469232881583;;t;GB;f;Europe/London;t;GBLON;;t;;f;7096001;t;;f;;f;;f;;f;;f;;Londres;;;Londra;Londres;Londýn;;;ロンドン;런던;Londen;Londyn;Londres;Лондон;;Londra;伦敦
 8268;London Marylebone;london-marylebone;7014750;;;;8267;f;GB;f;Europe/London;f;GBMEI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8269;London Victoria;london-victoria;7054260;;-0.14352500438690186;51.49589967008447;8267;f;GB;f;Europe/London;t;GBLVI;;f;;f;7000010;t;ZEP;t;;f;;f;;f;;f;;Londres;;;Londra;Londýn;;Londres;;ロンドン;런던;Londen;Londyn;Londres;Лондон;;Londra;伦敦
+8269;London Victoria;london-victoria;7054260;;-0.14352500438690186;51.49589967008447;8267;f;GB;f;Europe/London;t;GBLVI;;f;;f;7000010;t;ZEP;t;;f;;f;;f;;f;;Londres;;;Londra;Londres;Londýn;;;ロンドン;런던;Londen;Londyn;Londres;Лондон;;Londra;伦敦
 8270;London Waterloo;london-waterloo;7055980;;;;8267;f;GB;f;Europe/London;f;GBLWA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8271;London Southern Railway;london-southern-railway;7010720;;;;8267;f;GB;f;Europe/London;f;GBLWB;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8272;Stratford international;stratford-international;7015410;;;;8267;f;GB;f;Europe/London;f;GBSDI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7010,22 +7010,22 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8424;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8425;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8426;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8427;Firenze Campo di Marte;firenze-campo-di-marte;8306900;;11.27659;43.777574;;;IT;f;Europe/Rome;t;ITFCM;;f;;f;8300180;f;;f;;f;8306900;t;;f;;f;;Florence;Florence;Florenz;;Florencie;;Florencia;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
+8427;Firenze Campo di Marte;firenze-campo-di-marte;8306900;;11.27659;43.777574;;;IT;f;Europe/Rome;t;ITFCM;;f;;f;8300180;f;;f;;f;8306900;t;;f;;f;;Florence;Florence;Florenz;;Florencia;Florencie;;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
 8428;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8429;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8430;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8431;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8432;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8433;Firenze;firenze;8306998;;11.2551002;43.7725042;;t;IT;f;Europe/Rome;t;ITFLR;;f;;f;;f;;f;;f;8306998;t;;f;;f;;Florence;Florence;Florenz;;Florencie;;Florencia;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
-8434;Firenze Santa Maria Novella;firenze-santa-maria-novella;8306421;83064212;11.247806;43.77681;8433;f;IT;t;Europe/Rome;t;ITFNO;;f;;f;8300151;f;;f;;f;8306421;t;SMN;t;;f;;Florence;Florence;Florenz;;Florencie;;Florencia;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
-8435;Firenze Rifredi;firenze-rifredi;8306420;;11.236408;43.800137;8433;f;IT;f;Europe/Rome;t;ITFRI;;f;;f;8300497;f;;f;;f;8306420;t;;f;;f;;Florence;Florence;Florenz;;Florencie;;Florencia;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
+8433;Firenze;firenze;8306998;;11.2551002;43.7725042;;t;IT;f;Europe/Rome;t;ITFLR;;f;;f;;f;;f;;f;8306998;t;;f;;f;;Florence;Florence;Florenz;;Florencia;Florencie;;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
+8434;Firenze Santa Maria Novella;firenze-santa-maria-novella;8306421;83064212;11.247806;43.77681;8433;f;IT;t;Europe/Rome;t;ITFNO;;f;;f;8300151;f;;f;;f;8306421;t;SMN;t;;f;;Florence;Florence;Florenz;;Florencia;Florencie;;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
+8435;Firenze Rifredi;firenze-rifredi;8306420;;11.236408;43.800137;8433;f;IT;f;Europe/Rome;t;ITFRI;;f;;f;8300497;f;;f;;f;8306420;t;;f;;f;;Florence;Florence;Florenz;;Florencia;Florencie;;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
 8436;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8437;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8438;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8439;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8440;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8441;Montevarchi terranova;montevarchi-terranova;8306910;;11.564201;43.52538;;f;IT;f;Europe/Rome;t;ITFVT;;f;;f;;f;;f;;f;8306910;t;;f;;f;;;;;;;;;;;;;;;;;;
-8442;Genova Brignole;genova-brignole;8304702;;8.947197;44.406999;8450;f;IT;f;Europe/Rome;t;ITGBR;;f;;f;;f;;f;;f;8304702;t;;f;;f;;Gênes;Genoa;Genua;;Janov;;;;ジェノヴァ;제노바;Genua;Genua;;Генуя;Genua;Cenova;
+8442;Genova Brignole;genova-brignole;8304702;;8.947197;44.406999;8450;f;IT;f;Europe/Rome;t;ITGBR;;f;;f;;f;;f;;f;8304702;t;;f;;f;;Gênes;Genoa;Genua;;;Janov;;;ジェノヴァ;제노바;Genua;Genua;;Генуя;Genua;Cenova;
 8443;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8444;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8445;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7033,12 +7033,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8447;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8448;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8449;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8450;Genova;genova;8304999;;8.918988704681395;44.41633306978571;;t;IT;f;Europe/Rome;t;ITGOA;;f;;f;8396002;f;GOA;t;;f;8304999;t;;f;;f;;Gênes;Genoa;Genua;;Janov;;;;ジェノヴァ;제노바;Genua;Genua;;Генуя;Genua;Cenova;
+8450;Genova;genova;8304999;;8.918988704681395;44.41633306978571;;t;IT;f;Europe/Rome;t;ITGOA;;f;;f;8396002;f;GOA;t;;f;8304999;t;;f;;f;;Gênes;Genoa;Genua;;;Janov;;;ジェノヴァ;제노바;Genua;Genua;;Генуя;Genua;Cenova;
 8451;;;;;;;8450;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8452;;;;;;;8450;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8453;Genova Piazza Principe;genova-piazza-principe;8304700;;8.922072;44.417507;8450;f;IT;f;Europe/Rome;t;ITGPP;;f;;f;8300153;f;;f;;f;8304700;t;;f;;f;;Gênes;Genoa;Genua;;Janov;;;;ジェノヴァ;제노바;Genua;Genua;;Генуя;Genua;Cenova;
+8453;Genova Piazza Principe;genova-piazza-principe;8304700;;8.922072;44.417507;8450;f;IT;f;Europe/Rome;t;ITGPP;;f;;f;8300153;f;;f;;f;8304700;t;;f;;f;;Gênes;Genoa;Genua;;;Janov;;;ジェノヴァ;제노바;Genua;Genua;;Генуя;Genua;Cenova;
 8454;;;;;;;8450;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8455;Genova quinto al mare;genova-quinto-al-mare;8304705;;9.020556;44.385;8450;f;IT;f;Europe/Rome;t;ITAKC;;f;;f;;f;;f;;f;8304705;t;;f;;f;;Gênes;Genoa;Genua;;Janov;;;;ジェノヴァ;제노바;Genua;Genua;;Генуя;Genua;Cenova;
+8455;Genova quinto al mare;genova-quinto-al-mare;8304705;;9.020556;44.385;8450;f;IT;f;Europe/Rome;t;ITAKC;;f;;f;;f;;f;;f;8304705;t;;f;;f;;Gênes;Genoa;Genua;;;Janov;;;ジェノヴァ;제노바;Genua;Genua;;Генуя;Genua;Cenova;
 8456;;;;;;;8450;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8457;;;;;;;8450;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8458;;;;;;;8450;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7066,21 +7066,21 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8480;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8481;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8482;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8483;Milano;milano;8301650;;9.190599918365479;45.466632090847824;;t;IT;f;Europe/Rome;t;ITMIL;;t;;f;8396005;f;;f;;f;8301650;t;MI0;t;;f;;Milan;Milan;Mailand;;Milán;;Milán;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
+8483;Milano;milano;8301650;;9.190599918365479;45.466632090847824;;t;IT;f;Europe/Rome;t;ITMIL;;t;;f;8396005;f;;f;;f;8301650;t;MI0;t;;f;;Milan;Milan;Mailand;;Milán;Milán;;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
 8484;Milano Bovisa;milano-bovisa;8301641;;;;8483;f;IT;f;Europe/Rome;f;ITAEO;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8485;Milano Lambrate;milano-lambrate;8301701;;9.237225;45.485066;8483;f;IT;f;Europe/Rome;t;ITMLA;;f;;f;8300062;f;;f;;f;8301701;t;;f;;f;;Milan;Milan;Mailand;;Milán;;Milán;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
+8485;Milano Lambrate;milano-lambrate;8301701;;9.237225;45.485066;8483;f;IT;f;Europe/Rome;t;ITMLA;;f;;f;8300062;f;;f;;f;8301701;t;;f;;f;;Milan;Milan;Mailand;;Milán;Milán;;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
 8486;;;;;;;8483;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8487;;;;;;;8483;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8488;;;;;;;8483;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8489;;;;;;;8483;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8490;Milano Centrale;milano-centrale;8301700;83017004;9.204828;45.487143;8483;f;IT;t;Europe/Rome;t;ITBGE;;t;;f;8300046;t;;f;;f;8301700;t;MC_;t;;f;;Milan;Milan;Mailand;;Milán;;Milán;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
-8491;Milano Rogoredo;milano-rogoredo;8301820;83018200;9.2390140000;45.4336660000;8483;f;IT;f;Europe/Rome;t;ITMRO;;f;;f;8300418;t;;f;;f;8301820;t;RG_;t;;f;;Milan;Milan;Mailand;;Milán;;Milán;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
-8492;Milano Porta Garibaldi;milano-porta-garibaldi;8301645;83016451;9.187299;45.484437;8483;f;IT;f;Europe/Rome;t;ITMPG;;t;;f;8300047;t;;f;;f;8301645;t;MPG;t;;f;;Milan;Milan;Mailand;;Milán;;Milán;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
+8490;Milano Centrale;milano-centrale;8301700;83017004;9.204828;45.487143;8483;f;IT;t;Europe/Rome;t;ITBGE;;t;;f;8300046;t;;f;;f;8301700;t;MC_;t;;f;;Milan;Milan;Mailand;;Milán;Milán;;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
+8491;Milano Rogoredo;milano-rogoredo;8301820;83018200;9.2390140000;45.4336660000;8483;f;IT;f;Europe/Rome;t;ITMRO;;f;;f;8300418;t;;f;;f;8301820;t;RG_;t;;f;;Milan;Milan;Mailand;;Milán;Milán;;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
+8492;Milano Porta Garibaldi;milano-porta-garibaldi;8301645;83016451;9.187299;45.484437;8483;f;IT;f;Europe/Rome;t;ITMPG;;t;;f;8300047;t;;f;;f;8301645;t;MPG;t;;f;;Milan;Milan;Mailand;;Milán;Milán;;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
 8493;Modena;modena;8305032;;10.929948;44.654616;;;IT;f;Europe/Rome;t;ITMOD;;f;;f;8300214;f;;f;;f;8305032;t;;f;;f;;Modène;;;;;;;;モデナ;;;;;Модена;;;
 8494;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8495;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8496;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8497;Napoli Centrale;napoli-centrale;8309218;;14.273072;40.852826;22184;f;IT;t;Europe/Rome;t;ITNAC;;f;;f;8300239;f;;f;;f;8309218;t;NAC;t;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+8497;Napoli Centrale;napoli-centrale;8309218;;14.273072;40.852826;22184;f;IT;t;Europe/Rome;t;ITNAC;;f;;f;8300239;f;;f;;f;8309218;t;NAC;t;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 8498;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8499;;;;;;;;t;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8500;Napoli Marittima;napoli-marittima;8309220;;;;22184;f;IT;f;Europe/Rome;f;ITNMA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7111,8 +7111,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8525;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8526;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8527;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8528;Padova;padova;8302581;;11.8806200000;45.4178270000;;f;IT;f;Europe/Rome;t;ITQPA;;f;;f;8300098;t;;f;;f;8302581;t;PD_;t;;f;;Padoue;Padua;Padua;;;;Padua;;パドヴァ;파도바;Padua;Padwa;Pádua;Падуя;Padua;;帕多瓦
-8529;Piacenza;piacenza;8305000;;9.706363;45.052101;;f;IT;f;Europe/Rome;t;ITQPZ;;f;;f;8300230;f;;f;;f;8305000;t;;f;;f;;Plaisance;;;;;;Plasencia;;ピアチェンツァ;;;;Placência;Пьяченца;;;
+8528;Padova;padova;8302581;;11.8806200000;45.4178270000;;f;IT;f;Europe/Rome;t;ITQPA;;f;;f;8300098;t;;f;;f;8302581;t;PD_;t;;f;;Padoue;Padua;Padua;;Padua;;;;パドヴァ;파도바;Padua;Padwa;Pádua;Падуя;Padua;;帕多瓦
+8529;Piacenza;piacenza;8305000;;9.706363;45.052101;;f;IT;f;Europe/Rome;t;ITQPZ;;f;;f;8300230;f;;f;;f;8305000;t;;f;;f;;Plaisance;;;;Plasencia;;;;ピアチェンツァ;;;;Placência;Пьяченца;;;
 8530;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8531;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8532;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7125,10 +7125,10 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8539;Reggio di Calabria Centrale;reggio-di-calabria-centrale;8311781;;15.635792;38.104123;22399;;IT;t;Europe/Rome;t;ITAYW;;f;;f;8300337;f;;f;;f;8311781;t;;f;;f;;Reggio de Calabre;;;;;;;;レッジョ・ディ・カラブリア;;;;;Реджо-ди-Калабрия;;;
 8540;;;;;;;8534;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8541;;;;;;;8534;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8542;Roma;roma;8308349;;12.4829203;41.8932225;;t;IT;f;Europe/Rome;t;ITRMA;;f;;f;8396004;f;;f;;f;8308349;t;RM0;t;;f;;Rome;Rome;Rom;;Řím;Rom;;;ローマ;로마;Rome;Rzym;;Рим;Rom;;罗马市
-8543;Roma Tiburtina;roma-tiburtina;8308217;;12.531457;41.911072;8542;f;IT;f;Europe/Rome;t;ITRTB;;f;;f;8300262;f;;f;;f;8308217;t;RTB;t;;f;;Rome;Rome;Rom;;Řím;Rom;;;ローマ;로마;Rome;Rzym;;Рим;Rom;;罗马市
-8544;Roma Termini;roma-termini;8308409;83084095;12.531457;41.911072;8542;f;IT;t;Europe/Rome;t;ITRTI;;f;;f;8300263;f;;f;;f;8308409;t;RMT;t;;f;;Rome;Rome;Rom;;Řím;Rom;;;ローマ;로마;Rome;Rzym;;Рим;Rom;;罗马市
-8545;Roma Ostiense;roma-ostiense;8308406;;12.484902;41.872275;8542;f;IT;f;Europe/Rome;t;ITROS;;f;;f;8300261;f;;f;;f;8308406;t;OST;t;;f;;Rome;Rome;Rom;;Řím;Rom;;;ローマ;로마;Rome;Rzym;;Рим;Rom;;罗马市
+8542;Roma;roma;8308349;;12.4829203;41.8932225;;t;IT;f;Europe/Rome;t;ITRMA;;f;;f;8396004;f;;f;;f;8308349;t;RM0;t;;f;;Rome;Rome;Rom;;;Řím;Rom;;ローマ;로마;Rome;Rzym;;Рим;Rom;;罗马市
+8543;Roma Tiburtina;roma-tiburtina;8308217;;12.531457;41.911072;8542;f;IT;f;Europe/Rome;t;ITRTB;;f;;f;8300262;f;;f;;f;8308217;t;RTB;t;;f;;Rome;Rome;Rom;;;Řím;Rom;;ローマ;로마;Rome;Rzym;;Рим;Rom;;罗马市
+8544;Roma Termini;roma-termini;8308409;83084095;12.531457;41.911072;8542;f;IT;t;Europe/Rome;t;ITRTI;;f;;f;8300263;f;;f;;f;8308409;t;RMT;t;;f;;Rome;Rome;Rom;;;Řím;Rom;;ローマ;로마;Rome;Rzym;;Рим;Rom;;罗马市
+8545;Roma Ostiense;roma-ostiense;8308406;;12.484902;41.872275;8542;f;IT;f;Europe/Rome;t;ITROS;;f;;f;8300261;f;;f;;f;8308406;t;OST;t;;f;;Rome;Rome;Rom;;;Řím;Rom;;ローマ;로마;Rome;Rzym;;Рим;Rom;;罗马市
 8546;;;;;;;8542;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8547;;;;;;;8542;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8548;;;;;;;8542;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7148,18 +7148,18 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8562;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8563;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8564;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8565;Torino;torino;8300996;;7.686063051223755;45.07075504730648;;t;IT;f;Europe/Rome;t;ITTRN;;t;;f;8396006;f;;f;;f;8300996;t;TO0;t;;f;;Turin;Turin;Turin;;Turín;;Turín;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
-8566;Torino Lingotto;torino-lingotto;8300452;;7.657532;45.026194;8565;;IT;f;Europe/Rome;t;ITABV;;f;;f;8300516;f;;f;;f;8300452;t;;f;;f;;Turin;Turin;Turin;;Turín;;Turín;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
-8567;Torino Porta Nuova;torino-porta-nuova;8300219;;7.677713;45.061000;8565;f;IT;f;Europe/Rome;t;ITBGD;;f;;f;8300001;f;;f;;f;8300219;t;TOP;t;;f;;Turin;Turin;Turin;;Turín;;Turín;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
-8568;Torino Porta Susa;torino-porta-susa;8300222;83002220;7.665164;45.071832;8565;f;IT;f;Europe/Rome;t;ITTRS;;t;;f;8300522;f;;f;;f;8300222;t;OUE;t;;f;;Turin;Turin;Turin;;Turín;;Turín;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
+8565;Torino;torino;8300996;;7.686063051223755;45.07075504730648;;t;IT;f;Europe/Rome;t;ITTRN;;t;;f;8396006;f;;f;;f;8300996;t;TO0;t;;f;;Turin;Turin;Turin;;Turín;Turín;;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
+8566;Torino Lingotto;torino-lingotto;8300452;;7.657532;45.026194;8565;;IT;f;Europe/Rome;t;ITABV;;f;;f;8300516;f;;f;;f;8300452;t;;f;;f;;Turin;Turin;Turin;;Turín;Turín;;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
+8567;Torino Porta Nuova;torino-porta-nuova;8300219;;7.677713;45.061000;8565;f;IT;f;Europe/Rome;t;ITBGD;;f;;f;8300001;f;;f;;f;8300219;t;TOP;t;;f;;Turin;Turin;Turin;;Turín;Turín;;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
+8568;Torino Porta Susa;torino-porta-susa;8300222;83002220;7.665164;45.071832;8565;f;IT;f;Europe/Rome;t;ITTRS;;t;;f;8300522;f;;f;;f;8300222;t;OUE;t;;f;;Turin;Turin;Turin;;Turín;Turín;;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
 8569;;;;;;;8565;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8570;;;;;;;8565;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8571;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8572;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8573;Venezia;venezia;8302998;;12.33475;45.43711;;t;IT;f;Europe/Rome;t;ITVCE;;f;;f;8396008;f;;f;;f;8302998;t;;f;;f;;Venise;Venice;Venedig;;Benátky;Venedig;Venecia;Velence;ヴェネツィア;베네치아;Venetië;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
-8574;Venezia Santa Lucia;venezia-santa-lucia;8302593;83025932;12.3204620000;45.4413970000;8573;f;IT;t;Europe/Rome;t;ITAGP;;f;;f;8300094;t;;f;;f;8302593;t;VSL;t;;f;;Venise Gare centrale;Venice Main station;Venedig Hauptbahnhof;;Benátky;Venedig;Venecia;Velence;ヴェネツィア;베네치아;Venetië;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
-8575;Venezia Mestre;venezia-mestre;8302589;83025890;12.2319000000;45.4819020000;8573;f;IT;f;Europe/Rome;t;ITBGG;;f;;f;8300093;t;;f;;f;8302589;t;VEM;t;;f;;Venise;Venice;Venedig;;Benátky;Venedig;Venecia;Velence;ヴェネツィア;베네치아;Venetië;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
-8576;Venezia Carpenedo;venezia-carpenedo;8302672;;12.247595;45.506676;8573;f;IT;f;Europe/Rome;t;ITAID;;f;;f;8300968;f;;f;;f;8302672;t;;f;;f;;Venise;Venice;Venedig;;Benátky;Venedig;Venecia;Velence;ヴェネツィア;베네치아;Venetië;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
+8573;Venezia;venezia;8302998;;12.33475;45.43711;;t;IT;f;Europe/Rome;t;ITVCE;;f;;f;8396008;f;;f;;f;8302998;t;;f;;f;;Venise;Venice;Venedig;;Venecia;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Venetië;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
+8574;Venezia Santa Lucia;venezia-santa-lucia;8302593;83025932;12.3204620000;45.4413970000;8573;f;IT;t;Europe/Rome;t;ITAGP;;f;;f;8300094;t;;f;;f;8302593;t;VSL;t;;f;;Venise Gare centrale;Venice Main station;Venedig Hauptbahnhof;;Venecia;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Venetië;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
+8575;Venezia Mestre;venezia-mestre;8302589;83025890;12.2319000000;45.4819020000;8573;f;IT;f;Europe/Rome;t;ITBGG;;f;;f;8300093;t;;f;;f;8302589;t;VEM;t;;f;;Venise;Venice;Venedig;;Venecia;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Venetië;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
+8576;Venezia Carpenedo;venezia-carpenedo;8302672;;12.247595;45.506676;8573;f;IT;f;Europe/Rome;t;ITAID;;f;;f;8300968;f;;f;;f;8302672;t;;f;;f;;Venise;Venice;Venedig;;Venecia;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Venetië;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
 8577;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8578;Ventimiglia;ventimiglia;8304501;;7.609953;43.792586;9604;f;IT;f;Europe/Rome;t;ITVEF;;f;;f;8300146;f;;f;;f;8304501;t;;f;;f;;Vintimille;;;;;;;;ヴェンティミーリア;;;;;Вентимилья;;;文蒂米利亚
 8579;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7186,7 +7186,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8601;;;;;;;;f;LU;f;Europe/Luxembourg;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8602;;;;;;;;f;LU;f;Europe/Luxembourg;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8603;Kautenbach;kautenbach;8200130;;6.021702;49.94919;;f;LU;f;Europe/Luxembourg;f;LUKTB;;f;;f;8270630;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8604;Luxembourg;luxembourg;8200100;82001000;6.134391;49.599717;8731;f;LU;t;Europe/Luxembourg;t;LULUX;;t;;f;8200100;t;;f;;f;;f;;f;;f;;;;Luxemburg;Lussemburgo;Lucemburk;;Luxemburgo;;ルクセンブルク;룩셈부르크;Luxemburg;Luksemburg;Luxemburgo;Люксембург;;Lüksemburg;盧森堡市
+8604;Luxembourg;luxembourg;8200100;82001000;6.134391;49.599717;8731;f;LU;t;Europe/Luxembourg;t;LULUX;;t;;f;8200100;t;;f;;f;;f;;f;;f;;;;Luxemburg;Lussemburgo;Luxemburgo;Lucemburk;;;ルクセンブルク;룩셈부르크;Luxemburg;Luksemburg;Luxemburgo;Люксембург;;Lüksemburg;盧森堡市
 8605;Petange;petange;8200930;;5.879169;49.554195;;f;LU;f;Europe/Luxembourg;f;LUPET;;f;;f;8200930;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8606;Rodange;rodange;8200940;;;;;t;LU;f;Europe/Luxembourg;f;LURDG;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8607;Alkmaar;alkmaar;8400050;;4.7384740000;52.6379540000;;f;NL;f;Europe/Amsterdam;t;NLAAA;;f;;f;8400050;t;;f;;f;;f;;f;;f;;;;;;;;;;アルクマール;알크마르;;;;Алкмаар;;;阿尔克马尔
@@ -7202,7 +7202,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8617;Ede wageningen;ede-wageningen;8484200;;;;;f;NL;f;Europe/Amsterdam;f;NLAAK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8618;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8619;Gouda;gouda;8400258;;4.7029040000;52.0176260000;;f;NL;f;Europe/Amsterdam;t;NLAAM;;f;;f;8400258;t;;f;;f;;f;;f;;f;;;;;;;;;;ゴーダ;하우다;;;;Гауда;;;豪达
-8620;Groningen;groningen;8400263;;6.5641210000;53.2125800000;;f;NL;f;Europe/Amsterdam;t;NLAAN;;f;;f;8400263;t;;f;;f;;f;;f;;f;;Groningue;;;Groninga;;;Groninga;;フローニンゲン;흐로닝언;;;;Гронинген;;;格罗宁根
+8620;Groningen;groningen;8400263;;6.5641210000;53.2125800000;;f;NL;f;Europe/Amsterdam;t;NLAAN;;f;;f;8400263;t;;f;;f;;f;;f;;f;;Groningue;;;Groninga;Groninga;;;;フローニンゲン;흐로닝언;;;;Гронинген;;;格罗宁根
 8621;Den Helder;den-helder;8400311;;4.7604800000;52.9545720000;;f;NL;f;Europe/Amsterdam;t;NLAAO;;f;;f;8400311;t;;f;;f;;f;;f;;f;;Le Helder;;;;;;;;デン・ヘルダー;;;;;Ден-Хелдер;;;登海尔德
 8622;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8623;Hengelo;hengelo;8484316;;;;;f;NL;f;Europe/Amsterdam;f;NLAAQ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7213,12 +7213,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8628;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8629;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8630;Nieuwe schans;nieuwe-schans;8400457;;;;;f;NL;f;Europe/Amsterdam;f;NLAAX;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8631;Nijmegen;nijmegen;8400470;;5.8517070000;51.8418240000;;f;NL;f;Europe/Amsterdam;t;NLAAY;;f;;f;8400470;t;;f;;f;;f;;f;;f;;Nimègue;;Nimwegen;Nimega;;;Nimega;;ナイメーヘン;네이메헌;;;Nimegue;Неймеген;;;奈梅亨
+8631;Nijmegen;nijmegen;8400470;;5.8517070000;51.8418240000;;f;NL;f;Europe/Amsterdam;t;NLAAY;;f;;f;8400470;t;;f;;f;;f;;f;;f;;Nimègue;;Nimwegen;Nimega;Nimega;;;;ナイメーヘン;네이메헌;;;Nimegue;Неймеген;;;奈梅亨
 8632;Oldenzaal;oldenzaal;8484483;;6.933137;52.306279;;f;NL;f;Europe/Amsterdam;f;NLAAZ;;f;;f;8400483;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8633;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8634;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8635;Sittard;sittard;8400564;;5.858512;51.001603;;f;NL;f;Europe/Amsterdam;f;NLABC;;f;;f;8400564;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8636;Tilburg;tilburg;8400597;;5.0811160000;51.5609380000;;f;NL;f;Europe/Amsterdam;t;NLABD;;f;;f;8400597;t;;f;;f;;f;;f;;f;;;;;;;;Tilburgo;;ティルブルフ;틸뷔르흐;;;Tilburgo;Тилбург;;;蒂尔堡
+8636;Tilburg;tilburg;8400597;;5.0811160000;51.5609380000;;f;NL;f;Europe/Amsterdam;t;NLABD;;f;;f;8400597;t;;f;;f;;f;;f;;f;;;;;;Tilburgo;;;;ティルブルフ;틸뷔르흐;;;Tilburgo;Тилбург;;;蒂尔堡
 8637;Venlo;venlo;8484644;;6.17184;51.364407;;f;NL;f;Europe/Amsterdam;f;NLABE;;f;;f;8400644;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8638;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8639;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -7246,13 +7246,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8661;Breda;breda;8400131;;4.7764000000;51.5944590000;;f;NL;f;Europe/Amsterdam;t;NLBDA;;f;;f;8400131;t;;f;;f;;f;;f;;f;;;;;;;;;;ブレダ;브레다;;;;Бреда;;;布雷达
 8662;Dordrecht;dordrecht;8400180;;4.6668210000;51.8077820000;;f;NL;f;Europe/Amsterdam;t;NLDDT;;f;;f;8400180;t;;f;;f;;f;;f;;f;;;;;;;;;;ドルトレヒト;;;;;;;;
 8663;La Haye;la-haye;;;;;;t;NL;f;Europe/Amsterdam;f;NLDHC;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-8664;Den Haag Centraal;den-haag-centraal;8400282;;4.3239910000;52.0805060000;8663;f;NL;f;Europe/Amsterdam;t;NLDHH;;f;;f;8400282;t;;f;;f;;f;;f;;f;;La Haye Gare centrale;The Hague Main station;Hauptbahnhof;L’Aia Stazione centrale;;;La Haya;Hága;ハーグ;헤이그;;Haga;A Haia;Гаага;;Lahey;海牙
+8664;Den Haag Centraal;den-haag-centraal;8400282;;4.3239910000;52.0805060000;8663;f;NL;f;Europe/Amsterdam;t;NLDHH;;f;;f;8400282;t;;f;;f;;f;;f;;f;;La Haye Gare centrale;The Hague Main station;Hauptbahnhof;L’Aia Stazione centrale;La Haya;;;Hága;ハーグ;헤이그;;Haga;A Haia;Гаага;;Lahey;海牙
 8665;Eijsden maastricht grens;eijsden-maastricht-grens;8400220;;;;;f;NL;f;Europe/Amsterdam;f;NLEIJ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8666;Eindhoven;eindhoven;8400206;;5.4799500000;51.4430630000;;f;NL;f;Europe/Amsterdam;t;NLEIN;;f;;f;8400206;t;;f;;f;;f;;f;;f;;;;;;;;;;アイントホーフェン;에인트호번;;;;Эйндховен;;;埃因霍温
 8667;Haarlem;haarlem;8400285;;4.6364650000;52.3871100000;;f;NL;f;Europe/Amsterdam;t;NLGRZ;;f;;f;8400285;t;;f;;f;;f;;f;;f;;;;;;;;;;ハールレム;하를럼;;;;Харлем;;;哈勒姆
 8668;Maastricht;maastricht;8400424;;5.705875;50.849811;;f;NL;f;Europe/Amsterdam;f;NLMST;;f;;f;8400424;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8669;Roosendaal;roosendaal;8400526;;4.4566360000;51.5398590000;;f;NL;f;Europe/Amsterdam;t;NLROO;;f;;f;8400526;t;;f;;f;;f;;f;;f;;Rosendael;;;;;;;;ローゼンダール;;;;;Розендал;;;罗森达尔
-8670;Rotterdam Centraal;rotterdam-centraal;8400530;84005306;4.468839168548584;51.925068244603146;;f;NL;f;Europe/Amsterdam;t;NLRTA;;t;;f;8400530;f;QRH;t;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;;;Róterdam;;ロッテルダム;로테르담;;;Roterdão;Роттердам;;;鹿特丹
+8670;Rotterdam Centraal;rotterdam-centraal;8400530;84005306;4.468839168548584;51.925068244603146;;f;NL;f;Europe/Amsterdam;t;NLRTA;;t;;f;8400530;f;QRH;t;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;Róterdam;;;;ロッテルダム;로테르담;;;Roterdão;Роттердам;;;鹿特丹
 8671;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 8672;Amsterdam-Schiphol;amsterdam-schiphol;8400561;;4.7614870000;52.3087870000;;f;NL;f;Europe/Amsterdam;t;NLSPH;;t;;f;8400561;t;;f;;f;;f;;f;;f;;Aéroport;Airport;Flughafen;Aeroporto;;;;;;;;;;;;;
 8673;Utrecht Centraal;utrecht-centraal;8400621;;5.1111670000;52.0875800000;;f;NL;f;Europe/Amsterdam;t;NLUTC;;f;;f;8400621;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Hauptbahnhof;Stazione centrale;;;;;ユトレヒト;;;;;Утрехт;;;
@@ -8960,8 +8960,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10453;Les Milons;les-milons;8720755;;;;;f;FR;f;Europe/Paris;f;FRLML;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10454;Autevielle;autevielle;;;-0.9666670000;43.3833330000;;f;FR;f;Europe/Paris;f;FRGFA;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10455;Les Sieyes;les-sieyes;8775150;;;;;f;FR;f;Europe/Paris;f;FRHXU;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10456;Bologna Centrale;bologna-centrale;8305043;;11.3434060000;44.5061410000;22159;f;IT;t;Europe/Rome;t;ITAOZ;;f;;f;8300217;t;;f;;f;8305043;t;BC_;t;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
-10457;Bologna Corticella;bologna-corticella;8305725;;11.353987;44.55204;22159;f;IT;f;Europe/Rome;t;ITAMH;;f;;f;8300995;f;;f;;f;8305725;t;;f;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+10456;Bologna Centrale;bologna-centrale;8305043;;11.3434060000;44.5061410000;22159;f;IT;t;Europe/Rome;t;ITAOZ;;f;;f;8300217;t;;f;;f;8305043;t;BC_;t;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+10457;Bologna Corticella;bologna-corticella;8305725;;11.353987;44.55204;22159;f;IT;f;Europe/Rome;t;ITAMH;;f;;f;8300995;f;;f;;f;8305725;t;;f;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
 10458;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10459;Vicenza;vicenza;8302446;;11.540774;45.541096;;f;IT;f;Europe/Rome;t;ITAIN;;f;;f;8300126;f;;f;;f;8302446;t;;f;;f;;Vicence;;;;;;;;ヴィチェンツァ;;;;;Виченца;;;
 10460;Bardonecchia;bardonecchia;8300202;;6.709744334220886;45.0764640756508;;f;IT;f;Europe/Rome;t;ITBCC;;t;;f;8300004;f;;f;;f;8300202;t;;f;;f;;Bardonèche;;;;;;;;バルドネッキア;;;;;;;;
@@ -9002,7 +9002,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10495;Saarbrücken;saarbrucken;;;;;;t;DE;f;Europe/Berlin;f;DESAK;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10496;Belfort—Montbéliard TGV;belfort-montbeliard-tgv;8730082;87300822;6.897629;47.585935;10610;f;FR;f;Europe/Paris;t;FRTJA;BFB;t;;f;8730082;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10497;La Voulte Cité;la-voulte-cite;8733870;;4.793147;44.81457;5667;f;FR;f;Europe/Paris;t;FRVTE;;t;;f;8705299;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10498;Besançon-Franche-Comté TGV;besancon-franche-comte-tgv;8730086;87300863;5.952674;47.307557;5029;f;FR;f;Europe/Paris;t;FRTJB;BFC;t;;f;8730086;t;;f;;f;;f;;f;;f;;;;;;;;Besanzón;;ブザンソン;브장송;;;;Безансон;;;贝桑松
+10498;Besançon-Franche-Comté TGV;besancon-franche-comte-tgv;8730086;87300863;5.952674;47.307557;5029;f;FR;f;Europe/Paris;t;FRTJB;BFC;t;;f;8730086;t;;f;;f;;f;;f;;f;;;;;;Besanzón;;;;ブザンソン;브장송;;;;Безансон;;;贝桑松
 10499;Montauban Gare Routière;montauban-gare-routiere;8744184;87441840;1.339455;43.997756;;f;FR;f;Europe/Paris;f;FRUGA;;t;;f;8706018;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10500;Louviers Porte de l’eau;louviers-porte-de-leau;8740191;87401919;1.172606;49.192443;;f;FR;f;Europe/Paris;t;FRLPL;;t;;f;8705490;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10501;Montauban Prax;mountauban-prax;8744244;;;;;f;FR;f;Europe/Paris;f;FRUFZ;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9271,7 +9271,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10764;;;;;;;;t;FR;f;Europe/Paris;f;FRVJW;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10765;;;;;;;;t;FR;f;Europe/Paris;f;FRSFI;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10766;Metzervisse Centre;metzervisse-centre;8740683;;;;10629;f;FR;f;Europe/Paris;f;FRZCV;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10767;Mérignac-Arlac;merignac-arlac;8727825;87278259;-0.626197;44.826625;827;f;FR;f;Europe/Paris;t;FRODB;;t;;f;8706494;f;;f;;f;;f;;f;;f;;Bordeaux;Bordeaux;Bordeaux;Bordeaux;Bordeaux;;Burdeos;Bordeaux;ボルドー;보르도;Bordeaux;Bordeaux;Bordéus;Бордо;;Bordeaux;波尔多
+10767;Mérignac-Arlac;merignac-arlac;8727825;87278259;-0.626197;44.826625;827;f;FR;f;Europe/Paris;t;FRODB;;t;;f;8706494;f;;f;;f;;f;;f;;f;;Bordeaux;Bordeaux;Bordeaux;Bordeaux;Burdeos;Bordeaux;;Bordeaux;ボルドー;보르도;Bordeaux;Bordeaux;Bordéus;Бордо;;Bordeaux;波尔多
 10768;;;8751461;;;;2335;f;FR;f;Europe/Paris;f;FRTIT;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10769;;;8744190;;;;10663;f;FR;f;Europe/Paris;f;FRUFU;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10770;;;;;;;;f;FR;f;Europe/Paris;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9313,7 +9313,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10806;Bedburg (Erft);bedburg-erft;8015283;;6.572615;50.987481;;f;DE;f;Europe/Berlin;t;;;f;;f;8000030;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10807;Bottrop Hbf;bottrop-hbf;8010021;;6.936921;51.509538;;f;DE;f;Europe/Berlin;t;;;f;;f;8000047;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;ボトロップ;보트로프;;;;Ботроп;;;博特罗普
 10808;Brackwede;brackwede;8013603;;8.498428;51.997374;;f;DE;f;Europe/Berlin;t;;;f;;f;8000048;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10809;Braunschweig Hbf;braunschweig-hbf;8013240;;10.539699;52.252236;;f;DE;f;Europe/Berlin;t;;;f;;f;8000049;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;Brunswick;;ブラウンシュヴァイク;브라운슈바이크;;Brunszwik;;Брауншвейг;;;不伦瑞克
+10809;Braunschweig Hbf;braunschweig-hbf;8013240;;10.539699;52.252236;;f;DE;f;Europe/Berlin;t;;;f;;f;8000049;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Brunswick;;;;ブラウンシュヴァイク;브라운슈바이크;;Brunszwik;;Брауншвейг;;;不伦瑞克
 10810;Bünde (Westf);bunde-westf;8021173;;8.573875;52.202076;;f;DE;f;Europe/Berlin;t;DEAFG;;f;;f;8000059;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Бюнде;;;
 10811;Siershahn;siershahn;8019581;;7.771561;50.485388;;f;DE;f;Europe/Berlin;t;;;f;;f;8000060;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10812;Burg-u. Nieder Gemünden;burg-u-nieder-gemunden;8005610;;9.047606;50.691115;;f;DE;f;Europe/Berlin;t;;;f;;f;8000061;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9330,7 +9330,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10823;Gladbeck West;gladbeck-west;8010019;;6.97677;51.575357;;f;DE;f;Europe/Berlin;t;;;f;;f;8000125;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гладбек;;;格拉德貝克
 10824;Riedstadt-Goddelau;riedstadt-goddelau;8011246;;8.489187;49.83323;;f;DE;f;Europe/Berlin;t;;;f;;f;8000126;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10825;Grävenwiesbach;gravenwiesbach;8011554;;8.458552;50.382237;;f;DE;f;Europe/Berlin;t;;;f;;f;8000132;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гревенвисбах;;;格雷芬维斯巴赫
-10826;Trier Hbf;trier-hbf;8025181;;6.652449;49.756848;;f;DE;f;Europe/Berlin;t;DEZQF;;f;;f;8000134;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Trevír;;Tréveris;;トリーア;트리어;;Trewir;Tréveris;Трир;;;特里尔
+10826;Trier Hbf;trier-hbf;8025181;;6.652449;49.756848;;f;DE;f;Europe/Berlin;t;DEZQF;;f;;f;8000134;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Tréveris;Trevír;;;トリーア;트리어;;Trewir;Tréveris;Трир;;;特里尔
 10827;Groß Gerau;gross-gerau;8011236;;8.486212;49.924938;;f;DE;f;Europe/Berlin;t;;;f;;f;8000136;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10828;Grünstadt;grunstadt;8019350;;8.167958;49.56438;;f;DE;f;Europe/Berlin;t;;;f;;f;8000137;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Грюнштадт;;;格林斯塔特
 10829;Gruiten;gruiten;8008083;;7.011145;51.214611;;f;DE;f;Europe/Berlin;t;;;f;;f;8000138;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9353,7 +9353,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 10846;Landau (Pfalz) Hbf;landau-pfalz-hbf;8019426;;8.126167;49.198178;;f;DE;f;Europe/Berlin;t;;;f;;f;8000216;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;Ландау-на-Изаре;;;伊萨尔河畔兰道
 10847;Lauterbach (Hess) Nord;lauterbach-hess-nord;8005617;;9.408056;50.643607;;f;DE;f;Europe/Berlin;t;;;f;;f;8000222;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10848;Lollar;lollar;8011686;;8.701737;50.64794;;f;DE;f;Europe/Berlin;t;;;f;;f;8000234;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-10849;Mainz Hbf;mainz-hbf;8019051;;8.258722;50.001112;;f;DE;f;Europe/Berlin;t;;;f;;f;8000240;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Mohuč;;Maguncia;;マインツ;마인츠;;Moguncja;Mogúncia;Майнц;;;美因茨
+10849;Mainz Hbf;mainz-hbf;8019051;;8.258722;50.001112;;f;DE;f;Europe/Berlin;t;;;f;;f;8000240;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Maguncia;Mohuč;;;マインツ;마인츠;;Moguncja;Mogúncia;Майнц;;;美因茨
 10850;Mainz-Bischofsheim;mainz-bischofsheim;8011231;;8.358116;49.992815;;f;DE;f;Europe/Berlin;t;;;f;;f;8000241;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10851;Westerburg;westerburg;8019565;;7.966977;50.557643;;f;DE;f;Europe/Berlin;t;;;f;;f;8000245;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 10852;Rohrbach (Ilm);rohrbach-ilm;8020428;;11.57318;48.605851;;f;DE;f;Europe/Berlin;t;;;f;;f;8000256;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -9870,7 +9870,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 11363;Castrop-Rauxel Süd;castrop-rauxel-sud;8010066;;7.310198;51.550232;;f;DE;f;Europe/Berlin;t;;;f;;f;8001328;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11364;Castrop-Rauxel-Merklinde;castrop-rauxel-merklinde;8010168;;7.32423;51.527903;;f;DE;f;Europe/Berlin;t;;;f;;f;8001329;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11365;Chamerau;chamerau;8026259;;12.745256;49.196721;;f;DE;f;Europe/Berlin;t;;;f;;f;8001331;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-11366;Coburg Nord;coburg-nord;8085073;;10.964826;50.271598;;f;DE;f;Europe/Berlin;t;;;f;;f;8001334;t;;f;;f;;f;;f;;f;;Cobourg;;;Coburgo;;;Coburgo;;コーブルク;;;Powiat Coburg;Coburgo;Кобург;;;科堡
+11366;Coburg Nord;coburg-nord;8085073;;10.964826;50.271598;;f;DE;f;Europe/Berlin;t;;;f;;f;8001334;t;;f;;f;;f;;f;;f;;Cobourg;;;Coburgo;Coburgo;;;;コーブルク;;;Powiat Coburg;Coburgo;Кобург;;;科堡
 11367;Clarholz;clarholz;8021468;;8.200832;51.898456;;f;DE;f;Europe/Berlin;t;;;f;;f;8001335;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11368;Cloppenburg;cloppenburg;8021251;;8.055764;52.843996;;f;DE;f;Europe/Berlin;t;;;f;;f;8001337;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11369;Coburg-Neuses;coburg-neuses;8022814;;10.95136;50.278079;;f;DE;f;Europe/Berlin;t;;;f;;f;8001339;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10252,10 +10252,10 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 11745;Forsting;forsting;8020220;;12.091444;48.081861;;f;DE;f;Europe/Berlin;t;;;f;;f;8002028;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11746;Forth;forth;8022222;;11.221459;49.591698;;f;DE;f;Europe/Berlin;t;;;f;;f;8002029;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11747;Friedrichshafen Ost;friedrichshafen-ost;8029169;;9.50202;47.651709;;f;DE;f;Europe/Berlin;t;;;f;;f;8002030;t;;f;;f;;f;;f;;f;;;;;;;;;;フリードリヒスハーフェン;;;;;Фридрихсхафен;;;腓特烈港
-11748;Frankfurt (M) Mühlberg;frankfurt-m-muhlberg;8011268;;8.701504;50.101612;;f;DE;f;Europe/Berlin;t;;;f;;f;8002034;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+11748;Frankfurt (M) Mühlberg;frankfurt-m-muhlberg;8011268;;8.701504;50.101612;;f;DE;f;Europe/Berlin;t;;;f;;f;8002034;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 11749;Frankenstein (Pfalz);frankenstein-pfalz;8019407;;7.9698;49.438864;;f;DE;f;Europe/Berlin;t;;;f;;f;8002036;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-11750;Frankfurt (M) Lokalbahnhof;frankfurt-m-lokalbahnhof;8011470;;8.693027;50.102169;;f;DE;f;Europe/Berlin;t;;;f;;f;8002038;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-11751;Frankfurt (Main) Ost;frankfurt-main-ost;8011080;;8.708551;50.112965;;f;DE;f;Europe/Berlin;t;;;f;;f;8002039;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+11750;Frankfurt (M) Lokalbahnhof;frankfurt-m-lokalbahnhof;8011470;;8.693027;50.102169;;f;DE;f;Europe/Berlin;t;;;f;;f;8002038;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+11751;Frankfurt (Main) Ost;frankfurt-main-ost;8011080;;8.708551;50.112965;;f;DE;f;Europe/Berlin;t;;;f;;f;8002039;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 11752;Frankfurt am Main - Stadion;frankfurt-am-main-stadion;8011089;;8.633249;50.068226;;f;DE;f;Europe/Berlin;t;;;f;;f;8002040;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11753;Frankfurt-Berkersheim;frankfurt-berkersheim;8011149;;8.697827;50.176483;;f;DE;f;Europe/Berlin;t;;;f;;f;8002043;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11754;Frankfurt-Frankfurter Berg;frankfurt-frankfurter-berg;8011148;;8.67655;50.170262;;f;DE;f;Europe/Berlin;t;;;f;;f;8002044;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10272,11 +10272,11 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 11765;Frankfurt-Zeilsheim;frankfurt-zeilsheim;8069802;;8.506402;50.090213;;f;DE;f;Europe/Berlin;t;;;f;;f;8002055;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11766;Ludwigshafen (Rhein) BASF Süd;ludwigshafen-rhein-basf-sud;8019080;;8.438956;49.493968;;f;DE;f;Europe/Berlin;t;;;f;;f;8002056;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11767;Frauenau;frauenau;8026470;;13.300043;48.98765;;f;DE;f;Europe/Berlin;t;;;f;;f;8002057;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-11768;Frankfurt (M) Ostendstraße;frankfurt-m-ostendstrasse;8011469;;8.696982;50.11256;;f;DE;f;Europe/Berlin;t;;;f;;f;8002058;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-11769;Frankfurt (M) Stresemannallee;frankfurt-m-stresemannallee;8011471;;8.671246;50.094438;;f;DE;f;Europe/Berlin;t;;;f;;f;8002059;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+11768;Frankfurt (M) Ostendstraße;frankfurt-m-ostendstrasse;8011469;;8.696982;50.11256;;f;DE;f;Europe/Berlin;t;;;f;;f;8002058;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+11769;Frankfurt (M) Stresemannallee;frankfurt-m-stresemannallee;8011471;;8.671246;50.094438;;f;DE;f;Europe/Berlin;t;;;f;;f;8002059;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 11770;Freden (Leine);freden-leine;8013061;;9.899002;51.927788;;f;DE;f;Europe/Berlin;t;;;f;;f;8002063;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11771;Freiberg (Neckar);freiberg-neckar;8029591;;9.197798;48.93011;;f;DE;f;Europe/Berlin;t;;;f;;f;8002065;t;;f;;f;;f;;f;;f;;;;;;;;;;フライベルク;;;;Freiberga;Фрайбург;;;内卡河畔弗赖贝格
-11772;Freiburg West;freiburg-west;8014354;;7.812884;48.027324;;f;DE;f;Europe/Berlin;t;;;f;;f;8002066;t;;f;;f;;f;;f;;f;;Freiberg;Freiberg;;Friburgo;;;Freiberg;;フライベルク;;Freiberg;Freiberg;Freiberga;Фрайбург;Freiberg;;弗莱贝格
+11772;Freiburg West;freiburg-west;8014354;;7.812884;48.027324;;f;DE;f;Europe/Berlin;t;;;f;;f;8002066;t;;f;;f;;f;;f;;f;;Freiberg;Freiberg;;Friburgo;Freiberg;;;;フライベルク;;Freiberg;Freiberg;Freiberga;Фрайбург;Freiberg;;弗莱贝格
 11773;Freiburg-Herdern;freiburg-herdern;8014349;;7.850971;48.00824;;f;DE;f;Europe/Berlin;t;;;f;;f;8002067;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11774;Freiburg-St Georgen;freiburg-st-georgen;8014404;;7.803005;47.975492;;f;DE;f;Europe/Berlin;t;;;f;;f;8002069;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 11775;Freiburg-Wiehre;freiburg-wiehre;8014364;;7.854127;47.982414;;f;DE;f;Europe/Berlin;t;;;f;;f;8002070;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10530,7 +10530,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12023;Hannover-Leinhausen;hannover-leinhausen;8013558;;9.676177;52.396791;;f;DE;f;Europe/Berlin;t;;;f;;f;8002585;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12024;Hannover-Linden/Fischerhof;hannover-linden-fischerhof;8013507;;9.72311;52.352636;;f;DE;f;Europe/Berlin;t;;;f;;f;8002586;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12025;Hanweiler (Gr);hanweiler-gr;8025418;;7.057637;49.1118;;f;DE;f;Europe/Berlin;f;;;f;;f;8002587;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12026;Hannover Flughafen;hannover-flughafen;8033118;;9.700817;52.459302;;f;DE;f;Europe/Berlin;t;;;f;;f;8002589;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;Hanóver;;ハノーファー;하노버;;Hanower;Hanôver;Ганновер;;;汉诺威
+12026;Hannover Flughafen;hannover-flughafen;8033118;;9.700817;52.459302;;f;DE;f;Europe/Berlin;t;;;f;;f;8002589;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Hanóver;;;;ハノーファー;하노버;;Hanower;Hanôver;Ганновер;;;汉诺威
 12027;Harblek;harblek;8001558;;8.961445;54.36115;;f;DE;f;Europe/Berlin;t;;;f;;f;8002592;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12028;Harburg (Schwab);harburg-schwab;8002040;;10.698457;48.778894;;f;DE;f;Europe/Berlin;t;;;f;;f;8002593;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12029;Hardegsen;hardegsen;8013288;;9.825218;51.659002;;f;DE;f;Europe/Berlin;t;;;f;;f;8002594;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10874,7 +10874,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12367;Klingenbrunn;klingenbrunn;8026471;;13.33618;48.9447;;f;DE;f;Europe/Berlin;t;;;f;;f;8003338;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12368;Brigachtal Kirchdorf;brigachtal-kirchdorf;8071993;;8.467793;48.014379;;f;DE;f;Europe/Berlin;t;;;f;;f;8003339;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12369;Kloster Marienthal;kloster-marienthal;8019622;;7.668526;50.73865;;f;DE;f;Europe/Berlin;t;;;f;;f;8003340;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12370;Koblenz Stadtmitte;koblenz-stadtmitte;8091873;;7.589988;50.357714;;f;DE;f;Europe/Berlin;t;;;f;;f;8003341;t;;f;;f;;f;;f;;f;;Coblence;;;Coblenza;;;Coblenza;;コブレンツ;코블렌츠;;Koblencja;Coblença;Кобленц;;;科布倫茨
+12370;Koblenz Stadtmitte;koblenz-stadtmitte;8091873;;7.589988;50.357714;;f;DE;f;Europe/Berlin;t;;;f;;f;8003341;t;;f;;f;;f;;f;;f;;Coblence;;;Coblenza;Coblenza;;;;コブレンツ;코블렌츠;;Koblencja;Coblença;Кобленц;;;科布倫茨
 12371;Klosterlechfeld;klosterlechfeld;8002184;;10.83263;48.155393;;f;DE;f;Europe/Berlin;t;;;f;;f;8003342;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12372;Friedrichshafen-Kluftern;friedrichshafen-kluftern;8084736;;9.409512;47.688152;;f;DE;f;Europe/Berlin;t;;;f;;f;8003345;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12373;Knesebeck;knesebeck;8013168;;10.690268;52.677812;;f;DE;f;Europe/Berlin;t;;;f;;f;8003348;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -10888,7 +10888,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12381;Köln Frankfurter Straße;koln-frankfurter-strasse;8080777;;7.051264;50.915216;;f;DE;f;Europe/Berlin;t;;;f;;f;8003358;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12382;Köln Geldernstr./Parkgürtel;koln-geldernstr-parkgurtel;8015646;;6.941416;50.968549;;f;DE;f;Europe/Berlin;t;;;f;;f;8003360;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12383;Köln Volkhovener Weg;koln-volkhovener-weg;8015647;;6.893395;51.014268;;f;DE;f;Europe/Berlin;t;;;f;;f;8003362;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12384;Köln West;koln-west;8015468;;6.934386;50.943667;;f;DE;f;Europe/Berlin;t;;;f;;f;8003363;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Kolín nad Rýnem;;Colonia;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
+12384;Köln West;koln-west;8015468;;6.934386;50.943667;;f;DE;f;Europe/Berlin;t;;;f;;f;8003363;t;;f;;f;;f;;f;;f;;Cologne;Cologne;;Colonia;Colonia;Kolín nad Rýnem;;;ケルン;쾰른;Keulen;Kolonia;Colônia;Кёльн;;;科隆
 12385;Köln-Buchforst;koln-buchforst;8015120;;7.004322;50.953483;;f;DE;f;Europe/Berlin;t;;;f;;f;8003364;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12386;Köln-Chorweiler;koln-chorweiler;8015463;;6.897971;51.021046;;f;DE;f;Europe/Berlin;t;;;f;;f;8003365;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12387;Köln-Chorweiler Nord;koln-chorweiler-nord;8015648;;6.892775;51.02813;;f;DE;f;Europe/Berlin;t;;;f;;f;8003366;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -11101,7 +11101,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12594;Lübeck St Jürgen;lubeck-st-jurgen;8004930;;10.700866;53.842374;;f;DE;f;Europe/Berlin;t;;;f;;f;8003774;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12595;Lübeck-Kücknitz;lubeck-kucknitz;8004935;;10.818886;53.924949;;f;DE;f;Europe/Berlin;t;;;f;;f;8003776;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12596;Lüchtringen;luchtringen;8013328;;9.426511;51.790559;;f;DE;f;Europe/Berlin;t;;;f;;f;8003780;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12597;Lübeck Flughafen;lubeck-flughafen;8001682;;10.69772;53.803181;;f;DE;f;Europe/Berlin;t;;;f;;f;8003781;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;;;Lubeca;;リューベック;뤼베크;;Lubeka;;Любек;;;吕贝克
+12597;Lübeck Flughafen;lubeck-flughafen;8001682;;10.69772;53.803181;;f;DE;f;Europe/Berlin;t;;;f;;f;8003781;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Lubeca;;;;リューベック;뤼베크;;Lubeka;;Любек;;;吕贝克
 12598;Lüdenscheid;ludenscheid;8008378;;7.628857;51.220849;;f;DE;f;Europe/Berlin;t;;;f;;f;8003782;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Люденшайд;;;吕登沙伊德
 12599;Lüdinghausen;ludinghausen;8021113;;7.431652;51.761838;;f;DE;f;Europe/Berlin;t;;;f;;f;8003783;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Людингхаузен;;;吕丁格豪森
 12600;Lügde;lugde;8013447;;9.250826;51.959295;;f;DE;f;Europe/Berlin;t;;;f;;f;8003784;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Люгде;;;吕格德
@@ -11120,7 +11120,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12613;Mainaschaff;mainaschaff;8011348;;9.085739;49.982406;;f;DE;f;Europe/Berlin;t;;;f;;f;8003810;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12614;Mainleus;mainleus;8022018;;11.379525;50.099814;;f;DE;f;Europe/Berlin;t;;;f;;f;8003813;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12615;Mainroth;mainroth;8022019;;11.319288;50.12066;;f;DE;f;Europe/Berlin;t;;;f;;f;8003814;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12616;Mainz Nord;mainz-nord;8019070;;8.246847;50.020061;;f;DE;f;Europe/Berlin;t;;;f;;f;8003815;t;;f;;f;;f;;f;;f;;Mayence;;;Magonza;Mohuč;;Maguncia;;マインツ;마인츠;;Moguncja;Mogúncia;Майнц;;;美因茨
+12616;Mainz Nord;mainz-nord;8019070;;8.246847;50.020061;;f;DE;f;Europe/Berlin;t;;;f;;f;8003815;t;;f;;f;;f;;f;;f;;Mayence;;;Magonza;Maguncia;Mohuč;;;マインツ;마인츠;;Moguncja;Mogúncia;Майнц;;;美因茨
 12617;Mainz Römisches Theater;mainz-romisches-theater;8019054;;8.277563;49.993462;;f;DE;f;Europe/Berlin;t;DEAPE;;f;;f;8003816;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12618;Mainz-Gonsenheim;mainz-gonsenheim;8019268;;8.214477;49.997759;;f;DE;f;Europe/Berlin;t;;;f;;f;8003817;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12619;Mainz-Gustavsburg;mainz-gustavsburg;8011232;;8.314194;49.994316;;f;DE;f;Europe/Berlin;t;;;f;;f;8003818;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -11146,7 +11146,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12639;Marbach (Neckar);marbach-neckar;8029593;;9.264507;48.943747;;f;DE;f;Europe/Berlin;t;;;f;;f;8003853;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12640;Marbach West (Villingen-Schwenningen);marbach-west-villingen-schwenningen;8080297;;8.469151;48.031288;;f;DE;f;Europe/Berlin;t;;;f;;f;8003854;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12641;Marbeck-Heiden;marbeck-heiden;8010257;;6.90607;51.8094;;f;DE;f;Europe/Berlin;t;;;f;;f;8003855;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12642;Marburg Süd;marburg-sud;8005388;;8.762433;50.794464;;f;DE;f;Europe/Berlin;t;;;f;;f;8003856;t;;f;;f;;f;;f;;f;;Marbourg;;;;;;Marburgo;;マールブルク;;;;Marburgo;Марбург;;;
+12642;Marburg Süd;marburg-sud;8005388;;8.762433;50.794464;;f;DE;f;Europe/Berlin;t;;;f;;f;8003856;t;;f;;f;;f;;f;;f;;Marbourg;;;;Marburgo;;;;マールブルク;;;;Marburgo;Марбург;;;
 12643;Marbach Ost (Villingen-Schwenningen);marbach-ost-villingen-schwenningen;8072023;;8.475883;48.033679;;f;DE;f;Europe/Berlin;t;;;f;;f;8003857;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12644;Maria Veen;maria-veen;8021139;;7.09817;51.839262;;f;DE;f;Europe/Berlin;t;;;f;;f;8003860;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12645;Markelsheim;markelsheim;8029737;;9.835421;49.478264;;f;DE;f;Europe/Berlin;t;;;f;;f;8003873;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -11426,7 +11426,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12919;Niederzeuzheim;niederzeuzheim;8011541;;8.039691;50.468228;;f;DE;f;Europe/Berlin;t;;;f;;f;8004424;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12920;Niefern;niefern;8029498;;8.769273;48.920132;;f;DE;f;Europe/Berlin;t;;;f;;f;8004425;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12921;Münster-Häger;munster-hager;8021147;;7.562337;52.022058;;f;DE;f;Europe/Berlin;t;;;f;;f;8004426;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12922;Frankfurt (M) Konstablerwache;frankfurt-m-konstablerwache;8011078;;8.687094;50.114619;;f;DE;f;Europe/Berlin;t;;;f;;f;8004429;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+12922;Frankfurt (M) Konstablerwache;frankfurt-m-konstablerwache;8011078;;8.687094;50.114619;;f;DE;f;Europe/Berlin;t;;;f;;f;8004429;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 12923;Velbert-Nierenhof;velbert-nierenhof;8008162;;7.134127;51.372255;;f;DE;f;Europe/Berlin;t;;;f;;f;8004430;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12924;Nieukerk;nieukerk;8015027;;6.37559;51.458084;;f;DE;f;Europe/Berlin;t;;;f;;f;8004433;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12925;Nievenheim;nievenheim;8015307;;6.782118;51.123667;;f;DE;f;Europe/Berlin;t;;;f;;f;8004434;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -11451,7 +11451,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 12944;Norsingen;norsingen;8014407;;7.726192;47.939247;;f;DE;f;Europe/Berlin;t;;;f;;f;8004464;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12945;Nürnberg Nordost;nurnberg-nordost;8022210;;11.105453;49.473733;;f;DE;f;Europe/Berlin;t;;;f;;f;8004469;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12946;Nürnberg Ostring;nurnberg-ostring;8022588;;11.119935;49.454128;;f;DE;f;Europe/Berlin;t;;;f;;f;8004470;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-12947;Nürnberg Ost;nurnberg-ost;8022209;;11.120887;49.463809;;f;DE;f;Europe/Berlin;t;;;f;;f;8004471;t;;f;;f;;f;;f;;f;;Nuremberg;Nuremberg;;Norimberga;Norimberk;;Núremberg;;ニュルンベルク;뉘른베르크;Neurenberg;Norymberga;Nuremberga;Нюрнберг;;Nuremberg;纽伦堡
+12947;Nürnberg Ost;nurnberg-ost;8022209;;11.120887;49.463809;;f;DE;f;Europe/Berlin;t;;;f;;f;8004471;t;;f;;f;;f;;f;;f;;Nuremberg;Nuremberg;;Norimberga;Núremberg;Norimberk;;;ニュルンベルク;뉘른베르크;Neurenberg;Norymberga;Nuremberga;Нюрнберг;;Nuremberg;纽伦堡
 12948;Nürnberg Rothenburger Str.;nurnberg-rothenburger-str;8022192;;11.055338;49.445399;;f;DE;f;Europe/Berlin;t;;;f;;f;8004473;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12949;Bochum-Langendreer West;bochum-langendreer-west;8010405;;7.304364;51.478175;;f;DE;f;Europe/Berlin;t;;;f;;f;8004474;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 12950;Nürnberg-Dutzendteich;nurnberg-dutzendteich;8022207;;11.117382;49.437066;;f;DE;f;Europe/Berlin;t;;;f;;f;8004476;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -11814,7 +11814,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 13307;Rupprechtstegen;rupprechtstegen;8022306;;11.480483;49.597434;;f;DE;f;Europe/Berlin;t;;;f;;f;8005231;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13308;Rutesheim;rutesheim;8029445;;8.959548;48.790013;;f;DE;f;Europe/Berlin;t;;;f;;f;8005236;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13309;Saal (Donau);saal-donau;8026317;;11.933198;48.902424;;f;DE;f;Europe/Berlin;t;;;f;;f;8005238;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-13310;Saarbrücken Ost;saarbrucken-ost;8025468;;7.019074;49.230134;;f;DE;f;Europe/Berlin;t;;;f;;f;8005241;t;;f;;f;;f;;f;;f;;Sarrebruck;;;;;;Sarrebruck;;ザールブリュッケン;자르브뤼켄;;;;Саарбрюккен;;;萨尔布吕肯
+13310;Saarbrücken Ost;saarbrucken-ost;8025468;;7.019074;49.230134;;f;DE;f;Europe/Berlin;t;;;f;;f;8005241;t;;f;;f;;f;;f;;f;;Sarrebruck;;;;Sarrebruck;;;;ザールブリュッケン;자르브뤼켄;;;;Саарбрюккен;;;萨尔布吕肯
 13311;Saarbrücken-Burbach;saarbrucken-burbach;8025385;;6.957084;49.242171;;f;DE;f;Europe/Berlin;t;;;f;;f;8005243;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13312;Saarhölzbach;saarholzbach;8025353;;6.607502;49.516441;;f;DE;f;Europe/Berlin;t;;;f;;f;8005246;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13313;Saasen;saasen;8011636;;8.881917;50.593942;;f;DE;f;Europe/Berlin;t;;;f;;f;8005249;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12112,13 +12112,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 13605;Traunreut;traunreut;8020094;;12.58977;47.965064;;f;DE;f;Europe/Berlin;t;;;f;;f;8005894;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13606;Trechtingshausen;trechtingshausen;8019037;;7.852356;50.009041;;f;DE;f;Europe/Berlin;t;;;f;;f;8005896;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13607;Triangel;triangel;8013172;;10.577876;52.509246;;f;DE;f;Europe/Berlin;t;;;f;;f;8005901;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-13608;Trier Süd;trier-sud;8025183;;6.636879;49.744659;;f;DE;f;Europe/Berlin;t;;;f;;f;8005905;t;;f;;f;;f;;f;;f;;Trèves;;;Treviri;Trevír;;Tréveris;;トリーア;트리어;;Trewir;Tréveris;Трир;;;特里尔
+13608;Trier Süd;trier-sud;8025183;;6.636879;49.744659;;f;DE;f;Europe/Berlin;t;;;f;;f;8005905;t;;f;;f;;f;;f;;f;;Trèves;;;Treviri;Tréveris;Trevír;;;トリーア;트리어;;Trewir;Tréveris;Трир;;;特里尔
 13609;Triesdorf;triesdorf;8022747;;10.67914;49.200919;;f;DE;f;Europe/Berlin;t;;;f;;f;8005907;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13610;Trochtelfingen (b Bopfingen);trochtelfingen-b-bopfingen;8029559;;10.401445;48.838384;;f;DE;f;Europe/Berlin;t;;;f;;f;8005908;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13611;Trompet;trompet;8015106;;6.669016;51.413318;;f;DE;f;Europe/Berlin;t;;;f;;f;8005910;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13612;Trossingen Bahnhof;trossingen-bahnhof;8029434;;8.585318;48.08765;;f;DE;f;Europe/Berlin;t;;;f;;f;8005911;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13613;Trostberg;trostberg;8020137;;12.555647;48.024735;;f;DE;f;Europe/Berlin;t;;;f;;f;8005912;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-13614;Tübingen West;tubingen-west;8029333;;9.038249;48.52004;;f;DE;f;Europe/Berlin;t;;;f;;f;8005916;t;;f;;f;;f;;f;;f;;;;;Tubinga;;;Tubinga;;テュービンゲン;튀빙겐;;Tybinga;Tubinga;Тюбинген;;;蒂宾根
+13614;Tübingen West;tubingen-west;8029333;;9.038249;48.52004;;f;DE;f;Europe/Berlin;t;;;f;;f;8005916;t;;f;;f;;f;;f;;f;;;;;Tubinga;Tubinga;;;;テュービンゲン;튀빙겐;;Tybinga;Tubinga;Тюбинген;;;蒂宾根
 13615;Tübingen-Derendingen;tubingen-derendingen;8029334;;9.050591;48.503482;;f;DE;f;Europe/Berlin;t;;;f;;f;8005917;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13616;Tübingen-Lustnau;tubingen-lustnau;8029316;;9.094872;48.52405;;f;DE;f;Europe/Berlin;t;;;f;;f;8005918;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13617;Türkenfeld;turkenfeld;8002167;;11.077281;48.104721;;f;DE;f;Europe/Berlin;t;;;f;;f;8005920;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12395,7 +12395,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 13888;Würgendorf;wurgendorf;8088437;;8.141368;50.76;;f;DE;f;Europe/Berlin;t;;;f;;f;8006577;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13889;Würgendorf (Ort);wurgendorf-ort;8088438;;8.126374;50.75697;;f;DE;f;Europe/Berlin;t;;;f;;f;8006578;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13890;Würzbach (Saar);wurzbach-saar;8025470;;7.193437;49.244184;;f;DE;f;Europe/Berlin;t;;;f;;f;8006581;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-13891;Würzburg Süd;wurzburg-sud;8022668;;9.943498;49.788194;;f;DE;f;Europe/Berlin;t;;;f;;f;8006582;t;;f;;f;;f;;f;;f;;Wurtzbourg;;;;;;Wurzburgo;;ヴュルツブルク;뷔르츠부르크;;;Wurtzburgo;Вюрцбург;;;维尔茨堡
+13891;Würzburg Süd;wurzburg-sud;8022668;;9.943498;49.788194;;f;DE;f;Europe/Berlin;t;;;f;;f;8006582;t;;f;;f;;f;;f;;f;;Wurtzbourg;;;;Wurzburgo;;;;ヴュルツブルク;뷔르츠부르크;;;Wurtzburgo;Вюрцбург;;;维尔茨堡
 13892;Würzburg-Zell;wurzburg-zell;8022537;;9.884592;49.804941;;f;DE;f;Europe/Berlin;t;;;f;;f;8006586;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13893;Wüstenselbitz;wustenselbitz;8026030;;11.709555;50.218426;;f;DE;f;Europe/Berlin;t;;;f;;f;8006588;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13894;Wulfen (Westf);wulfen-westf;8021136;;7.011702;51.719301;;f;DE;f;Europe/Berlin;t;;;f;;f;8006590;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12446,9 +12446,9 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 13939;Zwingenberg (Baden);zwingenberg-baden;8014123;;9.042833;49.416031;;f;DE;f;Europe/Berlin;t;;;f;;f;8006686;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13940;Zwingenberg (Bergstr);zwingenberg-bergstr;8011303;;8.609122;49.725898;;f;DE;f;Europe/Berlin;t;;;f;;f;8006687;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13941;Unterschleißheim;unterschleissheim;8020559;;11.568631;48.2737;;f;DE;f;Europe/Berlin;t;;;f;;f;8006688;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Унтершлайсхайм;;;翁特尔斯希莱斯海姆
-13942;Frankfurt (M) Galluswarte;frankfurt-m-galluswarte;8011704;;8.644719;50.10403;;f;DE;f;Europe/Berlin;t;;;f;;f;8006690;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-13943;Frankfurt (M) Taunusanlage;frankfurt-m-taunusanlage;8011136;;8.668864;50.113567;;f;DE;f;Europe/Berlin;t;;;f;;f;8006691;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-13944;Frankfurt (M) Hauptwache;frankfurt-m-hauptwache;8011139;;8.67895;50.113927;;f;DE;f;Europe/Berlin;t;;;f;;f;8006692;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+13942;Frankfurt (M) Galluswarte;frankfurt-m-galluswarte;8011704;;8.644719;50.10403;;f;DE;f;Europe/Berlin;t;;;f;;f;8006690;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+13943;Frankfurt (M) Taunusanlage;frankfurt-m-taunusanlage;8011136;;8.668864;50.113567;;f;DE;f;Europe/Berlin;t;;;f;;f;8006691;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+13944;Frankfurt (M) Hauptwache;frankfurt-m-hauptwache;8011139;;8.67895;50.113927;;f;DE;f;Europe/Berlin;t;;;f;;f;8006692;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 13945;München-Neuperlach Süd;munchen-neuperlach-sud;8020558;;11.645156;48.088621;;f;DE;f;Europe/Berlin;t;;;f;;f;8006696;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13946;Stuttgart Schwabstr.;stuttgart-schwabstr;8029373;;9.156538;48.770237;;f;DE;f;Europe/Berlin;t;;;f;;f;8006698;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 13947;Stuttgart Feuersee;stuttgart-feuersee;8029374;;9.166273;48.772763;;f;DE;f;Europe/Berlin;t;;;f;;f;8006699;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12651,7 +12651,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14144;Trossingen Stadt;trossingen-stadt;8035439;;8.631208;48.07405;;f;DE;f;Europe/Berlin;t;;;f;;f;8007646;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14145;Wangerooge Flugplatz;wangerooge-flugplatz;8094426;;7.909185;53.788106;;f;DE;f;Europe/Berlin;t;;;f;;f;8007757;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14146;Helgoland (Reede);helgoland-reede;;;7.893445;54.179424;;f;DE;f;Europe/Berlin;f;;;f;;f;8007759;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14147;Wyk auf Föhr;wyk-auf-fohr;;;8.576608;54.692879;;f;DE;f;Europe/Berlin;t;;;f;;f;8007760;t;;f;;f;;f;;f;;f;;;;;;;Vyk;;;;;;;;Вик-ауф-Фёр;;;维克奥夫弗赫尔
+14147;Wyk auf Föhr;wyk-auf-fohr;;;8.576608;54.692879;;f;DE;f;Europe/Berlin;t;;;f;;f;8007760;t;;f;;f;;f;;f;;f;;;;;;;;Vyk;;;;;;;Вик-ауф-Фёр;;;维克奥夫弗赫尔
 14148;Wittdün (Amrum);wittdun-amrum;;;8.397767;54.629155;;f;DE;f;Europe/Berlin;t;;;f;;f;8007761;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14149;Norderney;norderney;8021454;;7.164204;53.697773;;f;DE;f;Europe/Berlin;t;;;f;;f;8007762;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14150;Juist;juist;8021455;;6.995765;53.672127;;f;DE;f;Europe/Berlin;t;;;f;;f;8007763;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12736,7 +12736,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14229;Bremen Turnerstraße;bremen-turnerstrasse;8088638;;8.544633;53.193613;;f;DE;f;Europe/Berlin;t;;;f;;f;8007897;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14230;Bremen-Farge;bremen-farge;8044901;;8.516065;53.205254;;f;DE;f;Europe/Berlin;t;;;f;;f;8007898;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14231;Adorf (Vogtl);adorf-vogtl;8006725;;12.261043;50.323501;;f;DE;f;Europe/Berlin;t;;;f;;f;8010001;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14232;Altenburg;altenburg;8023563;;12.443938;50.996569;;f;DE;f;Europe/Berlin;t;;;f;;f;8010003;t;;f;;f;;f;;f;;f;;Altenbourg;;;;;;Altenburgo;;アルテンブルク;알텐부르크;;;;Альтенбург;;;阿尔滕堡
+14232;Altenburg;altenburg;8023563;;12.443938;50.996569;;f;DE;f;Europe/Berlin;t;;;f;;f;8010003;t;;f;;f;;f;;f;;f;;Altenbourg;;;;Altenburgo;;;;アルテンブルク;알텐부르크;;;;Альтенбург;;;阿尔滕堡
 14233;Angermünde;angermunde;8028324;;13.996357;53.015222;;f;DE;f;Europe/Berlin;t;;;f;;f;8010004;t;;f;;f;;f;;f;;f;;;;;;;;;;アンガーミュンデ;;;;;Ангермюнде;;;安格尔明德
 14234;Annaberg-Buchholz Süd;annaberg-buchholz-sud;8006431;;12.998132;50.556619;;f;DE;f;Europe/Berlin;t;;;f;;f;8010005;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14235;Arnsdorf (Dresden);arnsdorf-dresden;8006176;;13.982208;51.092807;;f;DE;f;Europe/Berlin;t;;;f;;f;8010006;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12796,7 +12796,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14289;Eilsleben (b Magdeburg);eilsleben-b-magdeburg;8024034;;11.215211;52.150235;;f;DE;f;Europe/Berlin;t;;;f;;f;8010096;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14290;Elsterwerda;elsterwerda;8004348;;13.516432;51.459675;;f;DE;f;Europe/Berlin;t;;;f;;f;8010099;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14291;Elsterwerda-Biehla;elsterwerda-biehla;8004308;;13.519614;51.472197;;f;DE;f;Europe/Berlin;t;;;f;;f;8010100;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14292;Erfurt Nord;erfurt-nord;8016426;;11.029755;51.003104;;f;DE;f;Europe/Berlin;t;;;f;;f;8010102;t;;f;;f;;f;;f;;f;;;;;;;;Érfurt;;エアフルト;에르푸르트;;;;Эрфурт;;;埃尔福特
+14292;Erfurt Nord;erfurt-nord;8016426;;11.029755;51.003104;;f;DE;f;Europe/Berlin;t;;;f;;f;8010102;t;;f;;f;;f;;f;;f;;;;;;Érfurt;;;;エアフルト;에르푸르트;;;;Эрфурт;;;埃尔福特
 14293;Falkenberg (Elster);falkenberg-elster;8023235;;13.247681;51.583618;;f;DE;f;Europe/Berlin;t;;;f;;f;8010103;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14294;Eisenach Opelwerke Hp;eisenach-opelwerke-hp;8016098;;10.283488;50.979336;;f;DE;f;Europe/Berlin;t;;;f;;f;8010105;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14295;Falkenstein (Vogtl);falkenstein-vogtl;8059003;;12.36174;50.479302;;f;DE;f;Europe/Berlin;t;;;f;;f;8010106;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12854,7 +12854,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14347;Jatznick;jatznick;8028422;;13.937666;53.603063;;f;DE;f;Europe/Berlin;t;;;f;;f;8010179;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14348;Jüterbog;juterbog;8003449;;13.05435;51.997508;;f;DE;f;Europe/Berlin;t;;;f;;f;8010182;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Йютербог;;;于特博格
 14349;Sedlitz Ost;sedlitz-ost;8004271;;14.055254;51.5531;;f;DE;f;Europe/Berlin;t;;;f;;f;8010183;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14350;Chemnitz Süd;chemnitz-sud;8006558;;12.92682;50.823742;;f;DE;f;Europe/Berlin;t;;;f;;f;8010185;t;;f;;f;;f;;f;;f;;;;;;Saská Kamenice;;;;ケムニッツ;켐니츠;;;;Хемниц;;;开姆尼茨
+14350;Chemnitz Süd;chemnitz-sud;8006558;;12.92682;50.823742;;f;DE;f;Europe/Berlin;t;;;f;;f;8010185;t;;f;;f;;f;;f;;f;;;;;;;Saská Kamenice;;;ケムニッツ;켐니츠;;;;Хемниц;;;开姆尼茨
 14351;Karow (Meckl);karow-meckl;8027166;;12.272262;53.540273;;f;DE;f;Europe/Berlin;t;;;f;;f;8010188;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14352;Küstrin-Kietz;kustrin-kietz;8003279;;14.607911;52.568476;;f;DE;f;Europe/Berlin;t;;;f;;f;8010189;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14353;Klostermansfeld;klostermansfeld;8024232;;11.491899;51.574683;;f;DE;f;Europe/Berlin;t;;;f;;f;8010191;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -12890,7 +12890,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14383;Müncheberg (Mark);muncheberg-mark;8003269;;14.100335;52.524726;;f;DE;f;Europe/Berlin;t;;;f;;f;8010236;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Мюнхеберг;;;明歇贝格
 14384;Narsdorf;narsdorf;8023538;;12.716284;51.010826;;f;DE;f;Europe/Berlin;t;;;f;;f;8010238;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14385;Nauen;nauen;8003528;;12.88556;52.612694;;f;DE;f;Europe/Berlin;t;;;f;;f;8010239;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14386;Neubrandenburg;neubrandenburg;8028126;;13.261462;53.561829;;f;DE;f;Europe/Berlin;t;;;f;;f;8010241;t;;f;;f;;f;;f;;f;;Neubrandenbourg;;;;;;Nuevo Brandeburgo;;ノイブランデンブルク;노이브란덴부르크;;;;Нойбранденбурге;;;新勃兰登堡
+14386;Neubrandenburg;neubrandenburg;8028126;;13.261462;53.561829;;f;DE;f;Europe/Berlin;t;;;f;;f;8010241;t;;f;;f;;f;;f;;f;;Neubrandenbourg;;;;Nuevo Brandeburgo;;;;ノイブランデンブルク;노이브란덴부르크;;;;Нойбранденбурге;;;新勃兰登堡
 14387;Neudietendorf;neudietendorf;8016048;;10.910989;50.914506;;f;DE;f;Europe/Berlin;t;;;f;;f;8010242;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14388;Neukieritzsch;neukieritzsch;8023558;;12.413249;51.150293;;f;DE;f;Europe/Berlin;t;;;f;;f;8010243;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14389;Neumark (Sachs);neumark-sachs;8006702;;12.352661;50.660192;;f;DE;f;Europe/Berlin;t;;;f;;f;8010244;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13133,7 +13133,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14626;Borna (Leipzig);borna-leipzig;8023532;;12.486295;51.117923;;f;DE;f;Europe/Berlin;t;;;f;;f;8011242;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14627;Brahlstorf;brahlstorf;8027334;;10.951989;53.364417;;f;DE;f;Europe/Berlin;t;;;f;;f;8011248;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14628;Brand (Niederlausitz);brand-niederlausitz;8004007;;13.721494;52.029951;;f;DE;f;Europe/Berlin;t;;;f;;f;8011250;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14629;Brandenburg Altstadt;brandenburg-altstadt;8024290;;12.530342;52.411695;;f;DE;f;Europe/Berlin;t;;;f;;f;8011252;t;;f;;f;;f;;f;;f;;Brandebourg;;;Brandeburgo;;;Brandeburgo;;ブランデンブルク・アン・デア・ハーフェル;브란덴부르크안데어하펠;;;;Бранденбург;;;哈弗尔河畔勃兰登堡
+14629;Brandenburg Altstadt;brandenburg-altstadt;8024290;;12.530342;52.411695;;f;DE;f;Europe/Berlin;t;;;f;;f;8011252;t;;f;;f;;f;;f;;f;;Brandebourg;;;Brandeburgo;Brandeburgo;;;;ブランデンブルク・アン・デア・ハーフェル;브란덴부르크안데어하펠;;;;Бранденбург;;;哈弗尔河畔勃兰登堡
 14630;Braunsbedra;braunsbedra;8023021;;11.884593;51.288781;;f;DE;f;Europe/Berlin;t;;;f;;f;8011255;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14631;Braunsbedra Ost;braunsbedra-ost;8023020;;11.902239;51.289941;;f;DE;f;Europe/Berlin;t;;;f;;f;8011256;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14632;Braunsdorf-Lichtenwalde;braunsdorf-lichtenwalde;8042954;;13.012056;50.880104;;f;DE;f;Europe/Berlin;t;;;f;;f;8011257;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13203,7 +13203,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14696;Döberitz;doberitz;8024284;;12.368464;52.52433;;f;DE;f;Europe/Berlin;t;;;f;;f;8011390;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14697;Dörrberg;dorrberg;8016187;;10.798669;50.735351;;f;DE;f;Europe/Berlin;t;;;f;;f;8011397;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14698;Dohna (Sachs);dohna-sachs;8006029;;13.855415;50.960953;;f;DE;f;Europe/Berlin;t;;;f;;f;8011398;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14699;Dresden Flughafen;dresden-flughafen;8065112;;13.766224;51.124854;;f;DE;f;Europe/Berlin;t;;;f;;f;8011399;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Drážďany;;Dresde;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
+14699;Dresden Flughafen;dresden-flughafen;8065112;;13.766224;51.124854;;f;DE;f;Europe/Berlin;t;;;f;;f;8011399;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Dresde;Drážďany;;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
 14700;Domnitz (Saalkr);domnitz-saalkr;8023115;;11.835044;51.636906;;f;DE;f;Europe/Berlin;t;;;f;;f;8011402;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14701;Domsühl;domsuhl;8058191;;11.765872;53.485367;;f;DE;f;Europe/Berlin;t;;;f;;f;8011403;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14702;Dorfchemnitz;dorfchemnitz;8006589;;12.839652;50.665397;;f;DE;f;Europe/Berlin;t;;;f;;f;8011405;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13258,7 +13258,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14751;Engelsdorf Werkstätten;engelsdorf-werkstatten;8047958;;12.456082;51.340802;;f;DE;f;Europe/Berlin;t;;;f;;f;8011495;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14752;Erdeborn;erdeborn;8023051;;11.636967;51.468799;;f;DE;f;Europe/Berlin;t;;;f;;f;8011496;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14753;Erdmannsdorf-Augustusburg;erdmannsdorf-augustusburg;8006417;;13.083961;50.821279;;f;DE;f;Europe/Berlin;t;;;f;;f;8011497;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14754;Erfurt Ost;erfurt-ost;8016463;;11.043769;51.014538;;f;DE;f;Europe/Berlin;t;;;f;;f;8011500;t;;f;;f;;f;;f;;f;;;;;;;;Érfurt;;エアフルト;에르푸르트;;;;Эрфурт;;;埃尔福特
+14754;Erfurt Ost;erfurt-ost;8016463;;11.043769;51.014538;;f;DE;f;Europe/Berlin;t;;;f;;f;8011500;t;;f;;f;;f;;f;;f;;;;;;Érfurt;;;;エアフルト;에르푸르트;;;;Эрфурт;;;埃尔福特
 14755;Erfurt-Bischleben;erfurt-bischleben;8016047;;10.98844;50.93377;;f;DE;f;Europe/Berlin;t;;;f;;f;8011502;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14756;Erfurt-Gispersleben;erfurt-gispersleben;8016433;;11.000279;51.022125;;f;DE;f;Europe/Berlin;t;;;f;;f;8011503;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14757;Erla;erla;8006667;;12.787811;50.520599;;f;DE;f;Europe/Berlin;t;;;f;;f;8011505;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13392,7 +13392,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14885;Großräschen;grossraschen;8004219;;14.014902;51.591484;;f;DE;f;Europe/Berlin;t;;;f;;f;8011756;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гросрешен;;;格罗斯雷申
 14886;Großröhrsdorf;grossrohrsdorf;8006190;;14.017446;51.148774;;f;DE;f;Europe/Berlin;t;;;f;;f;8011758;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Гросрёрсдорф;;;格罗斯勒赫尔斯多夫
 14887;Großrudestedt;grossrudestedt;8016465;;11.091088;51.095648;;f;DE;f;Europe/Berlin;t;;;f;;f;8011759;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14888;Großschönau (Sachs);grossschonau-sachs;8041838;;14.665739;50.892456;;f;DE;f;Europe/Berlin;t;;;f;;f;8011761;t;;f;;f;;f;;f;;f;;;;;;;;Grossschönau;;;;;;;;;;
+14888;Großschönau (Sachs);grossschonau-sachs;8041838;;14.665739;50.892456;;f;DE;f;Europe/Berlin;t;;;f;;f;8011761;t;;f;;f;;f;;f;;f;;;;;;Grossschönau;;;;;;;;;;;;
 14889;Großschwabhausen;grossschwabhausen;8016419;;11.47989;50.936071;;f;DE;f;Europe/Berlin;t;;;f;;f;8011762;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14890;Großsteinberg;grosssteinberg;8023497;;12.637502;51.250757;;f;DE;f;Europe/Berlin;t;;;f;;f;8011763;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14891;Großwudicke;grosswudicke;8024067;;12.231442;52.5905;;f;DE;f;Europe/Berlin;t;;;f;;f;8011766;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13499,7 +13499,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 14992;Altes Lager;altes-lager;8003457;;12.989044;52.017357;;f;DE;f;Europe/Berlin;t;;;f;;f;8011968;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Альтес Лагер;;;
 14993;Jütrichau;jutrichau;;;12.126403;51.934206;;f;DE;f;Europe/Berlin;f;;;f;;f;8011969;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14994;Chemnitz Kinderwaldstätte;chemnitz-kinderwaldstatte;8006327;;12.953878;50.884383;;f;DE;f;Europe/Berlin;t;;;f;;f;8011970;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-14995;Chemnitz Mitte;chemnitz-mitte;8006627;;12.912626;50.826556;;f;DE;f;Europe/Berlin;t;;;f;;f;8011971;t;;f;;f;;f;;f;;f;;;;;;Saská Kamenice;;;;ケムニッツ;켐니츠;;;;Хемниц;;;开姆尼茨
+14995;Chemnitz Mitte;chemnitz-mitte;8006627;;12.912626;50.826556;;f;DE;f;Europe/Berlin;t;;;f;;f;8011971;t;;f;;f;;f;;f;;f;;;;;;;Saská Kamenice;;;ケムニッツ;켐니츠;;;;Хемниц;;;开姆尼茨
 14996;Chemnitz-Borna Hp;chemnitz-borna-hp;8006531;;12.894459;50.85987;;f;DE;f;Europe/Berlin;t;;;f;;f;8011974;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14997;Chemnitz Erfenschlag;chemnitz-erfenschlag;8006581;;12.950138;50.787533;;f;DE;f;Europe/Berlin;t;;;f;;f;8011975;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 14998;Chemnitz-Harthau;chemnitz-harthau;8042903;;12.924052;50.776863;;f;DE;f;Europe/Berlin;t;;;f;;f;8011977;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13689,7 +13689,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15182;Medewitz (Mark);medewitz-mark;8003413;;12.391827;52.060703;;f;DE;f;Europe/Berlin;t;;;f;;f;8012322;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15183;Meerane;meerane;8006731;;12.457251;50.85097;;f;DE;f;Europe/Berlin;t;;;f;;f;8012323;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15184;Meinersdorf (Erzgeb);meinersdorf-erzgeb;8006587;;12.888625;50.723153;;f;DE;f;Europe/Berlin;t;;;f;;f;8012324;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15185;Meißen;meissen;8006255;;13.482435;51.162806;;f;DE;f;Europe/Berlin;t;;;f;;f;8012326;t;;f;;f;;f;;f;;f;;;;;Misnia;Míšeň;;;;マイセン;마이센;;Miśnia;;Мейсен;;;迈森
+15185;Meißen;meissen;8006255;;13.482435;51.162806;;f;DE;f;Europe/Berlin;t;;;f;;f;8012326;t;;f;;f;;f;;f;;f;;;;;Misnia;;Míšeň;;;マイセン;마이센;;Miśnia;;Мейсен;;;迈森
 15186;Meißen Triebischtal;meissen-triebischtal;8006256;;13.462883;51.152558;;f;DE;f;Europe/Berlin;t;;;f;;f;8012327;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15187;Meitzendorf;meitzendorf;8024043;;11.558968;52.209393;;f;DE;f;Europe/Berlin;t;;;f;;f;8012328;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15188;Melchow;melchow;8028225;;13.694373;52.774869;;f;DE;f;Europe/Berlin;t;;;f;;f;8012329;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13735,7 +13735,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15228;Mühlanger;muhlanger;8023255;;12.748214;51.855713;;f;DE;f;Europe/Berlin;t;;;f;;f;8012393;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15229;Mühlbach (Pirna);muhlbach-pirna;8006034;;13.817723;50.913841;;f;DE;f;Europe/Berlin;t;;;f;;f;8012394;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15230;Müllrose;mullrose;8003186;;14.434248;52.242042;;f;DE;f;Europe/Berlin;t;;;f;;f;8012400;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Мюлльрозе;;;米尔罗塞
-15231;München (Bad Berka);munchen-bad-berka;8016034;;11.254899;50.870054;;f;DE;f;Europe/Berlin;t;;;f;;f;8012401;t;;f;;f;;f;;f;;f;;Munich;Munich;;Monaco di Baviera;Mnichov;;Múnich;;ミュンヘン;뮌헨;;Monachium;Munique;Мюнхен;;Münih;慕尼黑
+15231;München (Bad Berka);munchen-bad-berka;8016034;;11.254899;50.870054;;f;DE;f;Europe/Berlin;t;;;f;;f;8012401;t;;f;;f;;f;;f;;f;;Munich;Munich;;Monaco di Baviera;Múnich;Mnichov;;;ミュンヘン;뮌헨;;Monachium;Munique;Мюнхен;;Münih;慕尼黑
 15232;Mulda (Sachs);mulda-sachs;8046274;;13.413119;50.808964;;f;DE;f;Europe/Berlin;t;;;f;;f;8012407;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15233;Muldenhütten;muldenhutten;8006348;;13.38874;50.905301;;f;DE;f;Europe/Berlin;t;;;f;;f;8012408;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15234;Muldenstein;muldenstein;8023147;;12.354046;51.667784;;f;DE;f;Europe/Berlin;t;;;f;;f;8012409;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13743,7 +13743,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15236;Nassau (Erzgeb);nassau-erzgeb;8046275;;13.485976;50.769564;;f;DE;f;Europe/Berlin;t;;;f;;f;8012412;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15237;Nassenheide;nassenheide;8028020;;13.239195;52.81692;;f;DE;f;Europe/Berlin;t;;;f;;f;8012413;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15238;Nauendorf (Saalkr);nauendorf-saalkr;8023114;;11.884503;51.608518;;f;DE;f;Europe/Berlin;t;;;f;;f;8012414;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15239;Naumburg (Saale) Ost;naumburg-saale-ost;8016653;;11.823898;51.155525;;f;DE;f;Europe/Berlin;t;;;f;;f;8012415;t;;f;;f;;f;;f;;f;;Naumbourg;;;;;;Naumburgo;;ナウムブルク;나움부르크;;;;Наумбург;;;瑙姆堡
+15239;Naumburg (Saale) Ost;naumburg-saale-ost;8016653;;11.823898;51.155525;;f;DE;f;Europe/Berlin;t;;;f;;f;8012415;t;;f;;f;;f;;f;;f;;Naumbourg;;;;Naumburgo;;;;ナウムブルク;나움부르크;;;;Наумбург;;;瑙姆堡
 15240;Naunhof;naunhof;8023496;;12.594237;51.277086;;f;DE;f;Europe/Berlin;t;;;f;;f;8012416;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15241;Nebra;nebra;8016633;;11.570123;51.283441;;f;DE;f;Europe/Berlin;t;;;f;;f;8012417;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15242;Nechlin;nechlin;8028336;;13.902878;53.440924;;f;DE;f;Europe/Berlin;t;;;f;;f;8012418;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -13880,7 +13880,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15373;Pirna-Copitz;pirna-copitz;8006073;;13.933828;50.968396;;f;DE;f;Europe/Berlin;t;;;f;;f;8012640;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15374;Pirna-Copitz Nord;pirna-copitz-nord;8065537;;13.935824;50.977916;;f;DE;f;Europe/Berlin;t;;;f;;f;8012641;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15375;Plate (Meckl);plate-meckl;8058185;;11.507019;53.553209;;f;DE;f;Europe/Berlin;t;;;f;;f;8012643;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15376;Plauen (Vogtl) West;plauen-vogtl-west;8098111;;12.113153;50.493964;;f;DE;f;Europe/Berlin;t;;;f;;f;8012646;t;;f;;f;;f;;f;;f;;;;;;Plavno;;;;プラウエン;플라우엔;;;;Плауэн;;;普劳恩
+15376;Plauen (Vogtl) West;plauen-vogtl-west;8098111;;12.113153;50.493964;;f;DE;f;Europe/Berlin;t;;;f;;f;8012646;t;;f;;f;;f;;f;;f;;;;;;;Plavno;;;プラウエン;플라우엔;;;;Плауэн;;;普劳恩
 15377;Plauen (V) Zellwolle;plauen-v-zellwolle;8059065;;12.109251;50.480714;;f;DE;f;Europe/Berlin;t;;;f;;f;8012647;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15378;Plessa;plessa;8004311;;13.61685;51.470848;;f;DE;f;Europe/Berlin;t;;;f;;f;8012650;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15379;Plüschow;pluschow;8027014;;11.285848;53.837061;;f;DE;f;Europe/Berlin;t;;;f;;f;8012651;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14196,7 +14196,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15689;Weißandt-Gölzau;weissandt-golzau;8023123;;12.028762;51.669672;;f;DE;f;Europe/Berlin;t;;;f;;f;8013259;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15690;Weißenfels West;weissenfels-west;8016005;;11.944992;51.194394;;f;DE;f;Europe/Berlin;t;;;f;;f;8013261;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15691;Weißes Roß;weisses-ross;8006901;;13.661814;51.106147;;f;DE;f;Europe/Berlin;t;;;f;;f;8013263;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15692;Weimar West;weimar-west;8023825;;11.311558;50.988083;;f;DE;f;Europe/Berlin;t;;;f;;f;8013266;t;;f;;f;;f;;f;;f;;;;;;Výmar;;;;ヴァイマル;바이마르;;;;Веймар;;;魏玛
+15692;Weimar West;weimar-west;8023825;;11.311558;50.988083;;f;DE;f;Europe/Berlin;t;;;f;;f;8013266;t;;f;;f;;f;;f;;f;;;;;;;Výmar;;;ヴァイマル;바이마르;;;;Веймар;;;魏玛
 15693;Weinböhla Hp;weinbohla-hp;8065536;;13.561549;51.159094;;f;DE;f;Europe/Berlin;t;;;f;;f;8013267;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Вайнбёла;;;韦因伯赫拉
 15694;Weixdorf;weixdorf;8006196;;13.806469;51.150482;;f;DE;f;Europe/Berlin;t;;;f;;f;8013268;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15695;Weixdorf Bad;weixdorf-bad;8006195;;13.801758;51.140072;;f;DE;f;Europe/Berlin;t;;;f;;f;8013269;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14264,8 +14264,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15757;Zeutsch;zeutsch;8016325;;11.50826;50.75493;;f;DE;f;Europe/Berlin;t;;;f;;f;8013398;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15758;Zielitz;zielitz;8024079;;11.679999;52.295869;;f;DE;f;Europe/Berlin;t;;;f;;f;8013402;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15759;Ziltendorf;ziltendorf;8003179;;14.616334;52.199514;;f;DE;f;Europe/Berlin;t;;;f;;f;8013406;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15760;Zittau Hp;zittau-hp;8006960;;14.81682;50.898424;;f;DE;f;Europe/Berlin;t;;;f;;f;8013410;t;;f;;f;;f;;f;;f;;;;;;Žitava;;;;ツィッタウの;;;Żytawa;;Циттау;;;齐陶
-15761;Zittau Süd;zittau-sud;8006962;;14.814753;50.890235;;f;DE;f;Europe/Berlin;t;;;f;;f;8013411;t;;f;;f;;f;;f;;f;;;;;;Žitava;;;;ツィッタウの;;;Żytawa;;Циттау;;;齐陶
+15760;Zittau Hp;zittau-hp;8006960;;14.81682;50.898424;;f;DE;f;Europe/Berlin;t;;;f;;f;8013410;t;;f;;f;;f;;f;;f;;;;;;;Žitava;;;ツィッタウの;;;Żytawa;;Циттау;;;齐陶
+15761;Zittau Süd;zittau-sud;8006962;;14.814753;50.890235;;f;DE;f;Europe/Berlin;t;;;f;;f;8013411;t;;f;;f;;f;;f;;f;;;;;;;Žitava;;;ツィッタウの;;;Żytawa;;Циттау;;;齐陶
 15762;Zittau Vorstadt;zittau-vorstadt;8006963;;14.792253;50.890685;;f;DE;f;Europe/Berlin;t;;;f;;f;8013412;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15763;Zoblitz;zoblitz;8006092;;14.750741;51.123577;;f;DE;f;Europe/Berlin;t;;;f;;f;8013413;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15764;Zöberitz;zoberitz;8023126;;12.033454;51.504612;;f;DE;f;Europe/Berlin;t;;;f;;f;8013414;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14283,7 +14283,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15776;Zwota-Zechenbach;zwota-zechenbach;8059027;;12.39999;50.351134;;f;DE;f;Europe/Berlin;t;;;f;;f;8013436;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15777;Zwota;zwota;8059026;;12.42755;50.352662;;f;DE;f;Europe/Berlin;t;;;f;;f;8013437;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15778;Blankenburg (Harz);blankenburg-harz;8024456;;10.961086;51.795656;;f;DE;f;Europe/Berlin;t;;;f;;f;8013439;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15779;Dresden Mitte;dresden-mitte;8006218;;13.72411;51.056167;;f;DE;f;Europe/Berlin;t;;;f;;f;8013444;t;;f;;f;;f;;f;;f;;Dresde;;;Dresda;Drážďany;;Dresde;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
+15779;Dresden Mitte;dresden-mitte;8006218;;13.72411;51.056167;;f;DE;f;Europe/Berlin;t;;;f;;f;8013444;t;;f;;f;;f;;f;;f;;Dresde;;;Dresda;Dresde;Drážďany;;Drezda;ドレスデン;드레스덴;;Drezno;;Дрезден;;;德累斯顿
 15780;Freital-Potschappel;freital-potschappel;8006340;;13.661679;51.013423;;f;DE;f;Europe/Berlin;t;;;f;;f;8013445;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15781;Groß Dalzig;gross-dalzig;8023601;;12.271354;51.208292;;f;DE;f;Europe/Berlin;t;;;f;;f;8013447;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15782;Halle-Silberhöhe;halle-silberhohe;8023090;;11.967006;51.445391;;f;DE;f;Europe/Berlin;t;;;f;;f;8013448;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14394,7 +14394,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 15887;Schömberg (b Rottweil);schomberg-b-rottweil;;;8.758504;48.205742;;f;DE;f;Europe/Berlin;f;;;f;;f;8029359;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15888;Westerland (Sylt) DB AutoZug SyltShuttle;westerland-sylt-db-autozug-syltshuttle;8030918;;8.311012;54.90631;;f;DE;f;Europe/Berlin;f;;;f;;f;8030918;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15889;Birkenstein;birkenstein;8033457;;13.647773;52.515701;;f;DE;f;Europe/Berlin;t;;;f;;f;8070002;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-15890;Frankfurt (M) Flughafen Regionalbf;frankfurt-m-flughafen-regionalbf;8011090;;8.57125;50.051218;;f;DE;f;Europe/Berlin;t;;;f;;f;8070004;t;;f;;f;;f;;f;;f;;Francfort Aéroport;Airport;;Francoforte Aeroporto;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+15890;Frankfurt (M) Flughafen Regionalbf;frankfurt-m-flughafen-regionalbf;8011090;;8.57125;50.051218;;f;DE;f;Europe/Berlin;t;;;f;;f;8070004;t;;f;;f;;f;;f;;f;;Francfort Aéroport;Airport;;Francoforte Aeroporto;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 15891;Heidenheim Voithwerk;heidenheim-voithwerk;8035252;;10.155886;48.669288;;f;DE;f;Europe/Berlin;t;;;f;;f;8070005;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15892;Bruchsal Tunnelstr.;bruchsal-tunnelstr;8039248;;8.594379;49.119549;;f;DE;f;Europe/Berlin;t;;;f;;f;8070008;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 15893;Bruchsal Schlachthof;bruchsal-schlachthof;8039249;;8.609715;49.118929;;f;DE;f;Europe/Berlin;t;;;f;;f;8070009;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -14971,7 +14971,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 16464;Zeutern Sportplatz;zeutern-sportplatz;8042100;;8.670059;49.17806;;f;DE;f;Europe/Berlin;t;;;f;;f;8079617;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16465;Rostock Thierfelder Str.;rostock-thierfelder-str;8034328;;12.099912;54.077873;;f;DE;f;Europe/Berlin;t;;;f;;f;8079629;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16466;Heilbr.-Böckingen Berufsschulzentrum;heilbr-bockingen-berufsschulzentrum;8034512;;9.182328;49.140431;;f;DE;f;Europe/Berlin;t;;;f;;f;8079631;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-16467;Frankfurt (Main) Messe;frankfurt-main-messe;8032564;;8.64337;50.112003;;f;DE;f;Europe/Berlin;t;;;f;;f;8079632;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Frankfurt nad Mohanem;;Francfort;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+16467;Frankfurt (Main) Messe;frankfurt-main-messe;8032564;;8.64337;50.112003;;f;DE;f;Europe/Berlin;t;;;f;;f;8079632;t;;f;;f;;f;;f;;f;;Francfort;;;Francoforte;Francfort;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 16468;Singen (Htw) Rielasinger-Str.;singen-htw-rielasinger-str;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;8079709;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16469;Singen (Htw) Markuskirche;singen-htw-markuskirche;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;8079795;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16470;Rielasingen Zoll;rielasingen-zoll;;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;8079808;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -15258,7 +15258,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 16751;Delitzsch;delitzsch;8082893;;12.346917;51.522608;;f;DE;f;Europe/Berlin;t;;;f;;f;8096001;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16752;Helgoland;helgoland;8001582;;7.896349;54.180089;;f;DE;f;Europe/Berlin;t;;;f;;f;8096002;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Хельголанд;;;
 16753;Jena;jena;8036672;;11.582726;50.924008;;f;DE;f;Europe/Berlin;t;;;f;;f;8096004;t;;f;;f;;f;;f;;f;;Iéna;;;;;;;;イェーナ;예나;;;;Йена;;;耶拿
-16754;Plauen;plauen;8031734;;12.12723;50.506755;;f;DE;f;Europe/Berlin;t;;;f;;f;8096005;t;;f;;f;;f;;f;;f;;;;;;Plavno;;;;プラウエン;플라우엔;;;;Плауэн;;;普劳恩
+16754;Plauen;plauen;8031734;;12.12723;50.506755;;f;DE;f;Europe/Berlin;t;;;f;;f;8096005;t;;f;;f;;f;;f;;f;;;;;;;Plavno;;;プラウエン;플라우엔;;;;Плауэн;;;普劳恩
 16755;Pößneck;possneck;8002758;;11.588443;50.690441;;f;DE;f;Europe/Berlin;t;;;f;;f;8096007;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Пёснек;;;珀斯内克
 16756;Leipzig;leipzig;;;12.383333;51.346546;;t;DE;f;Europe/Berlin;f;;;f;;f;8096008;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 16757;Elsterwerda;elsterwerda;;;13.516827;51.459666;;f;DE;f;Europe/Berlin;f;;;f;;f;8096010;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -15961,7 +15961,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17455;Mazancourt;mazancourt;;;;;;f;FR;f;Europe/Paris;f;FRZIU;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17456;Boucly;boucly;8758851;;3.014244;49.935365;;f;FR;f;Europe/Paris;t;FRZIV;;t;;f;8706677;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17457;Reichshoffen Usines;reichshoffen-usines;8721323;;7.652436;48.919431;10638;f;FR;f;Europe/Paris;t;FRZMB;;t;;f;8701866;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17458;Salzburg Hbf;salzburg-hbf;8101114;;13.045819401741028;47.813046443088425;;f;AT;f;Europe/Vienna;t;ATSZG;;f;;f;8100002;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Salcburk;;Salzburgo;;ザルツブルク;잘츠부르크;;;Salzburgo;Зальцбург;;;萨尔斯堡
+17458;Salzburg Hbf;salzburg-hbf;8101114;;13.045819401741028;47.813046443088425;;f;AT;f;Europe/Vienna;t;ATSZG;;f;;f;8100002;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Salzburgo;Salcburk;;;ザルツブルク;잘츠부르크;;;Salzburgo;Зальцбург;;;萨尔斯堡
 17459;Duivendrecht;duivendrecht;8400194;;4.936552;52.323556;;f;NL;f;Europe/Amsterdam;t;NLDAA;;t;;f;8400194;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17476;Montdidier;montdidier;;;;;;f;FR;f;Europe/Paris;f;FRZKG;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17478;Roye;roye;;;;;;t;FR;f;Europe/Paris;f;FRRIY;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -15972,7 +15972,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17494;Kampen;kampen;8400353;;5.9245740000;52.5606020000;;f;NL;t;Europe/Amsterdam;t;NLKAF;;f;;f;8400353;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17495;Bratislava hl.st.;bratislava-hl-st;5613206;;17.106463;48.158908;;f;SK;t;Europe/Bratislava;t;SKABI;;f;;f;5600207;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17496;Zagreb Glavni Kolod.;zagreb-glavni-kolod;7872480;;15.978478;45.804453;;f;HR;t;Europe/Zagreb;t;HRZAG;;f;;f;7800020;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17497;Graz Hbf;graz-hbf;8103171;;15.4156640000;47.0678420000;;f;AT;f;Europe/Vienna;t;ATGRZ;;f;;f;8100173;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;Štýrský Hradec;;;Grác;グラーツ;그라츠;;;;Грац;;;格拉茨
+17497;Graz Hbf;graz-hbf;8103171;;15.4156640000;47.0678420000;;f;AT;f;Europe/Vienna;t;ATGRZ;;f;;f;8100173;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;Štýrský Hradec;;Grác;グラーツ;그라츠;;;;Грац;;;格拉茨
 17498;Judenburg;judenburg;8103615;;14.6657480000;47.1737260000;;f;AT;f;Europe/Vienna;t;ATJUD;;f;;f;8100073;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17499;Klagenfurt Hbf;klagenfurt-hbf;8103642;;14.3123910000;46.6158020000;;f;AT;f;Europe/Vienna;t;ATKLG;;f;;f;8100085;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;クラーゲンフルト;;;;;Клагенфурт;;;
 17500;Linz/Donau Hbf;linz-donau-hbf;8101591;;14.291122;48.291526;;f;AT;f;Europe/Vienna;f;ATLNZ;;f;;f;8183231;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;;;;;;;;;
@@ -15983,26 +15983,26 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17506;Karlovy Vary;karlovy-vary;5475875;;12.866853;50.235668;;f;CZ;f;Europe/Prague;t;CSAHA;;f;;f;5400006;t;;f;;f;;f;;f;;f;;;;Karlsbad;;;;;;カルロヴィ・ヴァリ;카를로비바리;Karlsbad;Karlowe Wary;;Карловы Вары;;Karlsbad;卡罗维发利
 17507;Liberec;liberec;5454212;;15.045946;50.761429;;f;CZ;f;Europe/Prague;t;CSAIT;;f;;f;5400198;t;;f;;f;;f;;f;;f;;;;;;;;;;リベレツ;리베레츠;;;;Либерец;;;利贝雷茨
 17508;Olomouc hl.n.;olomouc-hl-n;5434362;;17.277932;49.593128;;f;CZ;f;Europe/Prague;t;CSALY;;f;;f;5400010;t;;f;;f;;f;;f;;f;;;;Olmütz;;;;;Olmütz;オロモウツ;올로모우츠;;Ołomuniec;;Оломоуц;;;奧洛穆克
-17509;Praha hl.n.;praha-hl-n;5457076;;14.436037;50.083058;17587;f;CZ;f;Europe/Prague;t;CSANS;;f;;f;5400014;t;;f;;f;;f;;f;;f;;Prague;Prague;Prag;Praga;;Prag;Praga;Prága;プラハ;프라하;Praag;Praga;Praga;Прага;Prag;Prag;布拉格
+17509;Praha hl.n.;praha-hl-n;5457076;;14.436037;50.083058;17587;f;CZ;f;Europe/Prague;t;CSANS;;f;;f;5400014;t;;f;;f;;f;;f;;f;;Prague;Prague;Prag;Praga;Praga;;Prag;Prága;プラハ;프라하;Praag;Praga;Praga;Прага;Prag;Prag;布拉格
 17510;Teplice v Čechách;teplice-v-cechach;5453289;;13.828807;50.646762;;f;CZ;f;Europe/Prague;t;CSARB;;f;;f;5400101;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17511;Ústi nad Labem hl.n.;usti-nad-labem-hl-n;5453179;;14.044728;50.659563;;f;CZ;f;Europe/Prague;t;CSARZ;;f;;f;5400019;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17512;Aalborg St.;aalborg-st;8600020;;9.916486;57.043127;;f;DK;f;Europe/Copenhagen;t;DKAAH;;f;;f;8600004;t;;f;;f;;f;;f;;f;;;;;;;;;;オールボー;올보르;;;;Ольборг;Ålborg;;奥尔堡
 17513;Aarhus;aarhus;8600053;;10.204995;56.150075;;f;DK;f;Europe/Copenhagen;t;DKAAO;;f;;f;8600087;t;;f;;f;;f;;f;;f;;Århus;;Århus;Århus;Århus;Århus;Århus;;オーフス;;Århus;Århus;;Орхус;Århus;Århus;
 17514;Kolding St.;kolding-st;8600083;;9.481525;55.490842;;f;DK;f;Europe/Copenhagen;t;DKAAU;;f;;f;8601318;t;;f;;f;;f;;f;;f;;;;;;;;;;コリング;콜링;;;;Кольдинг;;;科靈
-17515;København;kobenhavn;8600626;;12.564618;55.672721;;f;DK;f;Europe/Copenhagen;t;DKCPH;;f;;f;8601309;t;;f;;f;;f;;f;;f;;Copenhague;Copenhagen;Kopenhagen;Copenaghen;Kodaň;;Copenhague;Koppenhága;コペンハーゲン;코펜하겐;Kopenhagen;Kopenhaga;Copenhaga;Копенгаген;Köpenhamn;Kopenhag;哥本哈根
+17515;København;kobenhavn;8600626;;12.564618;55.672721;;f;DK;f;Europe/Copenhagen;t;DKCPH;;f;;f;8601309;t;;f;;f;;f;;f;;f;;Copenhague;Copenhagen;Kopenhagen;Copenaghen;Copenhague;Kodaň;;Koppenhága;コペンハーゲン;코펜하겐;Kopenhagen;Kopenhaga;Copenhaga;Копенгаген;Köpenhamn;Kopenhag;哥本哈根
 17516;Odense St.;odense-st;8600512;;10.386001;55.401777;;f;DK;f;Europe/Copenhagen;t;DKACT;;f;;f;8601770;t;;f;;f;;f;;f;;f;;;;;;;;;;オーデンセ;오덴세;;;;Оденсе;;;欧登塞
 17517;Roskilde St.;roskilde-st;8600617;;12.088855;55.639012;;f;DK;f;Europe/Copenhagen;t;DKADC;;f;;f;8602026;t;;f;;f;;f;;f;;f;;;;;;;;;;ロスキレ;로스킬레;;;;Роскилле;;;罗斯基勒
-17518;Gdańsk Główny;gdansk-glowny;5100750;;18.643807;54.355523;;f;PL;f;Europe/Warsaw;t;PLGAW;;f;;f;5100009;t;;f;;f;;f;;f;;f;;Dantzig;Danzig;Danzig;Danzica;Gdaňsk;;;;グダニスク;그단스크;;;Gdańsk;Гданьск;;;格但斯克
+17518;Gdańsk Główny;gdansk-glowny;5100750;;18.643807;54.355523;;f;PL;f;Europe/Warsaw;t;PLGAW;;f;;f;5100009;t;;f;;f;;f;;f;;f;;Dantzig;Danzig;Danzig;Danzica;;Gdaňsk;;;グダニスク;그단스크;;;Gdańsk;Гданьск;;;格但斯克
 17519;Lodź Kaliska;lodz-kaliska;5104670;;19.430884;51.757416;;f;PL;f;Europe/Warsaw;t;PLABQ;;f;;f;5100039;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17520;Göteborg Central;goteborg-central;7401318;;11.973424;57.709308;;f;SE;f;Europe/Stockholm;t;SEGOT;;f;;f;7400003;t;;f;;f;;f;;f;;f;;;Gothenburg;;;;;Gotemburgo;;ヨーテボリ;예테보리;Gotenburg;;Gotemburgo;Гётеборг;;;哥德堡
+17520;Göteborg Central;goteborg-central;7401318;;11.973424;57.709308;;f;SE;f;Europe/Stockholm;t;SEGOT;;f;;f;7400003;t;;f;;f;;f;;f;;f;;;Gothenburg;;;Gotemburgo;;;;ヨーテボリ;예테보리;Gotenburg;;Gotemburgo;Гётеборг;;;哥德堡
 17521;Halmstad Central;halmstad-central;7401380;;12.8643;56.669211;;f;SE;f;Europe/Stockholm;t;SEACM;;f;;f;7400014;t;;f;;f;;f;;f;;f;;;;;;;;;;ハルムスタッド;할름스타드;;;;Хальмстад;;;哈尔姆斯塔德
 17522;Helsingborg Central;helsingborg-central;7401688;;12.695069;56.043688;;f;SE;f;Europe/Stockholm;t;SEAGH;;f;;f;7400154;t;;f;;f;;f;;f;;f;;;;;;;;;;ヘルシンボリ;헬싱보리;;;;Хельсингборг;;;赫尔辛堡
 17523;Malmö Central;malmo-central;7402611;;13.00126;55.60923;;f;SE;f;Europe/Stockholm;t;SEAAA;;f;;f;7400004;t;;f;;f;;f;;f;;f;;;Malmo;;;;;;;マルメ;;;;;Мальмё;;;马尔莫
 17524;Chalon-sur-Saône Gare Routière;chalon-sur-saone-gare-routiere;8760625;;4.8433969237;46.7817429085;5765;f;FR;f;Europe/Paris;f;FRNDR;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17525;Amsterdam Stadionplein;amsterdam-stadionplein;;;4.8574810000;52.3441030000;8657;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17526;Milano Autostazione;milano-autostazione;;;9.1276310000;45.4894410000;8483;f;IT;f;Europe/Rome;t;;;f;;f;;f;XLM;t;;f;;f;;f;;f;;Milan;Milan;Mailand;;Milán;;Milán;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
-17527;Nice Aéroport Côte d’Azur;nice-aeroport-cote-dazur;;;7.2109370000;43.6651400000;4836;f;FR;f;Europe/Paris;t;;;f;;f;;f;NCE;t;;f;;f;;f;;f;;;Airport;Flughafen;Nizza Aeroporto;;;Niza;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
-17528;Torino Autostazione;torino-autostazione;;;7.6561150000;45.0708540000;8565;f;IT;f;Europe/Rome;t;;;f;;f;;f;XUT;t;;f;;f;;f;;f;;Turin;Turin;Turin;;Turín;;Turín;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
+17526;Milano Autostazione;milano-autostazione;;;9.1276310000;45.4894410000;8483;f;IT;f;Europe/Rome;t;;;f;;f;;f;XLM;t;;f;;f;;f;;f;;Milan;Milan;Mailand;;Milán;Milán;;;ミラノ;밀라노;Milaan;Mediolan;Milão;Милан;;;
+17527;Nice Aéroport Côte d’Azur;nice-aeroport-cote-dazur;;;7.2109370000;43.6651400000;4836;f;FR;f;Europe/Paris;t;;;f;;f;;f;NCE;t;;f;;f;;f;;f;;;Airport;Flughafen;Nizza Aeroporto;Niza;;;Nizza;ニース;니스;;Nicea;;Ницца;;;尼斯
+17528;Torino Autostazione;torino-autostazione;;;7.6561150000;45.0708540000;8565;f;IT;f;Europe/Rome;t;;;f;;f;;f;XUT;t;;f;;f;;f;;f;;Turin;Turin;Turin;;Turín;Turín;;;トリノ;토리노;Turijn;Turyn;Turim;Турин;Turin;;
 17529;Wilderswil;wilderswil;8507388;;7.8694710000;46.6657010000;;f;CH;f;Europe/Zurich;t;;;f;;f;8507388;t;;f;;f;;f;;f;;f;;;;;;;;;;ヴィルダースヴィル;;;;;Вильдерсвиль;;;維爾德斯維爾
 17530;Stäfa;stafa;8503107;;8.7216310000;47.2405160000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503107;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17531;Stans;stans;8508391;;8.3667450000;46.9583270000;;f;CH;f;Europe/Zurich;t;CHSST;;f;;f;8508391;t;;f;;f;;f;;f;;f;;;;;;;;;;シュタンス;슈탄스;;;;Штанс;;;施坦斯
@@ -16024,7 +16024,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17550;Klosters Platz;klosters-platz;8509068;;9.8809420000;46.8691980000;;f;AT;f;Europe/Vienna;t;CHKST;;f;;f;8509068;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17555;Leoben Hbf;leoben-hbf;8103603;;15.0896070000;47.3866000000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100070;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;;Stazione centrale;;;;;レオーベン;레오벤;;;;Леобен;;;萊奧本
 17556;Liezen;liezen;8101459;;14.2417980000;47.5626620000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100131;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17557;Linz;linz;8101073;;14.2915180000;48.2902490000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100013;t;;f;;f;;f;;f;;f;;;;;;Linec;;;;リンツ;린츠;;;;Линц;;;林茨
+17557;Linz;linz;8101073;;14.2915180000;48.2902490000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100013;t;;f;;f;;f;;f;;f;;;;;;;Linec;;;リンツ;린츠;;;;Линц;;;林茨
 17558;Lustenau;lustenau;8102352;;9.6671160000;47.4503330000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100123;t;;f;;f;;f;;f;;f;;;;;;;;;;ルステナウ;루스테나우;;;;Лустенау;;;盧斯特瑙
 17559;Saalfelden;saalfelden;8101148;;12.8294220000;47.4268440000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100049;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17560;St. Pölten Hbf;st-polten-hbf;8101032;;15.6259120000;48.2076830000;;f;AT;f;Europe/Vienna;t;ATAAH;;f;;f;8100008;t;;f;;f;;f;;f;;f;;Gare centrale;Main station;Pölten;Stazione centrale;;;;;ザンクト・ペルテン;장크트푈텐;;;;Санкт-Пёльтен;;;聖帕爾滕
@@ -16035,7 +16035,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17566;Harderwijk;harderwijk;8400294;;5.6162890000;52.3380470000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400294;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17567;Heiloo;heiloo;8400309;;4.6996770000;52.5998670000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400309;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17568;Heemstede-Aerdenhout;heemstede-aerdenhout;8400302;;4.6066830000;52.3594230000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400302;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17569;’s-Hertogenbosch;s-hertogenbosch;8400319;;5.2938010000;51.6906710000;;f;NL;f;Europe/Amsterdam;t;NLSHE;;f;;f;8400319;t;;f;;f;;f;;f;;f;;Bois-le-Duc;;Herzogenbusch;Boscoducale;;;Bolduque;;;;;Hertogenbosch;;Хертогенбос;;;
+17569;’s-Hertogenbosch;s-hertogenbosch;8400319;;5.2938010000;51.6906710000;;f;NL;f;Europe/Amsterdam;t;NLSHE;;f;;f;8400319;t;;f;;f;;f;;f;;f;;Bois-le-Duc;;Herzogenbusch;Boscoducale;Bolduque;;;;;;;Hertogenbosch;;Хертогенбос;;;
 17570;Hoogeveen;hoogeveen;8400330;;6.4687270000;52.7352170000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400330;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Хоогевеен;;;
 17571;Lelystad Centrum;lelystad-centrum;8400394;;5.4704840000;52.5117360000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400394;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17572;Purmerend;purmerend;8400508;;4.9519320000;52.5045270000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400508;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16049,7 +16049,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17581;Dronten;dronten;8400198;;5.7216430000;52.5342540000;;f;NL;f;Europe/Amsterdam;t;NLDAI;;f;;f;8400198;t;;f;;f;;f;;f;;f;;;;;;;;;;ドロンテン;;;;;Дронтен;;;
 17582;St. Valentin;st-valentin;8101061;;14.5218480000;48.1791430000;;f;AT;f;Europe/Vienna;t;ATAAK;;f;;f;8100009;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17583;Berlin Hbf (Europaplatz);berlin-hbf-europaplatz;;;13.3690810000;52.5261550000;7527;f;DE;f;Europe/Berlin;f;;;f;;f;8070952;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17584;Kraków Główny;krakow-glowny;5100214;;19.9474230000;50.0671920000;;f;PL;t;Europe/Warsaw;t;PLKRK;;f;;f;5100028;t;;f;;f;;f;;f;;f;;Cracovie;Krakow;Krakau;Cracovia;Krakov;;Cracovia;Krakkó;クラクフ;크라쿠프;;;Cracóvia;Краков;;;克拉科夫
+17584;Kraków Główny;krakow-glowny;5100214;;19.9474230000;50.0671920000;;f;PL;t;Europe/Warsaw;t;PLKRK;;f;;f;5100028;t;;f;;f;;f;;f;;f;;Cracovie;Krakow;Krakau;Cracovia;Cracovia;Krakov;;Krakkó;クラクフ;크라쿠프;;;Cracóvia;Краков;;;克拉科夫
 17585;Kraków Główny (Bus);krakow-glowny-bus;;;19.9495800000;50.0679020000;;f;PL;f;Europe/Warsaw;f;;;f;;f;5104621;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17587;Praha;praha;;;14.4514810000;50.0819250000;;t;CZ;f;Europe/Prague;f;CSPRG;;f;;f;5496001;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17588;Praha hl.n. Wilsonova;praha-hl-n-wilsonova;;;14.4346170000;50.0833720000;17587;f;CZ;f;Europe/Prague;f;;;f;;f;5471014;t;;f;;f;;f;;f;;f;17509;;;;;;;;;;;;;;;;;
@@ -16201,12 +16201,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17734;Wien Meidling;wien-meidling;8103107;;16.3361230000;48.1749990000;;f;AT;f;Europe/Vienna;t;ATABM;;f;;f;8100514;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17735;Heiterwang-Plansee;heiterwang-plansee;8102248;;10.7484550000;47.4425030000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100550;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17736;Schaarbeek;schaarbeek;8811007;;4.3786540000;50.8784050000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800001;t;;f;;f;;f;;f;;f;;;;;;;;;;スカールベーク;;;;;Схарбек;;;斯哈尔贝克
-17737;Bruxelles-Central;bruxelles-central;8813003;;4.3570620000;50.8454960000;;f;BE;f;Europe/Brussels;t;BEBCE;;f;;f;8800003;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
-17738;Bruxelles-Luxembourg;bruxelles-luxembourg;8811304;;4.3739980000;50.8388080000;5974;f;BE;f;Europe/Brussels;t;BEBQL;;f;;f;8800005;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+17737;Bruxelles-Central;bruxelles-central;8813003;;4.3570620000;50.8454960000;;f;BE;f;Europe/Brussels;t;BEBCE;;f;;f;8800003;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+17738;Bruxelles-Luxembourg;bruxelles-luxembourg;8811304;;4.3739980000;50.8388080000;5974;f;BE;f;Europe/Brussels;t;BEBQL;;f;;f;8800005;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 17739;Halle;halle;8814308;;4.2400850000;50.7333730000;;f;BE;f;Europe/Brussels;t;BEHAB;;f;;f;8800006;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
 17740;Antwerpen-Berchem;antwerpen-berchem;8821121;;4.4324640000;51.1995270000;;f;BE;f;Europe/Brussels;t;BEBHM;;f;;f;8800008;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17741;Essen;essen;8821402;;4.4509990000;51.4626410000;;f;BE;f;Europe/Brussels;t;BEESS;;f;;f;8800009;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
-17742;Mechelen;mechelen;8822004;;4.4834680000;51.0175040000;;f;BE;f;Europe/Brussels;t;BEAAH;;f;;f;8800010;t;;f;;f;;f;;f;;f;;Malines;;Mecheln;Malines;;;Malinas;;メヘレン;메헬렌;;;;Мехелен;;;梅赫伦
+17742;Mechelen;mechelen;8822004;;4.4834680000;51.0175040000;;f;BE;f;Europe/Brussels;t;BEAAH;;f;;f;8800010;t;;f;;f;;f;;f;;f;;Malines;;Mecheln;Malines;Malinas;;;;メヘレン;메헬렌;;;;Мехелен;;;梅赫伦
 17743;Ans;ans;8841202;;5.5096860000;50.6610280000;;f;BE;f;Europe/Brussels;t;BEAAK;;f;;f;8800013;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;アンス;;;;;Анс;;;昂斯
 17744;Rivage;rivage;8842705;;5.5859680000;50.4850370000;;f;BE;f;Europe/Brussels;t;BEAAL;;f;;f;8800014;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17745;Flemalle-Haute;flemalle-haute;8843208;;5.4562270000;50.5947150000;;f;BE;f;Europe/Brussels;t;BEAAM;;f;;f;8800015;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16245,7 +16245,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17778;Gouvy;gouvy;8845005;;5.9537350000;50.1897240000;;f;BE;f;Europe/Brussels;t;BEGVY;;f;;f;8800060;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17779;Grupont;grupont;8864337;;5.2806860000;50.0908070000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800061;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17780;Houyet;houyet;8863842;;5.0061190000;50.1900020000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800065;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Уйе;;;乌耶
-17781;Ieper;ieper;8896503;;2.8762060000;50.8478240000;;f;BE;f;Europe/Brussels;t;BEACH;;f;;f;8800066;t;;f;;f;;f;;f;;f;;Ypres;Ypres;Ypern;Ypres;;;Ypres;;;;;Ypres;;Ипр;Ypern;;
+17781;Ieper;ieper;8896503;;2.8762060000;50.8478240000;;f;BE;f;Europe/Brussels;t;BEACH;;f;;f;8800066;t;;f;;f;;f;;f;;f;;Ypres;Ypres;Ypern;Ypres;Ypres;;;;;;;Ypres;;Ипр;Ypern;;
 17782;Izegem;izegem;8896909;;3.2147580000;50.9210410000;;f;BE;f;Europe/Brussels;t;BEABB;;f;;f;8800067;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Изегем;;;
 17783;Jamioulx;jamioulx;8871175;;4.4115010000;50.3527430000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800068;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17784;Jemeppe-sur-Sambre;jemeppe-sur-sambre;8874724;;4.6641520000;50.4516520000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800069;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16281,7 +16281,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17814;Waterloo;waterloo;8814266;;4.3835350000;50.7148470000;;f;BE;f;Europe/Brussels;t;BEWAT;;f;;f;8800136;t;;f;;f;;f;;f;;f;;;;;;;;;;ワーテルロー;워털루;;;;Ватерлоо;;;滑鐵盧
 17815;Philippeville;philippeville;8873122;;4.5359830000;50.1916120000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800140;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17816;Sint-Niklaas;sint-niklaas;8894508;;4.1442420000;51.1720380000;;f;BE;f;Europe/Brussels;t;BEACJ;;f;;f;8800143;t;;f;;f;;f;;f;;f;;Saint-Nicolas;;;;;;;;;;;;;Санкт-Никола;;;
-17817;Bruxelles-Schuman;bruxelles-schuman;8811916;;4.3803710000;50.8431230000;;f;BE;f;Europe/Brussels;t;BESCH;;f;;f;8800146;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+17817;Bruxelles-Schuman;bruxelles-schuman;8811916;;4.3803710000;50.8431230000;;f;BE;f;Europe/Brussels;t;BESCH;;f;;f;8800146;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 17818;Opwijk;opwijk;8812146;;4.1871660000;50.9747610000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800150;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17819;Nivelles;nivelles;8814209;;4.3353440000;50.6006030000;;f;BE;f;Europe/Brussels;t;BEACN;;f;;f;8800152;t;;f;;f;;f;;f;;f;;;;;;;;;;;;Nijvel;;;Нивель;;;尼韦尔
 17820;Marbehan;marbehan;8866175;;5.5395660000;49.7274540000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800156;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16315,8 +16315,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17848;Begijnendijk;begijnendijk;8821865;;4.7994660000;51.0225650000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800208;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17849;Sint-Truiden;sint-truiden;8831807;;5.1762760000;50.8175120000;;f;BE;f;Europe/Brussels;t;BEACK;;f;;f;8800209;t;;f;;f;;f;;f;;f;;Saint Trond;;;;;;;;;;;;;Синт-Трюйден;;;
 17850;Bokrijk;bokrijk;8831781;;5.4084400000;50.9556680000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800210;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17851;Bruxelles-Chapelle;bruxelles-chapelle;8813037;;4.3486300000;50.8412260000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800211;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
-17852;Bruxelles-Congres;bruxelles-congres;8813045;;4.3622040000;50.8515190000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800212;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+17851;Bruxelles-Chapelle;bruxelles-chapelle;8813037;;4.3486300000;50.8412260000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800211;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+17852;Bruxelles-Congres;bruxelles-congres;8813045;;4.3622040000;50.8515190000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800212;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 17853;Buda;buda;8811148;;4.4178830000;50.9084200000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800213;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;;;;;;;;;
 17854;Weerde;weerde;8822251;;4.4708380000;50.9775110000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800216;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17855;Duffel;duffel;8822210;;4.4928080000;51.0916300000;;f;BE;f;Europe/Brussels;t;BEDUF;;f;;f;8800218;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16333,7 +16333,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 17866;Evere;evere;8811106;;4.4009020000;50.8675550000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800231;t;;f;;f;;f;;f;;f;;;;;;;;;;エヴェレ;;;;;Эвере;;;埃韦勒
 17867;Bordet;bordet;8811163;;4.4090920000;50.8767420000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800232;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17868;Hofstade;hofstade;8822277;;4.4984980000;50.9885320000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800234;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-17869;Liège-Jonfosse;liege-jonfosse;8841558;;5.5619580000;50.6405060000;23044;f;BE;f;Europe/Brussels;t;;;f;;f;8800235;t;;f;;f;;f;;f;;f;;;;Lüttich;Liegi;Lutych;;Lieja;;リエージュ;리에주;Luik;;;Льеж;;;列日
+17869;Liège-Jonfosse;liege-jonfosse;8841558;;5.5619580000;50.6405060000;23044;f;BE;f;Europe/Brussels;t;;;f;;f;8800235;t;;f;;f;;f;;f;;f;;;;Lüttich;Liegi;Lieja;Lutych;;;リエージュ;리에주;Luik;;;Льеж;;;列日
 17870;Herstal;herstal;8841608;;5.6224830000;50.6606060000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800236;t;;f;;f;;f;;f;;f;;;;;;;;;;エルスタル;;;;;Эрсталь;;;赫尔斯塔尔
 17871;Milmort;milmort;8841665;;5.5998030000;50.6930300000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800237;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 17872;Liers;liers;8841673;;5.5684570000;50.6982260000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800238;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16597,12 +16597,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18130;Moensberg;moensberg;8814431;;4.3315420000;50.7786340000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800583;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18131;Beersel;beersel;8814423;;4.3020300000;50.7661660000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800584;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18132;Huizingen;huizingen;8814415;;4.2665590000;50.7518010000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800585;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18133;Liège-Palais;liege-palais;8841525;;5.5707140000;50.6464840000;23044;f;BE;f;Europe/Brussels;t;;;f;;f;8800586;t;;f;;f;;f;;f;;f;;;;Lüttich;Liegi;Lutych;;Lieja;;リエージュ;리에주;Luik;;;Льеж;;;列日
+18133;Liège-Palais;liege-palais;8841525;;5.5707140000;50.6464840000;23044;f;BE;f;Europe/Brussels;t;;;f;;f;8800586;t;;f;;f;;f;;f;;f;;;;Lüttich;Liegi;Lieja;Lutych;;;リエージュ;리에주;Luik;;;Льеж;;;列日
 18134;Aarsele;aarsele;8892288;;3.4181120000;50.9845410000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800594;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18135;Mortsel-Liersesteenw;mortsel-liersesteenw;8821246;;4.4690320000;51.1692960000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800607;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18136;Simonis;simonis;8812013;;4.3306340000;50.8631690000;;f;BE;f;Europe/Brussels;t;;;f;;f;8812013;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18137;Vivier d’Oie;vivier-doie;8814464;;4.3726580000;50.7960100000;;f;BE;f;Europe/Brussels;t;;;f;;f;8814464;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18138;Bruxelles-West;bruxelles-west;8815040;;4.3213030000;50.8492260000;;f;BE;f;Europe/Brussels;t;;;f;;f;8815040;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Brusel;;Bruselas;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+18138;Bruxelles-West;bruxelles-west;8815040;;4.3213030000;50.8492260000;;f;BE;f;Europe/Brussels;t;;;f;;f;8815040;t;;f;;f;;f;;f;;f;;;Brussels;Brüssel;;Bruselas;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Brussel;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 18139;Schelle;schelle;8824232;;4.3402700000;51.1254650000;;f;BE;f;Europe/Brussels;t;;;f;;f;8824232;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18140;Beverlo;beverlo;8832227;;5.2345890000;51.0890050000;;f;BE;f;Europe/Brussels;t;;;f;;f;8832227;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18141;Halanzy;halanzy;8866530;;5.7432890000;49.5559840000;;f;BE;f;Europe/Brussels;t;;;f;;f;8866530;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16612,7 +16612,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18145;Dinant;dinant;8863503;;4.9078130000;50.2611790000;;f;BE;f;Europe/Brussels;t;BEDNT;;f;;f;8800054;t;;f;;f;;f;;f;;f;;;;;;;;;;ディナン;;;;;Динан;;;迪南
 18146;Geel;geel;8832433;;4.9888780000;51.1688560000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800056;t;;f;;f;;f;;f;;f;;;;;;;;;;ヘール;;;;;Геел;;;赫尔
 18147;Herentals;herentals;8821717;;4.8285730000;51.1811170000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800063;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18148;Kortrijk;kortrijk;8896008;;3.2642970000;50.8244610000;;f;BE;f;Europe/Brussels;t;BEQKT;;f;;f;8800077;t;;f;;f;;f;;f;;f;;Courtrai;;;Courtrai;;;Courtrai;;コルトレイク;코르트레이크;;;Courtrai;Кортрейк;;;科特赖克
+18148;Kortrijk;kortrijk;8896008;;3.2642970000;50.8244610000;;f;BE;f;Europe/Brussels;t;BEQKT;;f;;f;8800077;t;;f;;f;;f;;f;;f;;Courtrai;;;Courtrai;Courtrai;;;;コルトレイク;코르트레이크;;;Courtrai;Кортрейк;;;科特赖克
 18149;Lier;lier;8821600;;4.5599760000;51.1358560000;;f;BE;f;Europe/Brussels;t;BELIR;;f;;f;8800083;t;;f;;f;;f;;f;;f;;Belgique;Belgium;Belgien;Belgio;;;;;リール;;;;;Льер;;;利尔
 18150;Zottegem;zottegem;8895208;;3.8146620000;50.8689580000;;f;BE;f;Europe/Brussels;t;BEAAG;;f;;f;8800098;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18151;Hasselt;hasselt;8831005;;5.3270610000;50.9308750000;;f;BE;f;Europe/Brussels;t;BEHST;;f;;f;8800114;t;;f;;f;;f;;f;;f;;;;;;;;;;ハッセルト;하셀트;;;;Хасселт;;;哈瑟尔特
@@ -16698,7 +16698,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18231;Cham (CH) See;cham-ch-see;;;8.4634780000;47.1786790000;;f;CH;f;Europe/Zurich;f;;;f;;f;8502250;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18232;Wohlen AG Bahnhof;wohlen-ag-bahnhof;;;8.2694640000;47.3488720000;;f;CH;f;Europe/Zurich;f;;;f;;f;8502889;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18233;Sursee Bahnhof;sursee-bahnhof;;;8.0986240000;47.1702290000;;f;CH;f;Europe/Zurich;f;;;f;;f;8502998;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18234;Zürich Flughafen;zurich-flughafen;8503016;;8.5623330000;47.4502790000;;f;CH;f;Europe/Zurich;t;CHAJO;;f;;f;8503016;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Curych;;Zúrich;;チューリッヒ;취리히;;Zurych;Zurique;Цюрих;;Zürih;
+18234;Zürich Flughafen;zurich-flughafen;8503016;;8.5623330000;47.4502790000;;f;CH;f;Europe/Zurich;t;CHAJO;;f;;f;8503016;t;;f;;f;;f;;f;;f;;Aéroport;Airport;;Aeroporto;Zúrich;Curych;;;チューリッヒ;취리히;;Zurych;Zurique;Цюрих;;Zürih;
 18235;Zürich HB SZU;zurich-hb-szu;8503088;;8.5392030000;47.3781860000;;f;CH;f;Europe/Zurich;f;;;f;;f;8503088;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18236;Küsnacht ZH;kusnacht-zh;8503101;;8.5806260000;47.3191630000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503101;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18237;Erlenbach ZH;erlenbach-zh;8503102;;8.5915120000;47.3057780000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503102;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -16710,8 +16710,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18243;Richterswil;richterswil;8503207;;8.7074640000;47.2083610000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503207;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18244;Lachen;lachen;8503220;;8.8527020000;47.1900680000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503220;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18245;Ziegelbrücke;ziegelbrucke;8503225;;9.0600290000;47.1361420000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503225;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18246;Glarus;glarus;8503230;;9.0715630000;47.0399220000;;f;CH;f;Europe/Zurich;t;CHAGW;;f;;f;8503230;t;;f;;f;;f;;f;;f;;Glaris;;;Glarona;;;Glaris;;グラールス;글라루스;;;Glarona;Гларус;;;格拉魯斯
-18247;Schwanden GL;schwanden-gl;8503233;;9.0774420000;46.9968540000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503233;t;;f;;f;;f;;f;;f;;Schwanden;Schwanden;;Schwanden;;;Schwanden;;;;Schwanden;;Schwanden;;;;
+18246;Glarus;glarus;8503230;;9.0715630000;47.0399220000;;f;CH;f;Europe/Zurich;t;CHAGW;;f;;f;8503230;t;;f;;f;;f;;f;;f;;Glaris;;;Glarona;Glaris;;;;グラールス;글라루스;;;Glarona;Гларус;;;格拉魯斯
+18247;Schwanden GL;schwanden-gl;8503233;;9.0774420000;46.9968540000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503233;t;;f;;f;;f;;f;;f;;Schwanden;Schwanden;;Schwanden;Schwanden;;;;;;Schwanden;;Schwanden;;;;
 18248;Linthal;linthal;8503239;;8.9975630000;46.9259470000;;f;CH;f;Europe/Zurich;t;CHAHY;;f;;f;8503239;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Линталь;;;兰塔
 18249;Pfäffikon ZH;pfaffikon-zh;8503301;;8.7847800000;47.3670750000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503301;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18250;Dietlikon;dietlikon;8503306;;8.6192340000;47.4202100000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503306;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17040,8 +17040,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18573;Sargans;sargans;8509411;;9.4462690000;47.0447940000;;f;CH;f;Europe/Zurich;t;CHZKA;;f;;f;8509411;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Зарганс;;;薩甘斯
 18574;Visp;visp;8501605;;7.8814540000;46.2940240000;;f;CH;f;Europe/Zurich;t;CHZLB;;t;;f;8501605;t;;f;;f;8501605;t;;f;;f;;Viège;;;;;;;;;;;;;;;;
 18575;Lauterbrunnen;lauterbrunnen;8507384;;7.9086100000;46.5989110000;;f;CH;f;Europe/Zurich;t;CHAKE;;f;;f;8507384;t;;f;;f;;f;;f;;f;;;;;;;;;;ラウターブルンネン;라우터브루넨;;;;Лаутербруннен;;;盧達本納
-18576;Interlaken Ost;interlaken-ost;8507492;85074922;7.8689770000;46.6906910000;;f;CH;f;Europe/Zurich;t;CHZTG;;t;;f;8507492;t;;f;;f;;f;;f;;f;;;;;;;;Entrelagos;;インターラーケン;인터라켄;;;;Интерлакен;;;因特拉肯
-18577;Plzeň hl.n.;plzen-hl-n;5473275;;13.3882460000;49.7431670000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400012;t;;f;;f;;f;;f;;f;;Pilsen;Pilsen;Pilsen;Pilsen;Plzeň;;Pilsen;Plzeň;プルゼニ;플젠;Pilsen;Pilzno;Plzeň;Пльзень;;;比尔森
+18576;Interlaken Ost;interlaken-ost;8507492;85074922;7.8689770000;46.6906910000;;f;CH;f;Europe/Zurich;t;CHZTG;;t;;f;8507492;t;;f;;f;;f;;f;;f;;;;;;Entrelagos;;;;インターラーケン;인터라켄;;;;Интерлакен;;;因特拉肯
+18577;Plzeň hl.n.;plzen-hl-n;5473275;;13.3882460000;49.7431670000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400012;t;;f;;f;;f;;f;;f;;Pilsen;Pilsen;Pilsen;Pilsen;Pilsen;Plzeň;;Plzeň;プルゼニ;플젠;Pilsen;Pilzno;Plzeň;Пльзень;;;比尔森
 18578;Kolín;kolin;5453414;;15.2135320000;50.0254010000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400022;t;;f;;f;;f;;f;;f;;République Tchèque;Czech Republic;Tschechien;Repubblica Ceca;;;;;;;;;;;;;
 18579;Česka Lípa hl.n.;ceska-lipa-hl-n;5456809;;14.5409500000;50.6790790000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400045;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18580;Praha-Libeň;praha-liben;5457176;;14.5014340000;50.1012610000;;f;CZ;f;Europe/Prague;t;;;f;;f;5400130;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17270,7 +17270,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18803;Balatonboglar;balatonboglar;5503475;;17.6468670000;46.7761600000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500044;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18804;Szolnok;szolnok;5513748;;20.1756950000;47.1795600000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500053;t;;f;;f;;f;;f;;f;;;;;;;;;;ソルノク;솔노크;;;;Сольнок;;;索尔诺克
 18805;Hajduszoboszlo;hajduszoboszlo;5513888;;21.4077920000;47.4296580000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500057;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-18806;Debrecen;debrecen;5513912;;21.6287920000;47.5196310000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500058;t;;f;;f;;f;;f;;f;;;;;;Debrecín;;;;デブレツェン;데브레첸;;Debreczyn;;Дебрецен;;;德布勒森
+18806;Debrecen;debrecen;5513912;;21.6287920000;47.5196310000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500058;t;;f;;f;;f;;f;;f;;;;;;;Debrecín;;;デブレツェン;데브레첸;;Debreczyn;;Дебрецен;;;德布勒森
 18807;Balatonfüred;balatonfured;5504416;;17.9018640000;46.9624530000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500073;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18808;Szeged;szeged;5517228;;20.1431810000;46.2398100000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500101;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18809;Eger;eger;5512401;;20.3821230000;47.8916230000;;f;HU;f;Europe/Budapest;t;;;f;;f;5500120;t;;f;;f;;f;;f;;f;;Hongrie;Hungary;Ungarn;Ungheria;;;;;エゲル;에게르;;;;Эгер;;Eğri;埃格爾
@@ -17411,7 +17411,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18944;Heino;heino;8400310;;6.2216320000;52.4273820000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400310;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18945;Helmond;helmond;8400313;;5.6619270000;51.4754780000;;f;NL;f;Europe/Amsterdam;t;NLAAP;;f;;f;8400313;t;;f;;f;;f;;f;;f;;;;;;;;;;ヘルモント;헬몬트;;;;Хелмонд;;;海爾蒙德
 18946;Heemskerk;heemskerk;8400317;;4.6863010000;52.4948280000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400317;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Хеемскерк;;;
-18947;’s-Hertogenbosch Oost;s-hertogenbosch-oost;8400320;;5.3173890000;51.7005590000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400320;t;;f;;f;;f;;f;;f;;Bois-le-Duc;;Herzogenbusch;Boscoducale;;;Bolduque;;;;;Hertogenbosch;;Хертогенбос;;;
+18947;’s-Hertogenbosch Oost;s-hertogenbosch-oost;8400320;;5.3173890000;51.7005590000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400320;t;;f;;f;;f;;f;;f;;Bois-le-Duc;;Herzogenbusch;Boscoducale;Bolduque;;;;;;;Hertogenbosch;;Хертогенбос;;;
 18948;Hilversum Noord;hilversum-noord;8400324;;5.1739660000;52.2378260000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400324;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Хилверсюм;;;希爾弗瑟姆
 18949;Hoek van Holland Haven;hoek-van-holland-haven;8400325;;4.1286100000;51.9754850000;;f;NL;f;Europe/Amsterdam;t;NLAAS;;f;;f;8400325;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 18950;Hoensbroek;hoensbroek;8400326;;5.9300840000;50.9056340000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400326;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17470,8 +17470,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19003;Roermond;roermond;8400523;;5.9945100000;51.1928480000;;f;NL;f;Europe/Amsterdam;t;NLABA;;f;;f;8400523;t;;f;;f;;f;;f;;f;;Ruremonde;;;;;;;;ルールモント;;;;;Рурмонд;;;鲁尔蒙德
 19004;Rosmalen;rosmalen;8400524;;5.3693730000;51.7150670000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400524;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19005;Rotterdam Blaak;rotterdam-blaak;8400529;;4.4890150000;51.9199860000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400529;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19006;Rotterdam Noord;rotterdam-noord;8400531;;4.4815810000;51.9422790000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400531;t;;f;;f;;f;;f;;f;;;;;;;;Róterdam;;ロッテルダム;로테르담;;;Roterdão;Роттердам;;;鹿特丹
-19007;Rotterdam Zuid;rotterdam-zuid;8400533;;4.5100310000;51.9048660000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400533;t;;f;;f;;f;;f;;f;;;;;;;;Róterdam;;ロッテルダム;로테르담;;;Roterdão;Роттердам;;;鹿特丹
+19006;Rotterdam Noord;rotterdam-noord;8400531;;4.4815810000;51.9422790000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400531;t;;f;;f;;f;;f;;f;;;;;;Róterdam;;;;ロッテルダム;로테르담;;;Roterdão;Роттердам;;;鹿特丹
+19007;Rotterdam Zuid;rotterdam-zuid;8400533;;4.5100310000;51.9048660000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400533;t;;f;;f;;f;;f;;f;;;;;;Róterdam;;;;ロッテルダム;로테르담;;;Roterdão;Роттердам;;;鹿特丹
 19008;Rijssen;rijssen;8400538;;6.5196870000;52.3119780000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400538;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19009;Rotterdam Lombardijen;rotterdam-lombardijen;8400542;;4.5307700000;51.8803700000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400542;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19010;Santpoort Noord;santpoort-noord;8400543;;4.6324200000;52.4336470000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400543;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17498,7 +17498,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19031;Vlaardingen West;vlaardingen-west;8400642;;4.3139230000;51.9040120000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400642;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19032;Vlaardingen Oost;vlaardingen-oost;8400649;;4.3616560000;51.9101060000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400649;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19033;Vleuten;vleuten;8400651;;5.0074770000;52.1031590000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400651;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19034;Vlissingen;vlissingen;8400652;;3.5955410000;51.4444110000;;f;NL;f;Europe/Amsterdam;t;NLABF;;f;;f;8400652;t;;f;;f;;f;;f;;f;;Flessingue;Flushing;;;;;Flesinga;;;플리싱언;;;;Флиссинген;;;弗利辛恩
+19034;Vlissingen;vlissingen;8400652;;3.5955410000;51.4444110000;;f;NL;f;Europe/Amsterdam;t;NLABF;;f;;f;8400652;t;;f;;f;;f;;f;;f;;Flessingue;Flushing;;;Flesinga;;;;;플리싱언;;;;Флиссинген;;;弗利辛恩
 19035;Vlissingen Souburg;vlissingen-souburg;8400653;;3.5949300000;51.4644390000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400653;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19036;Voorhout;voorhout;8400655;;4.4842770000;52.2247020000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400655;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19037;Voorburg;voorburg;8400658;;4.3588960000;52.0667250000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400658;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17534,17 +17534,17 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19067;Heerlen;heerlen;8400307;;5.9758390000;50.8906940000;;f;NL;f;Europe/Amsterdam;t;;;f;;f;8400307;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;Coriovalo;;;;
 19068;Bydgoszcz Główna;bydgoszcz-glowna;5101840;;17.9916400000;53.1351110000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100005;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19069;Gdynia Główna;gdynia-glowna;5100590;;18.5295540000;54.5208430000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100010;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19070;Gniezno;gniezno;5103080;;17.6017860000;52.5264340000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100013;t;;f;;f;;f;;f;;f;;;;;;Hnězdno;;;;グニェズノ;그니에즈노;;;;Гнезно;;;格涅兹诺
+19070;Gniezno;gniezno;5103080;;17.6017860000;52.5264340000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100013;t;;f;;f;;f;;f;;f;;;;;;;Hnězdno;;;グニェズノ;그니에즈노;;;;Гнезно;;;格涅兹诺
 19071;Inowrocław;inowroclaw;5101870;;18.2391840000;52.8014050000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100015;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19072;Katowice;katowice;5107331;;19.0171650000;50.2575110000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100020;t;;f;;f;;f;;f;;f;;;;Kattowitz;;Katovice;;;;カトヴィツェ;카토비체;;;;Катовице;;;卡托维兹
+19072;Katowice;katowice;5107331;;19.0171650000;50.2575110000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100020;t;;f;;f;;f;;f;;f;;;;Kattowitz;;;Katovice;;;カトヴィツェ;카토비체;;;;Катовице;;;卡托维兹
 19073;Konin;konin;5103310;;18.2533330000;52.2313990000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100026;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Конин;;;
 19074;Kutno;kutno;5103220;;19.3486150000;52.2269580000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100032;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Кутно;;;库特娜
 19075;Legnica;legnica;5105300;;16.1689240000;51.2138470000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100035;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19076;Sopot;sopot;5100594;;18.5623200000;54.4401650000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100056;t;;f;;f;;f;;f;;f;;;;Zoppot;;Sopoty;;;;ソポト;소포트;;;;Сопот;;;索波特
-19077;Szczecin Główny;szczecin-glowny;5100027;;14.5503170000;53.4187840000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100057;t;;f;;f;;f;;f;;f;;Stettin;Stettin;Stettin;Stettino;Štětín;Stettin;;;シュチェチン;슈체친;;;Estetino;Щецин;Stettin;;什切青
+19076;Sopot;sopot;5100594;;18.5623200000;54.4401650000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100056;t;;f;;f;;f;;f;;f;;;;Zoppot;;;Sopoty;;;ソポト;소포트;;;;Сопот;;;索波特
+19077;Szczecin Główny;szczecin-glowny;5100027;;14.5503170000;53.4187840000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100057;t;;f;;f;;f;;f;;f;;Stettin;Stettin;Stettin;Stettino;;Štětín;Stettin;;シュチェチン;슈체친;;;Estetino;Щецин;Stettin;;什切青
 19078;Tczew;tczew;5100711;;18.7901510000;54.0973170000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100061;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Тчев;;;
 19079;Warszawa Zachodnia;warszawa-zachodnia;5103350;;20.9652440000;52.2199740000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100067;t;;f;;f;;f;;f;;f;;Varsovie;Warsaw;Warschau;Varsavia;;;;;;;;;;;;;
-19080;Wrocław Główny;wroclaw-glowny;5106010;;17.0370840000;51.0980750000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100069;t;;f;;f;;f;;f;;f;;;;Breslau;Breslavia;Vratislav;;;;ヴロツワフ;브로츠와프;;;;Врослав;;;弗罗茨瓦夫
+19080;Wrocław Główny;wroclaw-glowny;5106010;;17.0370840000;51.0980750000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100069;t;;f;;f;;f;;f;;f;;;;Breslau;Breslavia;;Vratislav;;;ヴロツワフ;브로츠와프;;;;Врослав;;;弗罗茨瓦夫
 19081;Zbąszynek;zbaszynek;5102610;;15.8180930000;52.2425090000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100071;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19082;Rzepin;rzepin;5102580;;14.8150760000;52.3502180000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100082;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19083;Kostrzyn;kostrzyn;5101300;;14.6446950000;52.5915970000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100214;t;;f;;f;;f;;f;;f;;;;Küstrin;;;;;;コストシン・ナド・オドロン;;;;;Костшин;;;科斯琴
@@ -17558,7 +17558,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19091;Świnoujście Centrum;swinoujscie-centrum;5189954;;14.2360000000;53.9129930000;;f;PL;f;Europe/Warsaw;t;;;f;;f;5189954;t;;f;;f;;f;;f;;f;;;;;;;;;;シフィノウイシチェ;시비노우이시치에;;;;Свиноуйсьце;;;希維諾烏伊希切
 19092;Jesenice;jesenice;7942400;;14.0533040000;46.4363500000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900001;t;;f;;f;;f;;f;;f;;Slovénie;Slovenia;Slowenien;Slovenia;;;;;イェセニツェ;;;;;;;;
 19093;Lesce Bled;lesce-bled;7942313;;14.1576320000;46.3604270000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900002;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19094;Ljubljana;ljubljana;7942300;;14.5129400000;46.0586860000;;f;SI;f;Europe/Ljubljana;t;SILJU;;f;;f;7900003;t;;f;;f;;f;;f;;f;;;;;Lubiana;Lublaň;;Liubliana;;リュブリャナ;류블랴나;;Lublana;Liubliana;Любляна;;;卢布尔雅那
+19094;Ljubljana;ljubljana;7942300;;14.5129400000;46.0586860000;;f;SI;f;Europe/Ljubljana;t;SILJU;;f;;f;7900003;t;;f;;f;;f;;f;;f;;;;;Lubiana;Liubliana;Lublaň;;;リュブリャナ;류블랴나;;Lublana;Liubliana;Любляна;;;卢布尔雅那
 19095;Zidani Most;zidani-most;7942200;;15.1707080000;46.0852670000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900004;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19096;Maribor;maribor;7943400;;15.6580130000;46.5620640000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900006;t;;f;;f;;f;;f;;f;;;;Marburg an der Drau;Marburgo;;;;;マリボル;;;;;Марибор;;;
 19097;Pivka;pivka;7944100;;14.1911440000;45.6757100000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900011;t;;f;;f;;f;;f;;f;;;;;San Pietro del Carso;;;;;ピフカ;;;;;;;;
@@ -17566,7 +17566,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19099;Kranj;kranj;7942307;;14.3481680000;46.2390100000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900014;t;;f;;f;;f;;f;;f;;;;;;;;;;クラーニ;;;;;Крань;;;
 19100;Dobova;dobova;7942001;;15.6545520000;45.8988040000;;f;SI;f;Europe/Ljubljana;t;;;f;;f;7900017;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19101;Kuty;kuty;5613016;;17.0476910000;48.6618900000;;f;SK;f;Europe/Bratislava;t;;;f;;f;5600081;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19102;Stockholm Central;stockholm-central;7403751;;18.0576290000;59.3300090000;;f;SE;f;Europe/Stockholm;t;SESTO;;f;;f;7400002;t;;f;;f;;f;;f;;f;;;;;Stoccolma;;;Estocolmo;;ストックホルム;스톡홀름;;Sztokholm;Estocolmo;Стокгольм;;Stokolm;斯德哥尔摩
+19102;Stockholm Central;stockholm-central;7403751;;18.0576290000;59.3300090000;;f;SE;f;Europe/Stockholm;t;SESTO;;f;;f;7400002;t;;f;;f;;f;;f;;f;;;;;Stoccolma;Estocolmo;;;;ストックホルム;스톡홀름;;Sztokholm;Estocolmo;Стокгольм;;Stokolm;斯德哥尔摩
 19103;Alvesta station;alvesta-station;7400144;;14.5568790000;56.8984810000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400005;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19104;Hässleholm Central;hassleholm-central;7401707;;13.7639230000;56.1585160000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400006;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19105;Norrköping Central;norrkoping-central;7402930;;16.1836750000;58.5965620000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400007;t;;f;;f;;f;;f;;f;;;;;;;;;;ノーショーピング;노르셰핑;;;;Норрчёпинг;;;北雪平
@@ -17581,9 +17581,9 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19114;Eslöv station;eslov-station;7400816;;13.3042860000;55.8362350000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400053;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19115;Karlshamn Station;karlshamn-station;7401944;;14.8678160000;56.1767730000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400075;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;Карлсхамн;;;卡爾斯港
 19116;Karlskrona Central;karlskrona-central;7401948;;15.5852540000;56.1663190000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400076;t;;f;;f;;f;;f;;f;;;;;;;;;;カールスクルーナ;칼스크로나;;;;Карлскруна;;;卡尔斯克鲁纳
-19117;Kristianstad Central;kristianstad-central;7402117;;14.1510520000;56.0317770000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400081;t;;f;;f;;f;;f;;f;;;;;;;Christiansstad;;;クリシャンスタード;크리스티안스타드;;;;Кристианстад;;;克里斯蒂安斯塔德
+19117;Kristianstad Central;kristianstad-central;7402117;;14.1510520000;56.0317770000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400081;t;;f;;f;;f;;f;;f;;;;;;;;Christiansstad;;クリシャンスタード;크리스티안스타드;;;;Кристианстад;;;克里斯蒂安斯塔德
 19118;Laholm station;laholm-station;7402288;;12.9985540000;56.5016440000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400083;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-19119;Uppsala Central;uppsala-central;7404351;;17.6467500000;59.8580990000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400102;t;;f;;f;;f;;f;;f;;;;;;;;Upsala;;ウプサラ;웁살라;;;;Уппсала;;;乌普萨拉
+19119;Uppsala Central;uppsala-central;7404351;;17.6467500000;59.8580990000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400102;t;;f;;f;;f;;f;;f;;;;;;Upsala;;;;ウプサラ;웁살라;;;;Уппсала;;;乌普萨拉
 19120;Sölvesborg station;solvesborg-station;7403989;;14.5839280000;56.0498730000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400127;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19121;Ronneby station;ronneby-station;7403219;;15.2833510000;56.2066360000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400135;t;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 19122;Osby;osby;7403074;;13.9948110000;56.3798760000;;f;SE;f;Europe/Stockholm;t;;;f;;f;7400157;t;;f;;f;;f;;f;;f;;Suède;Sweden;Schweden;Svezia;;;;;;;;;;;;;
@@ -17617,7 +17617,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19151;Asciano;asciano;8306813;;11.579958;43.235651;;;IT;f;Europe/Rome;t;;;f;;f;8300970;f;;f;;f;8306813;t;;f;;f;;;;;;;;;;アシャーノ;;;;;Ашано;;;阿夏诺
 19152;Ascoli Piceno;ascoli-piceno;8307550;;13.58795;42.855434;;;IT;f;Europe/Rome;t;;;f;;f;8300548;f;;f;;f;8307550;t;;f;;f;;;;;;;;;;アスコリ・ピチェーノ;;;;;Асколи-Пичено;;;
 19153;Assemini;assemini;8312889;;8.998984;39.287382;;;IT;f;Europe/Rome;t;;;f;;f;8301163;f;;f;;f;8312889;t;;f;;f;;;;;;;;;;;;;;;Ассемини;;;
-19154;Assisi;assisi;8307008;;12.585113;43.058887;;;IT;f;Europe/Rome;t;ITAME;;f;;f;8300188;f;;f;;f;8307008;t;;f;;f;;Assise;;;;;;Asís;;アッシジ;;;Asyż;Assis;Ассизи;;;
+19154;Assisi;assisi;8307008;;12.585113;43.058887;;;IT;f;Europe/Rome;t;ITAME;;f;;f;8300188;f;;f;;f;8307008;t;;f;;f;;Assise;;;;Asís;;;;アッシジ;;;Asyż;Assis;Ассизи;;;
 19155;Botricello;botricello;8311829;;16.857578;38.934061;;;IT;f;Europe/Rome;t;;;f;;f;8300825;f;;f;;f;8311829;t;;f;;f;;;;;;;;;;;;;;;;;;
 19156;Bova Marina;bova-marina;8311860;;15.924067;37.930469;;;IT;f;Europe/Rome;t;ITBVM;;f;;f;8300838;f;;f;;f;8311860;t;;f;;f;;;;;;;;;;;;;;;;;;
 19157;Bovalino;bovalino;8311854;;16.180628;38.149123;;;IT;f;Europe/Rome;t;;;f;;f;8300832;f;;f;;f;8311854;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -17660,7 +17660,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19194;Bogliasco;bogliasco;8304709;;9.066097;44.379142;;;IT;f;Europe/Rome;t;;;f;;f;8301228;f;;f;;f;8304709;t;;f;;f;;;;;;;;;;;;;;;;;;
 19195;Boiano;boiano;8309453;;14.473486;41.488534;;;IT;f;Europe/Rome;t;;;f;;f;8302472;f;;f;;f;8309453;t;;f;;f;;;;;;;;;;;;;;;;;;
 19196;Bolgheri;bolgheri;8306028;;10.550504;43.244865;;;IT;f;Europe/Rome;t;;;f;;f;8301229;f;;f;;f;8306028;t;;f;;f;;;;;;;;;;;;;;;;;;
-19197;Bologna Borgo Panigale;bologna-borgo-panigale;8305100;;11.284824;44.515013;22159;;IT;f;Europe/Rome;t;;;f;;f;8300997;f;;f;;f;8305100;t;;f;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+19197;Bologna Borgo Panigale;bologna-borgo-panigale;8305100;;11.284824;44.515013;22159;;IT;f;Europe/Rome;t;;;f;;f;8300997;f;;f;;f;8305100;t;;f;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
 19198;Cantu-Cermenate;cantu-cermenate;8301313;;9.098368;45.713419;;;IT;f;Europe/Rome;t;;;f;;f;8301310;f;;f;;f;8301313;t;;f;;f;;;;;;;;;;;;;;;;;;
 19199;Candiolo;candiolo;8300512;;7.598914;44.96122;;;IT;f;Europe/Rome;t;;;f;;f;8301079;f;;f;;f;8300512;t;;f;;f;;;;;;;;;;カンディオーロ;;;;;;;;
 19200;Catania Centrale;catania-centrale;8312332;;15.10016;37.506574;22160;;IT;t;Europe/Rome;t;ITCAC;;f;;f;8300307;f;;f;;f;8312332;t;;f;;f;;Catane;;;;;;;;カターニア;;;Katania;;Катания;;;
@@ -17683,7 +17683,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19218;Colle Isarco/Gossensass;colle-isarco-gossensass;8302005;;11.44138;46.938011;;;IT;f;Europe/Rome;t;ITCOI;;f;;f;8300091;f;;f;;f;8302005;t;;f;;f;;;;;;;;;;;;;;;;;;
 19219;Colle Mattia;colle-mattia;8308651;;12.728365;41.832731;;;IT;f;Europe/Rome;t;;;f;;f;8301780;f;;f;;f;8308651;t;;f;;f;;;;;;;;;;;;;;;;;;
 19220;Collecchio;collecchio;8306151;;10.212285;44.755151;;;IT;f;Europe/Rome;t;;;f;;f;8301369;f;;f;;f;8306151;t;;f;;f;;;;;;;;;;;;;;;;;;
-19221;Bologna San Ruffillo;bologna-san-ruffillo;8305130;;11.373116;44.462723;22159;;IT;f;Europe/Rome;t;ITAMJ;;f;;f;8300996;f;;f;;f;8305130;t;;f;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+19221;Bologna San Ruffillo;bologna-san-ruffillo;8305130;;11.373116;44.462723;22159;;IT;f;Europe/Rome;t;ITAMJ;;f;;f;8300996;f;;f;;f;8305130;t;;f;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
 19222;Bolzano Novarese;bolzano-novarese;8300014;;8.441194;45.764685;;;IT;f;Europe/Rome;t;;;f;;f;8301273;f;;f;;f;8300014;t;;f;;f;;;;;;;;;;;;;;;;;;
 19223;Bolzano Sud/Bozen Süd;bolzano-sud-bozen-sud;8302226;;11.326444;46.473511;;;IT;f;Europe/Rome;t;;;f;;f;8301251;f;;f;;f;8302226;t;;f;;f;;;;;;;;;;;;;;;;;;
 19224;Ariano Irpino;ariano-irpino;8309316;;15.117438;41.181984;;;IT;f;Europe/Rome;t;ITAIX;;f;;f;8300818;f;;f;;f;8309316;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18111,7 +18111,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19649;Ispra;ispra;8301121;;8.620987;45.811546;;;IT;f;Europe/Rome;t;;;f;;f;8300607;f;;f;;f;8301121;t;;f;;f;;;;;;;;;;;;;;;;;;
 19650;Itri;itri;8308607;;13.54553;41.271328;;;IT;f;Europe/Rome;t;;;f;;f;8300856;f;;f;;f;8308607;t;;f;;f;;;;;;;;;;イトリ;;;;;;;;
 19651;Ivrea;ivrea;8300154;;7.876393;45.461461;;;IT;f;Europe/Rome;t;;;f;;f;8300021;f;;f;;f;8300154;t;;f;;f;;Ivrée;;;;;;;;イヴレーア;;;;;Ивреа;;;
-19652;Jesi;jesi;8307202;;13.251969;43.520384;;;IT;f;Europe/Rome;t;ITAMU;;f;;f;8300205;f;;f;;f;8307202;t;;f;;f;;;Iesi;;;;;Iesi;;イェージ;;;;;Джези;;;
+19652;Jesi;jesi;8307202;;13.251969;43.520384;;;IT;f;Europe/Rome;t;ITAMU;;f;;f;8300205;f;;f;;f;8307202;t;;f;;f;;;Iesi;;;Iesi;;;;イェージ;;;;;Джези;;;
 19653;Joppolo;joppolo;8311763;;15.897144;38.580767;;;IT;f;Europe/Rome;t;;;f;;f;8301066;f;;f;;f;8311763;t;;f;;f;;;;;;;;;;;;;;;;;;
 19654;Legnago;legnago;8302366;;11.304681;45.18907;;;IT;f;Europe/Rome;t;;;f;;f;8300682;f;;f;;f;8302366;t;;f;;f;;;;;;;;;;;;;;;Леньяго;;;
 19655;Lendinara;lendinara;8302373;;11.591239;45.081945;;;IT;f;Europe/Rome;t;;;f;;f;8300689;f;;f;;f;8302373;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18308,7 +18308,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19848;Prata-Pratola;prata-pratola;8309513;;14.842673;40.988536;;;IT;f;Europe/Rome;t;;;f;;f;8302644;f;;f;;f;8309513;t;;f;;f;;;;;;;;;;;;;;;;;;
 19849;Pratignone;pratignone;8306423;;11.16026;43.84992;;;IT;f;Europe/Rome;t;;;f;;f;8301935;f;;f;;f;8306423;t;;f;;f;;;;;;;;;;;;;;;;;;
 19850;Prato Centrale;prato-centrale;8306416;;11.109309;43.879063;;;IT;f;Europe/Rome;t;ITALB;;f;;f;8300170;f;;f;;f;8306416;t;;f;;f;;;;;;;;;;;;;;;;;;
-19851;Mantova;mantova;8302336;;10.783405;45.158875;;;IT;f;Europe/Rome;t;;;f;;f;8300541;f;;f;;f;8302336;t;;f;;f;;Mantoue;;Mantua;;;;Mantua;;マントヴァ県;만토바 현;Mantua;Mantua;Mântua;Мантуя;;;曼托瓦省
+19851;Mantova;mantova;8302336;;10.783405;45.158875;;;IT;f;Europe/Rome;t;;;f;;f;8300541;f;;f;;f;8302336;t;;f;;f;;Mantoue;;Mantua;;Mantua;;;;マントヴァ県;만토바 현;Mantua;Mantua;Mântua;Мантуя;;;曼托瓦省
 19852;Mantova Frassine;mantova-frassine;8302380;;10.831093;45.150542;;;IT;f;Europe/Rome;t;;;f;;f;8301698;f;;f;;f;8302380;t;;f;;f;;;;;;;;;;;;;;;;;;
 19853;Manziana-Canale Monterano;manziana-canale-monterano;8308314;;12.134385;42.125195;;;IT;f;Europe/Rome;t;;;f;;f;8301795;f;;f;;f;8308314;t;;f;;f;;;;;;;;;;;;;;;;;;
 19854;Montoro-Forino;montoro-forino;8309518;;14.757438;40.820006;;;IT;f;Europe/Rome;t;;;f;;f;8302599;f;;f;;f;8309518;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18416,7 +18416,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19956;Pietrelcina;pietrelcina;8309508;;14.832462;41.188762;;;IT;f;Europe/Rome;t;;;f;;f;8302634;f;;f;;f;8309508;t;;f;;f;;;;;;;;;;;;;;;;;;
 19957;Pieve Ligure;pieve-ligure;8304711;;9.091024;44.372552;;;IT;f;Europe/Rome;t;;;f;;f;8301903;f;;f;;f;8304711;t;;f;;f;;;;;;;;;;;;;;;;;;
 19958;Pignataro Maggiore;pignataro-maggiore;8309207;;14.160797;41.173624;;;IT;f;Europe/Rome;t;;;f;;f;8300813;f;;f;;f;8309207;t;;f;;f;;;;;;;;;;;;;;;;;;
-19959;Pinerolo;pinerolo;8300517;;7.337121;44.887616;;;IT;f;Europe/Rome;t;;;f;;f;8300523;f;;f;;f;8300517;t;;f;;f;;Pignerol;;;;;;Peñarol;;ピネローロ;;;;;Пинероло;;;
+19959;Pinerolo;pinerolo;8300517;;7.337121;44.887616;;;IT;f;Europe/Rome;t;;;f;;f;8300523;f;;f;;f;8300517;t;;f;;f;;Pignerol;;;;Peñarol;;;;ピネローロ;;;;;Пинероло;;;
 19960;Gravellona Toce;gravellona-toce;8300007;;8.428331;45.934105;;;IT;f;Europe/Rome;t;;;f;;f;8300957;f;;f;;f;8300007;t;;f;;f;;;;;;;;;;;;;;;;;;
 19961;Piano d’Orta Bolognano;piano-dorta-bolognano;8307714;;13.95133;42.254217;;;IT;f;Europe/Rome;t;;;f;;f;8301860;f;;f;;f;8307714;t;;f;;f;;;;;;;;;;;;;;;;;;
 19962;Piano Orizzontale dei Giovi;piano-orizzontale-dei-giovi;8304216;;8.918926;44.530799;;;IT;f;Europe/Rome;t;;;f;;f;8301900;f;;f;;f;8304216;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18452,13 +18452,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 19992;Fagnano-Campana;fagnano-campana;8307420;;13.567796;42.248554;;;IT;f;Europe/Rome;t;;;f;;f;8300795;f;;f;;f;8307420;t;;f;;f;;;;;;;;;;;;;;;;;;
 19993;Dossobuono;dossobuono;8302330;;10.914621;45.392154;;;IT;f;Europe/Rome;t;;;f;;f;8300685;f;;f;;f;8302330;t;;f;;f;;;;;;;;;;;;;;;;;;
 19994;Druogno;druogno;8314002;;8.433913;46.133153;;;IT;f;Europe/Rome;t;;;f;;f;8302809;f;;f;;f;8314002;t;;f;;f;;;;;;;;;;;;;;;;;;
-19995;Firenze Rovezzano;firenze-rovezzano;8306901;;11.308699;43.768855;;;IT;f;Europe/Rome;t;;;f;;f;8302795;f;;f;;f;8306901;t;;f;;f;;Florence;Florence;Florenz;;Florencie;;Florencia;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
-19996;Firenze Statuto;firenze-statuto;8306430;;11.249703;43.787319;;;IT;f;Europe/Rome;t;;;f;;f;8301531;f;;f;;f;8306430;t;;f;;f;;Florence;Florence;Florenz;;Florencie;;Florencia;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
+19995;Firenze Rovezzano;firenze-rovezzano;8306901;;11.308699;43.768855;;;IT;f;Europe/Rome;t;;;f;;f;8302795;f;;f;;f;8306901;t;;f;;f;;Florence;Florence;Florenz;;Florencia;Florencie;;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
+19996;Firenze Statuto;firenze-statuto;8306430;;11.249703;43.787319;;;IT;f;Europe/Rome;t;;;f;;f;8301531;f;;f;;f;8306430;t;;f;;f;;Florence;Florence;Florenz;;Florencia;Florencie;;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
 19997;Fisciano;fisciano;8309519;;14.77565;40.761082;;;IT;f;Europe/Rome;t;;;f;;f;8302537;f;;f;;f;8309519;t;;f;;f;;;;;;;;;;;;;;;;;;
 19998;Nozzano;nozzano;8306351;;10.407935;43.830026;;;IT;f;Europe/Rome;t;;;f;;f;8301814;f;;f;;f;8306351;t;;f;;f;;;;;;;;;;;;;;;;;;
 19999;Fiorenzuola;fiorenzuola;8305007;;9.916827;44.929021;;;IT;f;Europe/Rome;t;;;f;;f;8300235;f;;f;;f;8305007;t;;f;;f;;;;;;;;;;;;;;;;;;
 20000;;;;;;;;;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-20001;Firenze Castello;firenze-castello;8306419;;11.218313;43.8195;;;IT;f;Europe/Rome;t;;;f;;f;8301503;f;;f;;f;8306419;t;;f;;f;;Florence;Florence;Florenz;;Florencie;;Florencia;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
+20001;Firenze Castello;firenze-castello;8306419;;11.218313;43.8195;;;IT;f;Europe/Rome;t;;;f;;f;8301503;f;;f;;f;8306419;t;;f;;f;;Florence;Florence;Florenz;;Florencia;Florencie;;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
 20002;;;;;;;;;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 20003;Galliera Veneta-Tombolo;galliera-veneta-tombolo;8302541;;11.827718;45.652787;;;IT;f;Europe/Rome;t;;;f;;f;8301598;f;;f;;f;8302541;t;;f;;f;;;;;;;;;;;;;;;;;;
 20004;Genova Sturla;genova-sturla;8304703;;8.981473;44.397875;;;IT;f;Europe/Rome;t;;;f;;f;8301594;f;;f;;f;8304703;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18488,8 +18488,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20028;Mussotto;mussotto;8300824;;8.016687;44.713477;;;IT;f;Europe/Rome;t;;;f;;f;8301791;f;;f;;f;8300824;t;;f;;f;;;;;;;;;;;;;;;;;;
 20029;Muzzana del Turgnano;muzzana-del-turgnano;8303204;;13.132655;45.816885;;;IT;f;Europe/Rome;t;;;f;;f;8300898;f;;f;;f;8303204;t;;f;;f;;;;;;;;;;;;;;;;;;
 20030;;;;;;;;;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-20031;Napoli Gianturco;napoli-gianturco;8309110;;14.287266;40.845958;22184;;IT;f;Europe/Rome;t;;;f;;f;8301012;f;;f;;f;8309110;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
-20032;Napoli Piazza Amedeo;napoli-piazza-amedeo;8309106;;14.2336;40.837473;22184;;IT;f;Europe/Rome;t;;;f;;f;8302631;f;;f;;f;8309106;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+20031;Napoli Gianturco;napoli-gianturco;8309110;;14.287266;40.845958;22184;;IT;f;Europe/Rome;t;;;f;;f;8301012;f;;f;;f;8309110;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+20032;Napoli Piazza Amedeo;napoli-piazza-amedeo;8309106;;14.2336;40.837473;22184;;IT;f;Europe/Rome;t;;;f;;f;8302631;f;;f;;f;8309106;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 20033;Grottaglie;grottaglie;8311602;;17.424402;40.529098;;;IT;f;Europe/Rome;t;;;f;;f;8302556;f;;f;;f;8311602;t;;f;;f;;;;;;;;;;;;;;;Гротталье;;;
 20034;Mulinetti;mulinetti;8304713;;9.13028;44.362242;;;IT;f;Europe/Rome;t;;;f;;f;8301787;f;;f;;f;8304713;t;;f;;f;;;;;;;;;;;;;;;;;;
 20035;Pietra Ligure;pietra-ligure;8304520;;8.277752;44.145548;;;IT;f;Europe/Rome;t;ITAAP;;f;;f;8300035;f;;f;;f;8304520;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18508,9 +18508,9 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20048;None;none;8300513;;7.54007;44.938064;;;IT;f;Europe/Rome;t;;;f;;f;8301811;f;;f;;f;8300513;t;;f;;f;;;;;;;;;;ノーネ;;;;;;;;
 20049;Notaresco;notaresco;8307903;;13.876369;42.701476;;;IT;f;Europe/Rome;t;;;f;;f;8301812;f;;f;;f;8307903;t;;f;;f;;;;;;;;;;;;;;;;;;
 20050;Noto;noto;8312424;;15.074307;36.882498;;;IT;f;Europe/Rome;t;;;f;;f;8302609;f;;f;;f;8312424;t;;f;;f;;;;;;;;;;ノート;;;;;Ното;;;
-20051;Napoli San Giovanni Barra;napoli-san-giovanni-barra;8309800;;14.305541;40.833158;22184;;IT;f;Europe/Rome;t;;;f;;f;8301013;f;;f;;f;8309800;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+20051;Napoli San Giovanni Barra;napoli-san-giovanni-barra;8309800;;14.305541;40.833158;22184;;IT;f;Europe/Rome;t;;;f;;f;8301013;f;;f;;f;8309800;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 20052;Racalmuto;racalmuto;8312373;;13.727624;37.405903;;;IT;f;Europe/Rome;t;;;f;;f;8300528;f;;f;;f;8312373;t;;f;;f;;;;;;;;;;;;;;;;;;
-20053;Ravenna;ravenna;8305811;;12.208384;44.419242;;;IT;f;Europe/Rome;t;ITANH;;f;;f;8300219;f;;f;;f;8305811;t;;f;;f;;Ravenne;;;;;;Rávena;;ラヴェンナ;;;Rawenna;;Равенна;;;
+20053;Ravenna;ravenna;8305811;;12.208384;44.419242;;;IT;f;Europe/Rome;t;ITANH;;f;;f;8300219;f;;f;;f;8305811;t;;f;;f;;Ravenne;;;;Rávena;;;;ラヴェンナ;;;Rawenna;;Равенна;;;
 20054;Airasca;airasca;8300514;;7.483348;44.928077;;;IT;f;Europe/Rome;t;;;f;;f;8300644;f;;f;;f;8300514;t;;f;;f;;;;;;;;;;アイラスカ;;;;;;;;
 20055;Acquafredda;acquafredda;8311722;;15.672432;40.034808;;;IT;f;Europe/Rome;t;;;f;;f;8301123;f;;f;;f;8311722;t;;f;;f;;;;;;;;;;アックアフレッダ;;;;;;;;
 20056;Rotondi Paolisi;rotondi-paolisi;8339016;;14.593106;41.035667;;;IT;f;Europe/Rome;t;;;f;;f;8303227;f;;f;;f;8339016;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18522,7 +18522,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20062;Nocera Inferiore;nocera-inferiore;8309814;;14.636353;40.745234;;;IT;f;Europe/Rome;t;ITNCR;;f;;f;8300255;f;;f;;f;8309814;t;;f;;f;;;;;;;;;;;;;;;;;;
 20063;Acqui Terme;acqui-terme;8300867;;8.473663;44.67228;;;IT;f;Europe/Rome;t;;;f;;f;8300656;f;;f;;f;8300867;t;;f;;f;;;;;;;;;;アックイ・テルメ;;;;;;;;
 20064;Adria;adria;8305420;;12.054148;45.060533;;;IT;f;Europe/Rome;t;;;f;;f;8300690;f;;f;;f;8305420;t;;f;;f;;;;;;;;;;;;;;;Адрия;;;
-20065;Paola;paola;8311739;;16.033852;39.358999;;;IT;f;Europe/Rome;t;ITAYU;;f;;f;8300335;f;;f;;f;8311739;t;;f;;f;;;;;;;;Paula;;パオラ;;;;;Паола;;;保拉
+20065;Paola;paola;8311739;;16.033852;39.358999;;;IT;f;Europe/Rome;t;ITAYU;;f;;f;8300335;f;;f;;f;8311739;t;;f;;f;;;;;;Paula;;;;パオラ;;;;;Паола;;;保拉
 20066;Ponte San Pietro;ponte-san-pietro;8301528;;9.584271;45.699243;;;IT;f;Europe/Rome;t;;;f;;f;8300964;f;;f;;f;8301528;t;;f;;f;;;;;;;;;;;;;;;;;;
 20067;Acquappesa;acquappesa;8311736;;15.955969;39.486439;;;IT;f;Europe/Rome;t;;;f;;f;8301148;f;;f;;f;8311736;t;;f;;f;;;;;;;;;;アックアッペーザ;;;;;;;;
 20068;Dueville;dueville;8302146;;11.546104;45.635087;;;IT;f;Europe/Rome;t;;;f;;f;8300693;f;;f;;f;8302146;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18708,7 +18708,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20248;Taino-Angera;taino-angera;8301122;;8.606173;45.772281;;;IT;f;Europe/Rome;t;;;f;;f;8302230;f;;f;;f;8301122;t;;f;;f;;;;;;;;;;;;;;;;;;
 20249;Talamone;talamone;8308002;;11.164737;42.564597;;;IT;f;Europe/Rome;t;;;f;;f;8302233;f;;f;;f;8308002;t;;f;;f;;;;;;;;;;;;;;;;;;
 20250;Taormina-Giardini;taormina-giardini;8312317;;15.282632;37.84544;;;IT;f;Europe/Rome;t;ITAYY;;f;;f;8300339;f;;f;;f;8312317;t;;f;;f;;;;;;;;;;;;;;;;;;
-20251;Taranto;taranto;8311465;;17.224311;40.483486;;;IT;f;Europe/Rome;t;ITAVA;;f;;f;8300292;f;;f;;f;8311465;t;;f;;f;;Tarente;;Tarent;;;;Tarento;;ターラント;;Tarente;Tarent;;Таранто;;;
+20251;Taranto;taranto;8311465;;17.224311;40.483486;;;IT;f;Europe/Rome;t;ITAVA;;f;;f;8300292;f;;f;;f;8311465;t;;f;;f;;Tarente;;Tarent;;Tarento;;;;ターラント;;Tarente;Tarent;;Таранто;;;
 20252;Spotorno-Noli;spotorno-noli;8304526;;8.410972;44.226658;;;IT;f;Europe/Rome;t;;;f;;f;8300271;f;;f;;f;8304526;t;;f;;f;;;;;;;;;;;;;;;;;;
 20253;Spagnuola;spagnuola;8312106;;12.477027;37.836298;;;IT;f;Europe/Rome;t;;;f;;f;8302704;f;;f;;f;8312106;t;;f;;f;;;;;;;;;;;;;;;;;;
 20254;Spresiano;spresiano;8302709;;12.266913;45.777791;;;IT;f;Europe/Rome;t;;;f;;f;8300634;f;;f;;f;8302709;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18922,13 +18922,13 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20463;Samassi-Serrenti;samassi-serrenti;8312885;;8.899069;39.482951;;;IT;f;Europe/Rome;t;;;f;;f;8302130;f;;f;;f;8312885;t;;f;;f;;;;;;;;;;;;;;;;;;
 20464;Samoggia;samoggia;8305039;;11.132313;44.571681;;;IT;f;Europe/Rome;t;;;f;;f;8302062;f;;f;;f;8305039;t;;f;;f;;;;;;;;;;;;;;;;;;
 20465;Sampieri;sampieri;8312419;;14.744601;36.731901;;;IT;f;Europe/Rome;t;;;f;;f;8302686;f;;f;;f;8312419;t;;f;;f;;;;;;;;;;;;;;;;;;
-20466;San Remo;san-remo;8304505;;7.784343;43.829038;;;IT;f;Europe/Rome;t;ITSRE;;f;;f;8300182;f;;f;;f;8304505;t;;f;;f;;Sanremo;Sanremo;Sanremo;Sanremo;Sanremo;;Sanremo;;サンレーモ;;;Sanremo;Sanremo;Сан-Ремо;Sanremo;;
+20466;San Remo;san-remo;8304505;;7.784343;43.829038;;;IT;f;Europe/Rome;t;ITSRE;;f;;f;8300182;f;;f;;f;8304505;t;;f;;f;;Sanremo;Sanremo;Sanremo;Sanremo;Sanremo;Sanremo;;;サンレーモ;;;Sanremo;Sanremo;Сан-Ремо;Sanremo;;
 20467;Saluggia;saluggia;8300235;;8.017236;45.234303;;;IT;f;Europe/Rome;t;;;f;;f;8302059;f;;f;;f;8300235;t;;f;;f;;;;;;;;;;;;;;;;;;
 20468;Salussola;salussola;8300074;;8.11502;45.445172;;;IT;f;Europe/Rome;t;;;f;;f;8302065;f;;f;;f;8300074;t;;f;;f;;;;;;;;;;;;;;;;;;
 20469;Sipicciano;sipicciano;8308300;;12.255002;42.546367;;;IT;f;Europe/Rome;t;;;f;;f;8302128;f;;f;;f;8308300;t;;f;;f;;;;;;;;;;;;;;;;;;
 20470;Sipicciano San Nicola;sipicciano-san-nicola;8308326;;12.234606;42.545441;;;IT;f;Europe/Rome;t;;;f;;f;8302183;f;;f;;f;8308326;t;;f;;f;;;;;;;;;;;;;;;;;;
 20471;Tito;tito;8309834;;15.69824;40.607349;;;IT;f;Europe/Rome;t;;;f;;f;8302429;f;;f;;f;8309834;t;;f;;f;;;;;;;;;;;;;;;;;;
-20472;Tivoli;tivoli;8308508;;12.805034;41.961924;;;IT;f;Europe/Rome;t;;;f;;f;8300386;f;;f;;f;8308508;t;;f;;f;;;;;;;;Tibur;;ティヴォリ;;;;;Тиволи;;;
+20472;Tivoli;tivoli;8308508;;12.805034;41.961924;;;IT;f;Europe/Rome;t;;;f;;f;8300386;f;;f;;f;8308508;t;;f;;f;;;;;;Tibur;;;;ティヴォリ;;;;;Тиволи;;;
 20473;Tocco-Castiglione;tocco-castiglione;8307705;;13.904532;42.226369;;;IT;f;Europe/Rome;t;;;f;;f;8300782;f;;f;;f;8307705;t;;f;;f;;;;;;;;;;;;;;;;;;
 20474;Tolentino;tolentino;8307304;;13.290056;43.214373;;;IT;f;Europe/Rome;t;;;f;;f;8300801;f;;f;;f;8307304;t;;f;;f;;;;;;;;;;;;;;;;;;
 20475;Tommaso Natale;tommaso-natale;8312131;;13.288331;38.190149;;;IT;f;Europe/Rome;t;;;f;;f;8302713;f;;f;;f;8312131;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -18988,7 +18988,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20529;Ponte Schiavo;ponte-schiavo;8312060;;15.494059;38.080616;;;IT;f;Europe/Rome;t;;;f;;f;8312060;f;;f;;f;8312060;t;;f;;f;;;;;;;;;;;;;;;;;;
 20530;Malpensa Aeroporto;malpensa-aeroporto;8325635;;8.711086;45.62724;;;IT;f;Europe/Rome;t;;;f;;f;8303905;f;;f;;f;8325635;t;;f;;f;;;;;;;;;;;;;;;;;;
 20531;Fratte-Villa Comunale;fratte-villa-comunale;8309534;;14.778014;40.69645;;;IT;f;Europe/Rome;t;;;f;;f;8391590;f;;f;;f;8309534;t;;f;;f;;;;;;;;;;;;;;;;;;
-20532;Siracusa;siracusa;8312349;;15.281733;37.068907;;;IT;f;Europe/Rome;t;ITAYX;;f;;f;8300338;f;;f;;f;8312349;t;;f;;f;;Syracuse;Syracuse;Syrakus;;Syrakusy;Syrakus;;;シラクサ;시라쿠사;Syracuse;Syrakuzy;;Сиракуза;Syrakusa;Siraküza;锡拉库扎
+20532;Siracusa;siracusa;8312349;;15.281733;37.068907;;;IT;f;Europe/Rome;t;ITAYX;;f;;f;8300338;f;;f;;f;8312349;t;;f;;f;;Syracuse;Syracuse;Syrakus;;;Syrakusy;Syrakus;;シラクサ;시라쿠사;Syracuse;Syrakuzy;;Сиракуза;Syrakusa;Siraküza;锡拉库扎
 20533;Sagrado;sagrado;8303307;;13.483693;45.872286;;;IT;f;Europe/Rome;t;;;f;;f;8302112;f;;f;;f;8303307;t;;f;;f;;;;;;;;;;;;;;;;;;
 20534;;;;;;;;;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 20535;Vernante;vernante;8300616;;7.536079;44.244726;;;IT;f;Europe/Rome;t;;;f;;f;8300390;f;;f;;f;8300616;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -19067,7 +19067,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20609;Trecate;trecate;8300252;;8.740085;45.428668;;;IT;f;Europe/Rome;t;;;f;;f;8302275;f;;f;;f;8300252;t;;f;;f;;;;;;;;;;;;;;;;;;
 20610;Treviso Centrale;treviso-centrale;8302712;;12.245132;45.6597;;;IT;f;Europe/Rome;t;ITAIW;;f;;f;8300130;f;;f;;f;8302712;t;;f;;f;;Trévise;;;;;;;;トレヴィーゾ;;;;;Тревизо;;;
 20611;Tricesimo San Pelagio;tricesimo-san-pelagio;8303028;;13.215122;46.170314;;;IT;f;Europe/Rome;t;;;f;;f;8302862;f;;f;;f;8303028;t;;f;;f;;;;;;;;;;;;;;;;;;
-20612;Trieste Centrale;trieste-centrale;8303317;;13.770431;45.657408;;;IT;f;Europe/Rome;t;ITTRT;;f;;f;8300107;f;;f;;f;8303317;t;;f;;f;;;;Triest;;Terst;;;Trieszt;トリエステ;트리에스테;Triëst;Triest;;Триест;;;
+20612;Trieste Centrale;trieste-centrale;8303317;;13.770431;45.657408;;;IT;f;Europe/Rome;t;ITTRT;;f;;f;8300107;f;;f;;f;8303317;t;;f;;f;;;;Triest;;;Terst;;Trieszt;トリエステ;트리에스테;Triëst;Triest;;Триест;;;
 20613;Tufo;tufo;8309512;;14.815948;41.013868;;;IT;f;Europe/Rome;t;;;f;;f;8302716;f;;f;;f;8309512;t;;f;;f;;;;;;;;;;;;;;;;;;
 20614;Tuoro sul Trasimeno;tuoro-sul-trasimeno;8307000;;12.079335;43.1967;;;IT;f;Europe/Rome;t;;;f;;f;8300757;f;;f;;f;8307000;t;;f;;f;;;;;;;;;;;;;;;;;;
 20615;Vada;vada;8306025;;10.470158;43.353032;;;IT;f;Europe/Rome;t;;;f;;f;8300991;f;;f;;f;8306025;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -19169,7 +19169,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20711;Marano Ticino;marano-ticino;8300983;;8.626471;45.629424;;;IT;f;Europe/Rome;t;;;f;;f;8301661;f;;f;;f;8300983;t;;f;;f;;;;;;;;;;;;;;;;;;
 20712;Castel Gandolfo;castel-gandolfo;8308703;;12.65229;41.746902;;;IT;f;Europe/Rome;t;;;f;;f;8302509;f;;f;;f;8308703;t;;f;;f;;;;;;;;;;;;;;;;;;
 20713;Marotta-Mondolfo;marotta-mondolfo;8307107;;13.137285;43.7697;;;IT;f;Europe/Rome;t;;;f;;f;8301728;f;;f;;f;8307107;t;;f;;f;;;;;;;;;;;;;;;;;;
-20714;Napoli Montesanto;napoli-montesanto;8309107;;14.245268;40.847001;22184;;IT;f;Europe/Rome;t;;;f;;f;8302753;f;;f;;f;8309107;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+20714;Napoli Montesanto;napoli-montesanto;8309107;;14.245268;40.847001;22184;;IT;f;Europe/Rome;t;;;f;;f;8302753;f;;f;;f;8309107;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 20715;Genova Pra;genova-pra;8304535;;8.789247;44.425391;;;IT;f;Europe/Rome;t;ITAJX;;f;;f;8300980;f;;f;;f;8304535;t;;f;;f;;;;;;;;;;;;;;;;;;
 20716;Massalombarda;massalombarda;8305952;;11.827871;44.448871;;;IT;f;Europe/Rome;t;;;f;;f;8301717;f;;f;;f;8305952;t;;f;;f;;;;;;;;;;;;;;;;;;
 20717;Rapallo;rapallo;8304720;;9.231553;44.351239;;;IT;f;Europe/Rome;t;ITALL;;f;;f;8300178;f;;f;;f;8304720;t;;f;;f;;;;;;;;;;ラパッロ;;;;;Рапалло;;;
@@ -19320,8 +19320,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 20863;Fontaniva;fontaniva;8302534;;11.749027;45.634791;;;IT;f;Europe/Rome;t;;;f;;f;8300887;f;;f;;f;8302534;t;;f;;f;;;;;;;;;;;;;;;;;;
 20864;Falciano-Mondragone-Carinola;falciano-mondragone-carinola;8309001;;13.97169;41.123428;;;IT;f;Europe/Rome;t;;;f;;f;8301517;f;;f;;f;8309001;t;;f;;f;;;;;;;;;;;;;;;;;;
 20865;Melano-Marischio;melano-marischio;8307065;;12.860075;43.345049;;;IT;f;Europe/Rome;t;;;f;;f;8301731;f;;f;;f;8307065;t;;f;;f;;;;;;;;;;;;;;;;;;
-20866;Napoli Campi Flegrei;napoli-campi-flegrei;8309103;;14.19483;40.822362;22184;;IT;f;Europe/Rome;t;ITNCA;;f;;f;8300253;f;;f;;f;8309103;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
-20867;Napoli Mergellina;napoli-mergellina;8309105;;14.218759;40.831459;22184;;IT;f;Europe/Rome;t;ITNAM;;f;;f;8300240;f;;f;;f;8309105;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+20866;Napoli Campi Flegrei;napoli-campi-flegrei;8309103;;14.19483;40.822362;22184;;IT;f;Europe/Rome;t;ITNCA;;f;;f;8300253;f;;f;;f;8309103;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+20867;Napoli Mergellina;napoli-mergellina;8309105;;14.218759;40.831459;22184;;IT;f;Europe/Rome;t;ITNAM;;f;;f;8300240;f;;f;;f;8309105;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 20868;Pellezzano;pellezzano;8309521;;14.770229;40.722303;;;IT;f;Europe/Rome;t;;;f;;f;8302622;f;;f;;f;8309521;t;;f;;f;;;;;;;;;;;;;;;;;;
 20869;Monfalcone;monfalcone;8303310;;13.543238;45.807393;;;IT;f;Europe/Rome;t;ITAHD;;f;;f;8300103;f;;f;;f;8303310;t;;f;;f;;;;;;;;;;モンファルコーネ;;;;;Монфальконе;;;
 20870;Casoria-Afragola;casoria-afragola;8309009;;14.298619;40.907732;;;IT;f;Europe/Rome;t;;;f;;f;8302378;f;;f;;f;8309009;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -19500,8 +19500,8 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 21045;Castellina in Chianti-Monteriggioni;castellina-in-chianti-monteriggioni;8306808;;11.2123;43.4087;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8306808;t;;f;;f;;;;;;;;;;;;;;;;;;
 21046;Bibbiano;bibbiano;8329104;;10.4692262;44.6640627;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8329104;t;;f;;f;;;;;;;;;;;;;;;;;;
 21047;Colico;colico;8301420;;9.37529;46.138;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8301420;t;;f;;f;;;;;;;;;;;;;;;;;;
-21048;Bologna San Vitale;bologna-san-vitale;8327204;;11.3728;44.4961;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8327204;t;;f;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
-21049;Bologna Via Larga;bologna-via-larga;8327297;;11.3925;44.4967;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8327297;t;;f;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+21048;Bologna San Vitale;bologna-san-vitale;8327204;;11.3728;44.4961;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8327204;t;;f;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+21049;Bologna Via Larga;bologna-via-larga;8327297;;11.3925;44.4967;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8327297;t;;f;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
 21050;Bolognina;bolognina;8305315;;11.144166667;44.765277778;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8305315;t;;f;;f;;;;;;;;;;;;;;;;;;
 21051;Bolotana;bolotana;8342515;;8.9624703;40.3103635;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8342515;t;;f;;f;;;;;;;;;;;;;;;;;;
 21052;Bomba;bomba;8351007;;14.347729;42.032974;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8351007;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -19612,9 +19612,9 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 21157;Bono;bono;8342606;;9.0299928;40.4168302;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8342606;t;;f;;f;;;;;;;;;;;;;;;;;;
 21158;Boretto;boretto;8328316;;10.5534;44.9034;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8328316;t;;f;;f;;;;;;;;;;;;;;;;;;
 21159;Borghetto Parmense;borghetto-parmense;8306100;;10.1176;44.8371;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8306100;t;;f;;f;;;;;;;;;;;;;;;;;;
-21160;Bologna Panigale Scala;bologna-panigale-scala;8305323;;11.28467559814453;44.51511398458795;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8305323;t;;f;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
-21161;Bologna Rimesse;bologna-rimesse;8327207;;11.3735;44.494;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8327207;t;;f;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
-21162;Bologna Santa Rita;bologna-santa-rita;8327295;;11.3835;44.4957;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8327295;t;;f;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+21160;Bologna Panigale Scala;bologna-panigale-scala;8305323;;11.28467559814453;44.51511398458795;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8305323;t;;f;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+21161;Bologna Rimesse;bologna-rimesse;8327207;;11.3735;44.494;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8327207;t;;f;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+21162;Bologna Santa Rita;bologna-santa-rita;8327295;;11.3835;44.4957;22159;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8327295;t;;f;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
 21163;Castellino sul Biferno;castellino-sul-biferno;8309472;;14.6995;41.6213;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8309472;t;;f;;f;;;;;;;;;;;;;;;;;;
 21164;Castellino Tanaro;castellino-tanaro;8300741;;7.98124;44.427835;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8300741;t;;f;;f;;;;;;;;;;;;;;;;;;
 21165;Calciano;calciano;8311455;;16.202500000;40.594722222;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8311455;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -20113,7 +20113,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 21658;;;;;;;;;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 21659;Fiumelatte;fiumelatte;8301412;;9.29277;45.9991;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8301412;t;;f;;f;;;;;;;;;;;;;;;;;;
 21660;Fiumetorto;fiumetorto;8312015;;13.7749;37.9666;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8312015;t;;f;;f;;;;;;;;;;;;;;;;;;
-21661;Firenze Cascine;firenze-cascine;8306515;;11.2278;43.7824;;;IT;f;Europe/Rome;t;ITFCA;;f;;f;;f;;f;;f;8306515;t;;f;;f;;Florence;Florence;Florenz;;Florencie;;Florencia;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
+21661;Firenze Cascine;firenze-cascine;8306515;;11.2278;43.7824;;;IT;f;Europe/Rome;t;ITFCA;;f;;f;;f;;f;;f;8306515;t;;f;;f;;Florence;Florence;Florenz;;Florencia;Florencie;;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
 21662;Gamberale;gamberale;8351003;;14.207315;41.906031;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8351003;t;;f;;f;;;;;;;;;;;;;;;;;;
 21663;Gallipoli;gallipoli;8341091;;17.9911;40.0583;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8341091;t;;f;;f;;;;;;;;;;;;;;;Галлиполи;;;
 21664;Gallitello;gallitello;8312115;;12.9489;37.8579;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8312115;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -20134,7 +20134,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 21679;Meda;meda;8325025;;9.15891;45.6624;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8325025;t;;f;;f;;;;;;;;;;メーダ;;;;;Мед;;;
 21680;Potenza Centrale;potenza-centrale;8311420;;15.806551;40.630109;;;IT;f;Europe/Rome;t;ITAUV;;f;;f;8300291;f;;f;;f;8311420;t;;f;;f;;;;;;;;;;ポテンツァ;;;;;;;;
 21681;Musei;musei;8312953;;8.67651;39.2885;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8312953;t;;f;;f;;;;;;;;;;;;;;;;;;
-21682;Napoli Marittima;napoli-marittima;8316506;;14.256198406219482;40.838842482626404;22184;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8316506;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+21682;Napoli Marittima;napoli-marittima;8316506;;14.256198406219482;40.838842482626404;22184;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8316506;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 21683;Mozzate;mozzate;8325224;;8.95507;45.6778;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8325224;t;;f;;f;;;;;;;;;;;;;;;;;;
 21684;Pietrafitta;pietrafitta;8354304;;16.323537826538086;39.26922482677927;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8354304;t;;f;;f;;;;;;;;;;;;;;;;;;
 21685;Piene Frontiere;piene-frontiere;8323601;;7.530555556;43.890277778;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8323601;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -20151,12 +20151,12 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 21696;Exilles;exilles;8300251;;6.926944444;45.090000000;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8300251;t;;f;;f;;;;;;;;;;;;;;;;;;
 21697;Piazzola;piazzola;8329105;;10.8191595;46.4107636;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8329105;t;;f;;f;;;;;;;;;;;;;;;;;;
 21698;Neive;neive;8300827;;8.12017;44.7228;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8300827;t;;f;;f;;;;;;;;;;;;;;;;;;
-21699;Napoli Piazza Leopardi;napoli-piazza-leopardi;8309104;;14.2004;40.8248;22184;;IT;f;Europe/Rome;t;ITAQN;;f;;f;;f;;f;;f;8309104;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+21699;Napoli Piazza Leopardi;napoli-piazza-leopardi;8309104;;14.2004;40.8248;22184;;IT;f;Europe/Rome;t;ITAQN;;f;;f;;f;;f;;f;8309104;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 21700;Niardo Losine;niardo-losine;8326023;;10.325839519500732;45.981441702946924;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8326023;t;;f;;f;;;;;;;;;;;;;;;;;;
-21701;Napoli Piazza Cavour;napoli-piazza-cavour;8309108;;14.255;40.8553;22184;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8309108;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+21701;Napoli Piazza Cavour;napoli-piazza-cavour;8309108;;14.255;40.8553;22184;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8309108;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 21702;Nicorvo;nicorvo;8300273;;8.67129;45.2756;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8300273;t;;f;;f;;;;;;;;;;;;;;;;;;
 21703;Noicattaro Citta’;noicattaro-citta;8341006;;16.9863224029541;41.028769282003026;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8341006;t;;f;;f;;;;;;;;;;;;;;;;;;
-21704;Napoli Piazza Garibaldi;napoli-piazza-garibaldi;8309109;;14.2707;40.8526;22184;;IT;f;Europe/Rome;t;ITQAA;;f;;f;;f;;f;;f;8309109;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+21704;Napoli Piazza Garibaldi;napoli-piazza-garibaldi;8309109;;14.2707;40.8526;22184;;IT;f;Europe/Rome;t;ITQAA;;f;;f;;f;;f;;f;8309109;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 21705;Nardo’ Centrale;nardo-centrale;8341088;;18.0492526;40.1617497;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8341088;t;;f;;f;;;;;;;;;;;;;;;;;;
 21706;Racale-Alliste;racale-alliste;8341071;;18.087637424468994;39.965477436645436;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8341071;t;;f;;f;;;;;;;;;;;;;;;;;;
 21707;Rapolla-Lavello;rapolla-lavello;8311301;;15.741388889;41.009166667;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8311301;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -20455,7 +20455,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22000;Vallo della Lucania-Castelnuovo;vallo-della-lucania-castelnuovo;8311709;;15.158419;40.229631;;;IT;f;Europe/Rome;t;ITVDL;;f;;f;8300345;f;;f;;f;8311709;t;;f;;f;;;;;;;;;;;;;;;;;;
 22001;Valmozzola;valmozzola;8306157;;9.94249;44.5795;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8306157;t;;f;;f;;;;;;;;;;;;;;;;;;
 22002;Valvasone;valvasone;8303061;;12.8711;46.0004;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8303061;t;;f;;f;;;;;;;;;;;;;;;;;;
-22003;Firenze San Marco Vecchio;firenze-san-marco-vecchio;8306950;;11.2677;43.791;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8306950;t;;f;;f;;Florence;Florence;Florenz;;Florencie;;Florencia;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
+22003;Firenze San Marco Vecchio;firenze-san-marco-vecchio;8306950;;11.2677;43.791;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8306950;t;;f;;f;;Florence;Florence;Florenz;;Florencia;Florencie;;;フィレンツェ;피렌체;Florence;Firence;Florença;Флоренция;Florens;Floransa;佛罗伦萨
 22004;Nocera Inferiore Mercato;nocera-inferiore-mercato;8309709;;14.6497;40.746;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8309709;t;;f;;f;;;;;;;;;;;;;;;;;;
 22005;Rio di Pusteria;rio-di-pusteria;8302102;;11.6698;46.7972;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8302102;t;;f;;f;;;Mühlbach;Mühlbach;;;;;;リオ・ディ・プステリーア;;Mühlbach;;;;;;
 22006;Bosco (Cs);bosco-cs;8354250;;16.2941144;39.284401;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8354250;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -20611,7 +20611,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22156;;;;;;;;;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22157;Bari;bari;8311699;;16.8620293;41.1257843;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8311699;t;;f;;f;;;;;;;;;;;;;;;;;;
 22158;Benevento;benevento;8309999;;14.770131111145018;41.14175621597;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8309999;t;;f;;f;;Bénévent;;Benevent;;;;;;ベネヴェント;;;Benewent;;Беневенто;;;
-22159;Bologna;bologna;8305999;;11.343169212341307;44.493681377379744;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8305999;t;;f;;f;;Bologne;;;;;;Bolonia;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
+22159;Bologna;bologna;8305999;;11.343169212341307;44.493681377379744;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8305999;t;;f;;f;;Bologne;;;;Bolonia;;;;ボローニャ;볼로냐;;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
 22160;Catania;catania;8312796;;15.088133811950684;37.50141898722712;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8312796;t;;f;;f;;Catane;;;;;;;;カターニア;;;Katania;;Катания;;;
 22161;Civitavecchia;civitavecchia;8308997;;11.798737049102781;42.088123382714144;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8308997;t;;f;;f;;;;;;;;;;チヴィタヴェッキア;;;;;Чивитавеккья;;;
 22162;Asti Boana;asti-boana;8300351;;;;;;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;8300351;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -20636,7 +20636,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22181;Villamaggiore;villamaggiore;8301802;;9.19051;45.3205;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8301802;t;;f;;f;;;;;;;;;;;;;;;;;;
 22182;Villamar;villamar;8342303;;8.958837;39.618044;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8342303;t;;f;;f;;;;;;;;;;;;;;;;;;
 22183;;;;;;;;;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-22184;Napoli;napoli;8309993;;14.28171157836914;40.85871378519896;;;IT;f;Europe/Rome;t;ITNAP;;f;;f;;f;;f;;f;8309993;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+22184;Napoli;napoli;8309993;;14.28171157836914;40.85871378519896;;;IT;f;Europe/Rome;t;ITNAP;;f;;f;;f;;f;;f;8309993;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 22185;Reviglione di Somma Vesuviana;reviglione-di-somma-vesuviana;8309762;;14.482777778;40.873055556;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8309762;t;;f;;f;;;;;;;;;;;;;;;;;;
 22186;Palermo;palermo;8312792;;13.35789442062378;38.12074922665;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8312792;t;;f;;f;;Palerme;;;;;;;;パレルモ;;;;;Палермо;;;巴勒莫市
 22187;Pisa;pisa;8306993;;10.398817062377928;43.71089730436839;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8306993;t;;f;;f;;Pise;;;;;;;;ピサ;;;Piza;;Пиза;;;
@@ -20817,7 +20817,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22362;Casarano;casarano;8341059;;18.1589071;40.0031833;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8341059;t;;f;;f;;;;;;;;;;;;;;;;;;
 22363;Capodacqua-Pieve Fanonica;capodacqua-pieve-fanonica;8307215;;12.7541;43.0268;;;IT;t;Europe/Rome;t;;;f;;f;;f;;f;;f;8307215;t;;f;;f;;;;;;;;;;;;;;;;;;
 22364;Tradate;tradate;8325227;;8.90695;45.7104;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8325227;t;;f;;f;;;;;;;;;;;;;;;;;;
-22365;Napoli Molo Beverello;napoli-molo-beverello;8386707;;14.254406690597532;40.83752752831728;22184;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8386707;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+22365;Napoli Molo Beverello;napoli-molo-beverello;8386707;;14.254406690597532;40.83752752831728;22184;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8386707;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 22366;Rescaldina;rescaldina;8325622;;8.94662;45.6223;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8325622;t;;f;;f;;;;;;;;;;レスカルディーナ;;;;;;;;
 22367;Revere Scalo;revere-scalo;8305306;;11.129444444;45.040277778;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8305306;t;;f;;f;;;;;;;;;;;;;;;;;;
 22368;Ribera;ribera;8312608;;13.267707824707031;37.501010429493284;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8312608;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -20839,7 +20839,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22384;San Lorenzo St.Lorenzen;san-lorenzo-st-lorenzen;8302016;;11.903160810470581;46.7815190242636;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8302016;t;;f;;f;;;;;;;;;;;;;;;;;;
 22385;San Gennaro;san-gennaro;8308736;;12.7264;41.6746;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8308736;t;;f;;f;;;;;;;;;;;;;;;;;;
 22386;Milano Porta Garibaldi Passante;milano-porta-garibaldi-passante;8301662;;9.185000000;45.484166667;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8301662;t;;f;;f;;;;;;;;;;;;;;;;;;
-22387;Napoli Molo Mergellina;napoli-molo-mergellina;8386708;;14.218626022338867;40.83158961661274;22184;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8386708;t;;f;;f;;Naples;Naples;Neapel;;Neapol;;Nápoles;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
+22387;Napoli Molo Mergellina;napoli-molo-mergellina;8386708;;14.218626022338867;40.83158961661274;22184;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8386708;t;;f;;f;;Naples;Naples;Neapel;;Nápoles;Neapol;;Nápoly;ナポリ;나폴리;Napels;Neapol;Nápoles;Неаполь;Neapel;;那不勒斯
 22388;Ladispoli-Cerveteri;ladispoli-cerveteri;8308021;;12.0815;41.9534;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8308021;t;;f;;f;;;;;;;;;;;;;;;;;;
 22389;Sellia Marina;sellia-marina;8311831;;16.7647;38.9039;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8311831;t;;f;;f;;;;;;;;;;;;;;;;;;
 22390;Milano Porta Venezia;milano-porta-venezia;8301664;;9.20917;45.4756;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8301664;t;;f;;f;;;;;;;;;;;;;;;;;;
@@ -21039,7 +21039,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22584;Paris-Gare-du-Nord Eurostar;paris-gare-du-nord-eurostar;;;2.354598;48.880697;4916;f;FR;f;Europe/Paris;f;;;f;;f;8798014;t;;f;;f;;f;;f;;f;4922;;;;;;;;;;;;;;;;;
 22585;Marne-la-Vallée—Chessy Eurostar;marne-la-vallee-chessy-eurostar;;;2.782853;48.870737;4819;f;FR;f;Europe/Paris;f;;;f;;f;8798948;t;;f;;f;;f;;f;;f;4757;;;;;;;;;;;;;;;;;
 22586;Lille Europe Eurostar;lille-europe-eurostar;;;3.074877;50.639229;4652;f;FR;f;Europe/Paris;f;;;f;;f;8798949;t;;f;;f;;f;;f;;f;4653;;;;;;;;;;;;;;;;;
-22587;Kołobrzeg;kolobrzeg;5100410;;15.569649;54.182310;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100025;t;;f;;f;;f;;f;;f;;;;;;Kolobřeh;;;;;코워브제크;;;;Колобжег;;;科沃布热格
+22587;Kołobrzeg;kolobrzeg;5100410;;15.569649;54.182310;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100025;t;;f;;f;;f;;f;;f;;;;;;;Kolobřeh;;;;코워브제크;;;;Колобжег;;;科沃布热格
 22598;Montpellier;montpellier;;;3.8961821794509888;43.599448798154995;;t;FR;f;Europe/Paris;t;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;モンペリエ;몽펠리에;;;;Монпелье;;;蒙彼利埃
 22599;Montpellier Les Sabines – Gare Routière;montpellier-les-sabines-gare-routiere;;;3.860406875610351;43.58409023914171;22598;f;FR;f;Europe/Paris;t;;;f;;f;;f;XMT;t;;f;;f;;f;;f;;;;;;;;;;モンペリエ;몽펠리에;;;;Монпелье;;;蒙彼利埃
 22600;Nîmes;nimes;;;4.360021948814392;43.836678232954476;;f;FR;f;Europe/Paris;t;;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;ニーム;님;;;;Ним;;;尼姆
@@ -21086,7 +21086,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 22641;La Chapelle Erdre Active;la-chapelle-erdre-active;8763662;;-1.54445;47.28284;;f;FR;f;Europe/Paris;t;FRRPL;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22642;Babinière;babiniere;8759034;;-1.54417;47.25878;;f;FR;f;Europe/Paris;t;FRVKR;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22643;Haluchère Batignolles;haluchere-batignolles;8759033;;-1.52264;47.24878;;f;FR;f;Europe/Paris;t;FRVKQ;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
-22644;Wien Hbf;wien-hbf;8101003;;16.375864;48.184923;;f;AT;f;Europe/Vienna;t;ATALV;;f;;f;8103000;t;;f;;f;;f;;f;;f;;Vienne Gare centrale;Vienna Main station;;Vienna Stazione centrale;Vídeň;;Viena;Bécs;;빈;Wenen;Wiedeń;Viena;Вена;;Viyana;
+22644;Wien Hbf;wien-hbf;8101003;;16.375864;48.184923;;f;AT;f;Europe/Vienna;t;ATALV;;f;;f;8103000;t;;f;;f;;f;;f;;f;;Vienne Gare centrale;Vienna Main station;;Vienna Stazione centrale;Viena;Vídeň;;Bécs;;빈;Wenen;Wiedeń;Viena;Вена;;Viyana;
 22645;Gare fictive 1;gare-fictive-1;;;;;;f;FR;f;Europe/Paris;f;FRMMM;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22646;Gare fictive 2;gare-fictive-2;;;;;;f;FR;f;Europe/Paris;f;FRNNN;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 22647;Gare fictive 3;gare-fictive-3;8734333;;;;;f;FR;f;Europe/Paris;f;FROOO;;f;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -21462,7 +21462,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 23017;Berlin Friedrichstr;berlin-friedrichstr;8003137;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;f;;f;7512;;;;;;;;;;;;;;;;;
 23018;Auch Hôpital;auch-hopital;8766846;;0.57897;43.63068;;f;FR;f;Europe/Paris;t;FRLJX;;t;;f;;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 23019;Flughafen Wien;flughafen-wien;8102924;;16.563056;48.120833;;f;AT;f;Europe/Berlin;t;;;f;;f;8100353;t;;f;;f;;f;;f;;f;;Vienne Aéroport;Vienna Airport;;Vienna Aeroporto;;;;;;;;;;;;;
-23020;La Barasse;la-barasse;8763558;87635581;5.4845101;43.2858384;4790;f;FR;f;Europe/Paris;t;FRSSA;;t;;f;;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marseille;Marseille;Marsella;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
+23020;La Barasse;la-barasse;8763558;87635581;5.4845101;43.2858384;4790;f;FR;f;Europe/Paris;t;FRSSA;;t;;f;;f;;f;;f;;f;;f;;f;;Marseille;Marseille;Marseille;Marsiglia;Marsella;Marseille;Marseille;Marseille;マルセイユ;마르세유;Marseille;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
 23021;bari-policlinico;bari-policlinico;8311517;;16.855000000;41.109444444;22157;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;8311517;f;;f;;f;;;;;;;;;;;;;;;;;;
 23022;Torino di Sangro-Paglieta;torino-di-sangro-paglieta;8307820;;14.552500000;42.228055556;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;8307820;f;;f;;f;;;;;;;;;;;;;;;;;;
 23023;Villabate-Ficarazzelli;villabate-ficarazzelli;8312006;;13.451388889;38.086388889;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;8312006;f;;f;;f;;;;;;;;;;;;;;;;;;
@@ -21486,5 +21486,5 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 23041;Engen Busbahnhof;engen-busbahnhof;;;8.77323;47.85598;7587;f;DE;f;Europe/Berlin;f;;;f;;f;501477;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 23042;Leutkirch Busbahnhof;leutkirch-busbahnhof;;;10.01655;47.82623;7461;f;DE;f;Europe/Berlin;f;;;f;;f;490138;f;;f;;f;;f;;f;;f;;;;;;;;;;;;;;;;;;
 23043;Toulouse Gironis;toulouse-gironis;8768814;;1.417999;43.563604;5306;f;FR;f;Europe/Paris;f;FRXTO;;t;;f;;f;;f;;f;;f;;f;;f;;;;;Tolosa;;;;;トゥールーズ;툴루즈;;Tuluza;;Тулуза;;;圖盧茲
-23044;Liège;liege;;;5.566667;50.633333;;t;BE;f;Europe/Brussels;t;BEFAA;;t;;f;;f;;f;;f;;f;;f;;f;;;;Lüttich;Liegi;Lutych;;Lieja;;リエージュ;리에주;Luik;;;Льеж;;;列日
+23044;Liège;liege;;;5.566667;50.633333;;t;BE;f;Europe/Brussels;t;BEFAA;;t;;f;;f;;f;;f;;f;;f;;f;;;;Lüttich;Liegi;Lieja;Lutych;;;リエージュ;리에주;Luik;;;Льеж;;;列日
 23045;Reggio Emilia;reggio-emilia;;;10.63052;44.69784;;;IT;f;Europe/Rome;t;;;f;;f;;f;;f;;f;8313550;t;;f;;f;;;;;;;;;;;;;;;Реджо-Эмилия;;;


### PR DESCRIPTION
The info:es column has been moved to the right of the info:it column. Information has been added the info:es column, such as central stations, distance to the city, airports and countries for disambiguation.