### PR TITLE
enable SNCF for Ventimiglia and Kortrijk

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -7161,7 +7161,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 8575;Venezia Mestre;venezia-mestre;8302589;83025890;12.2319000000;45.4819020000;8573;f;IT;f;Europe/Rome;t;ITBGG;;f;;f;8300093;t;;f;;f;8302589;t;VEM;t;;f;f;;Venedig;Venice;Venecia;Venise;;Venetië;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
 8576;Venezia Carpenedo;venezia-carpenedo;8302672;;12.247595;45.506676;8573;f;IT;f;Europe/Rome;t;ITAID;;f;;f;8300968;f;;f;;f;8302672;t;;f;;f;f;;Venedig;Venice;Venecia;Venise;;Venetië;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
 8577;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-8578;Ventimiglia;ventimiglia;8304501;;7.609953;43.792586;9604;f;IT;f;Europe/Rome;t;ITVEF;;f;;f;8300146;f;;f;;f;8304501;t;;f;;f;f;;;;;Vintimille;;;;;;ヴェンティミーリア;;;;Вентимилья;;;文蒂米利亚
+8578;Ventimiglia;ventimiglia;8304501;;7.609953;43.792586;9604;f;IT;f;Europe/Rome;t;ITVEF;;t;;f;8300146;f;;f;;f;8304501;t;;f;;f;f;;;;;Vintimille;;;;;;ヴェンティミーリア;;;;Вентимилья;;;文蒂米利亚
 8579;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8580;Verone;verone;;;;;;t;IT;f;Europe/Rome;f;ITVER;;t;;f;;f;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8581;Verona Porta Nuova;verona-porta-nuova;8302430;83024307;10.9827410000;45.4286590000;8580;f;IT;t;Europe/Rome;t;ITVRN;;f;;f;8300120;t;;f;;f;8302430;t;VPN;t;;f;f;;;;;Vérone;;;;;;ヴェローナ;;Werona;;Верона;;;
@@ -16612,7 +16612,7 @@ id;name;slug;uic;uic8_sncf;longitude;latitude;parent_station_id;is_city;country;
 18145;Dinant;dinant;8863503;;4.9078130000;50.2611790000;;f;BE;f;Europe/Brussels;t;BEDNT;;f;;f;8800054;t;;f;;f;;f;;f;;f;f;;;;;;;;;;;ディナン;;;;Динан;;;迪南
 18146;Geel;geel;8832433;;4.9888780000;51.1688560000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800056;t;;f;;f;;f;;f;;f;f;;;;;;;;;;;ヘール;;;;Геел;;;赫尔
 18147;Herentals;herentals;8821717;;4.8285730000;51.1811170000;;f;BE;f;Europe/Brussels;t;;;f;;f;8800063;t;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-18148;Kortrijk;kortrijk;8896008;;3.2642970000;50.8244610000;;f;BE;f;Europe/Brussels;t;BEQKT;;f;;f;8800077;t;;f;;f;;f;;f;;f;f;;;;Courtrai;Courtrai;Courtrai;;;;;コルトレイク;코르트레이크;;Courtrai;Кортрейк;;;科特赖克
+18148;Kortrijk;kortrijk;8896008;;3.2642970000;50.8244610000;;f;BE;f;Europe/Brussels;t;BEQKT;;t;;f;8800077;t;;f;;f;;f;;f;;f;f;;;;Courtrai;Courtrai;Courtrai;;;;;コルトレイク;코르트레이크;;Courtrai;Кортрейк;;;科特赖克
 18149;Lier;lier;8821600;;4.5599760000;51.1358560000;;f;BE;f;Europe/Brussels;t;BELIR;;f;;f;8800083;t;;f;;f;;f;;f;;f;f;;Belgien;Belgium;Bélgica;Lierre;Belgio;België;;;;リール;;;;Льер;;;利尔
 18150;Zottegem;zottegem;8895208;;3.8146620000;50.8689580000;;f;BE;f;Europe/Brussels;t;BEAAG;;f;;f;8800098;t;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 18151;Hasselt;hasselt;8831005;;5.3270610000;50.9308750000;;f;BE;f;Europe/Brussels;t;BEHST;;f;;f;8800114;t;;f;;f;;f;;f;;f;f;;;;;;;;;;;ハッセルト;하셀트;;;Хасселт;;;哈瑟尔特


### PR DESCRIPTION
This allows to sell SNCF tickets to Ventimiglia and Kortrijk. For Ventimiglia, I’m not entirely sure that I enabled the correct station (there are various entries).