### PR TITLE
Activate Cerbère for Renfe

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -4385,7 +4385,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5763;Bandol;bandol;8775522;87755223;43.14046747767621;5.750162601470947;;f;FR;f;Europe/Paris;t;FRXBZ;;t;;f;8700665;f;;f;;f;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Бандоль;;;邦多
 5764;Le Creusot TGV;le-creusot-tgv;8769410;87694109;46.765364;4.500071;;f;FR;f;Europe/Paris;t;FRXCC;LCM;t;;f;8700167;f;;f;;f;;f;;f;;f;;f;;f;t;;;;;;;;;;;ル＝クルーゾ;;;;Ле-Крёзо;;;
 5765;Chalon-sur-Saône;chalon-sur-saone;8772500;87725002;46.781034125625254;4.84371542930603;;f;FR;f;Europe/Paris;t;FRXCD;CSS;t;;f;8700091;t;;f;;f;8772500;f;;f;;f;;f;;f;t;;;;;;;;;;;シャロン＝シュル＝ソーヌ;;;;Шалон-сюр-Сон;;;索恩河畔沙隆
-5766;Cerbère;cerbere;8778500;87785006;42.441661;3.163187;;f;FR;f;Europe/Paris;t;FRXCE;CER;t;;f;8700147;f;;f;;f;;f;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5766;Cerbère;cerbere;8778500;87785006;42.441661;3.163187;;f;FR;f;Europe/Paris;t;FRXCE;CER;t;;f;8700147;f;;f;;f;;f;;f;;f;8700290;t;;f;t;;;;;;;;;;;;;;;;;;
 5767;Chamonix Mont Blanc;chamonix-mont-blanc;8774678;87746784;45.91990069246709;6.866669654846191;;f;FR;f;Europe/Paris;t;FRXCF;CHX;t;;f;8700299;f;;f;;f;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5768;Cagnes-sur-Mer;cagnes-sur-mer;;;43.6666670000;7.1500000000;;t;FR;f;Europe/Paris;f;FRXCG;;t;;f;;f;;f;;f;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5769;Compiègne;compiegne;8727669;87276691;49.42230471648786;2.823502421379089;;f;FR;f;Europe/Paris;t;FRXCP;CPE;t;;f;8700246;f;;f;;f;;f;;f;;f;;f;;f;t;;;;;;;;;;;コンピエーニュ;콩피에뉴;;;Компьень;;;贡比涅


### PR DESCRIPTION
Some Renfe trains go to Cerbère (French station, just after Portbou), more or less the same way they go to Hendaye on the other side of Pyrénées.