### PR TITLE
Add renfe_id for French train stations

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -1,40 +1,40 @@
 id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;is_main_station;time_zone;is_suggestable;sncf_id;sncf_tvs_id;sncf_is_enabled;idtgv_id;idtgv_is_enabled;db_id;db_is_enabled;busbud_id;busbud_is_enabled;ouigo_id;ouigo_is_enabled;trenitalia_id;trenitalia_is_enabled;trenitalia_rtvt_id;ntv_id;ntv_is_enabled;hkx_id;hkx_is_enabled;renfe_id;renfe_is_enabled;atoc_id;atoc_is_enabled;sncf_self_service_machine;same_as;info:de;info:en;info:es;info:fr;info:it;info:nl;info:cs;info:da;info:hu;info:ja;info:ko;info:pl;info:pt;info:ru;info:sv;info:tr;info:zh
 1;Château-Arnoux—St-Auban;chateau-arnoux-st-auban;;;44.0817900000;6.0016250000;;t;FR;f;Europe/Paris;f;FRAAA;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2;Château-Arnoux—St-Auban;chateau-arnoux-st-auban;8775123;87751230;44.061499;5.997342;1;f;FR;t;Europe/Paris;t;FRCAA;;t;;f;8700156;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2;Château-Arnoux—St-Auban;chateau-arnoux-st-auban;8775123;87751230;44.061499;5.997342;1;f;FR;t;Europe/Paris;t;FRCAA;;t;;f;8700156;f;;f;;f;;f;;;f;;f;8700334;f;;f;f;;;;;;;;;;;;;;;;;;
 3;Château-Arnoux Mairie;chateau-arnoux-mairie;8775122;87751222;44.063863;6.011248;1;f;FR;f;Europe/Paris;t;FRHXG;;t;;f;8704959;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4;Digne-les-Bains;digne-les-bains;9921024;;44.3500000000;6.3500000000;;t;FR;f;Europe/Paris;f;FRAAB;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6;Digne-les-Bains;digne-les-bains;8775149;87751495;44.088710133980605;6.222982406616211;4;f;FR;t;Europe/Paris;t;FRXDI;;t;;f;8703212;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+6;Digne-les-Bains;digne-les-bains;8775149;87751495;44.088710133980605;6.222982406616211;4;f;FR;t;Europe/Paris;t;FRXDI;;t;;f;8703212;f;;f;;f;;f;;;f;;f;8700335;f;;f;f;;;;;;;;;;;;;;;;;;
 7;La Crau;la-crau;8775561;87755611;43.144929623552464;6.068830490112305;;f;FR;f;Europe/Paris;t;FRAAC;;t;;f;8703562;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8;Aire-sur-l’Adour;aire-sur-ladour;8767104;87671040;43.703854;-0.258269;;f;FR;f;Europe/Paris;t;FRAAD;;t;;f;8702631;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9;Cagnes-sur-Mer;cagnes-sur-mer;8775632;87756320;43.65779730975508;7.148301601409912;5768;f;FR;t;Europe/Paris;t;FRAAE;;t;;f;8700480;f;;f;;f;8775632;f;;;f;;f;;f;;f;f;;;;;;;;;;;カーニュ＝シュル＝メール;;;;Кань-сюр-Мер;;;卡涅
+9;Cagnes-sur-Mer;cagnes-sur-mer;8775632;87756320;43.65779730975508;7.148301601409912;5768;f;FR;t;Europe/Paris;t;FRAAE;;t;;f;8700480;f;;f;;f;8775632;f;;;f;;f;8700373;f;;f;f;;;;;;;;;;;カーニュ＝シュル＝メール;;;;Кань-сюр-Мер;;;卡涅
 10;Menton;menton;;;43.7764860000;7.5043490000;;t;FR;f;Europe/Paris;f;FRAAF;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-11;Menton;menton;8775648;87756486;43.774716;7.493156;10;f;FR;t;Europe/Paris;t;FRXMT;MEN;t;;f;8700150;f;;f;;f;8775648;t;S75648;;f;;f;;f;;f;t;;;;;;Mentone;;;;;;;;;Ментона;;;
-12;Menton—Garavan;menton-garavan;8775649;87756494;43.785269;7.517247;10;f;FR;f;Europe/Paris;t;FRIAG;;t;;f;8701518;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Mentone;;;;;;;;;;;;
+11;Menton;menton;8775648;87756486;43.774716;7.493156;10;f;FR;t;Europe/Paris;t;FRXMT;MEN;t;;f;8700150;f;;f;;f;8775648;t;S75648;;f;;f;8700295;f;;f;t;;;;;;Mentone;;;;;;;;;Ментона;;;
+12;Menton—Garavan;menton-garavan;8775649;87756494;43.785269;7.517247;10;f;FR;f;Europe/Paris;t;FRIAG;;t;;f;8701518;f;;f;;f;;f;;;f;;f;8700240;f;;f;f;;;;;;Mentone;;;;;;;;;;;;
 16;Vievola;vievola;;;;;;t;FR;f;Europe/Paris;f;FRAAH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 17;Vievola;vievola;8300618;;;;16;f;FR;f;Europe/Paris;f;ITAAE;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 18;Vievola;vievola;8775689;;44.11257890785429;7.562788724899292;16;f;FR;t;Europe/Paris;t;FRIAU;;t;;f;8704841;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 19;Mandelieu-la-Napoule;mandelieu-la-napoule;8775759;87757591;43.52418047111926;6.941471099853516;;f;FR;f;Europe/Paris;t;FRAAJ;;t;;f;8701499;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 23;Decazeville;decazeville;;;44.5500000000;2.2500000000;;t;FR;f;Europe/Paris;f;FRAAQ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 24;Decazeville Centre;decazeville-centre;8761367;87613679;44.561434;2.255896;23;f;FR;t;Europe/Paris;t;FRFTW;;t;;f;8703204;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-25;Viviez—Decazeville;viviez-decazeville;8761366;87613661;44.5556;2.218384;23;f;FR;f;Europe/Paris;t;FRVZD;VZI;t;;f;8704899;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+25;Viviez—Decazeville;viviez-decazeville;8761366;87613661;44.5556;2.218384;23;f;FR;f;Europe/Paris;t;FRVZD;VZI;t;;f;8704899;f;;f;;f;;f;;;f;;f;8700537;f;;f;f;;;;;;;;;;;;;;;;;;
 26;Decazeville Fontvergne;decazeville-fontvergne;8761369;87613695;44.55563533558816;2.263741493225097;23;f;FR;f;Europe/Paris;t;FRFTX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 27;St-Sever;st-sever;;;48.8333330000;-1.0333330000;;t;FR;f;Europe/Paris;f;FRAAS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 28;St-Sever Centre;st-sever-centre;8741929;87419291;48.839517;-1.049283;27;f;FR;f;Europe/Paris;t;FRDQV;;t;;f;8704656;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-29;St-Sever;st-sever;8744771;87447714;48.843715;-1.051746;27;f;FR;t;Europe/Paris;t;FRDUQ;;t;;f;8704655;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-30;Vire;vire;;;48.83897;-0.88928;;t;FR;f;Europe/Paris;t;FRAAT;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+29;St-Sever;st-sever;8744771;87447714;48.843715;-1.051746;27;f;FR;t;Europe/Paris;t;FRDUQ;;t;;f;8704655;f;;f;;f;;f;;;f;;f;8700755;f;;f;f;;;;;;;;;;;;;;;;;;
+30;Vire;vire;;;48.83897;-0.88928;;t;FR;f;Europe/Paris;t;FRAAT;;t;;f;;f;;f;;f;;f;;;f;;f;8700754;f;;f;f;;;;;;;;;;;;;;;;;;
 31;Vire Centre;vire-centre;8744816;87448167;48.837638;-0.880538;30;f;FR;f;Europe/Paris;f;FRDUY;;t;;f;8704890;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 32;Vire;vire;8744815;87448159;48.846421;-0.883001;30;f;FR;t;Europe/Paris;f;FRDUX;VIR;t;;f;8700424;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 33;Marans;marans;;;46.3000000000;-1.0000000000;;t;FR;f;Europe/Paris;f;FRAAV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 34;Marans Centre;marans-centre;8738988;87389882;46.290815;-0.979212;33;f;FR;f;Europe/Paris;t;FRDHK;;t;;f;8706478;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-35;Marans;marans;8748506;87485060;46.310878;-0.991204;33;f;FR;t;Europe/Paris;t;FREII;;t;;f;8702440;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-36;Uzerche;uzerche;8759420;87594200;45.440848;1.570253;5607;f;FR;t;Europe/Paris;t;FRAAW;URE;t;;f;8702147;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-38;Dijon Ville;dijon-ville;8771304;87713040;47.323199;5.026345;1782;f;FR;t;Europe/Paris;t;FRABA;DJV;t;;f;8700021;f;;f;;f;8771304;t;;;f;;f;;f;;f;t;;;;;;Digione;;;;;ディジョン;디종;;;Дижон;;;第戎
+35;Marans;marans;8748506;87485060;46.310878;-0.991204;33;f;FR;t;Europe/Paris;t;FREII;;t;;f;8702440;f;;f;;f;;f;;;f;;f;8700668;f;;f;f;;;;;;;;;;;;;;;;;;
+36;Uzerche;uzerche;8759420;87594200;45.440848;1.570253;5607;f;FR;t;Europe/Paris;t;FRAAW;URE;t;;f;8702147;f;;f;;f;;f;;;f;;f;8700512;f;;f;f;;;;;;;;;;;;;;;;;;
+38;Dijon Ville;dijon-ville;8771304;87713040;47.323199;5.026345;1782;f;FR;t;Europe/Paris;t;FRABA;DJV;t;;f;8700021;f;;f;;f;8771304;t;;;f;;f;8700025;f;;f;t;;;;;;Digione;;;;;ディジョン;디종;;;Дижон;;;第戎
 40;Pontrieux;pontrieux;;;48.7000000000;-3.1666670000;;t;FR;f;Europe/Paris;f;FRABD;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 41;Pontrieux Halte;pontrieux-halte;8747383;87473835;48.69809;-3.164355;40;f;FR;f;Europe/Paris;t;FREAB;;t;;f;8704288;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 42;Pontrieux;pontrieux;8747384;87473843;48.706018;-3.156382;40;f;FR;t;Europe/Paris;t;FREAC;;t;;f;8704287;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 43;Auboué;auboue;8719168;87191684;49.216167463145354;5.9714555740356445;;f;FR;f;Europe/Paris;t;FRABE;;t;;f;8700567;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-44;Périgueux;perigueux;8759500;87595009;45.18725079810115;0.7075291872024536;4957;f;FR;t;Europe/Paris;t;FRABF;PXR;t;;f;8700405;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ペリグー;;;;Перигё;;;佩里格
-45;Besançon Viotte;besancon-viotte;8771800;87718007;47.24733;6.021999;5029;f;FR;t;Europe/Paris;t;FRABG;BNV;t;;f;8700044;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;Besanzón;;;;;;;ブザンソン;브장송;;;Безансон;;;贝桑松
+44;Périgueux;perigueux;8759500;87595009;45.18725079810115;0.7075291872024536;4957;f;FR;t;Europe/Paris;t;FRABF;PXR;t;;f;8700405;f;;f;;f;;f;;;f;;f;8700057;f;;f;t;;;;;;;;;;;ペリグー;;;;Перигё;;;佩里格
+45;Besançon Viotte;besancon-viotte;8771800;87718007;47.24733;6.021999;5029;f;FR;t;Europe/Paris;t;FRABG;BNV;t;;f;8700044;f;;f;;f;;f;;;f;;f;8700053;f;;f;t;;;;Besanzón;;;;;;;ブザンソン;브장송;;;Безансон;;;贝桑松
 47;Douarnenez Office de Tourisme;douarnenez-office-de-tourisme;8747990;87479907;48.09336269013469;-4.3303728103637695;;f;FR;f;Europe/Paris;t;FREEV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ドゥアルヌネ;;;;Дуарнене;;;杜阿尔纳纳
 50;Concarneau;concarneau;;;47.8666670000;-3.9166670000;;t;FR;f;Europe/Paris;f;FRABJ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 51;Concarneau Port;concarneau-port;8747989;87479899;47.867055;-3.927593;50;f;FR;f;Europe/Paris;t;FREEU;;t;;f;8703141;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -49,26 +49,26 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 62;Labège Village;labege-village;8761202;87612028;43.530533;1.532921;60;f;FR;f;Europe/Paris;t;FRFRX;;t;;f;8702526;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 63;Azay-le-Rideau Mairie;azay-le-rideau-mairie;8711029;87110296;47.2666670000;0.4666670000;5083;f;FR;f;Europe/Paris;t;FRABR;;t;;f;8702748;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Castillo de Azay-le-Rideau;;;;;;;アゼ＝ル＝リドー城;아제르리도;;;Азе-лё-Ридо;;;阿泽莱里多
 64;Albas;albas;8761375;87613752;44.4666670000;1.2333330000;9007;f;FR;t;Europe/Paris;t;FRABS;;t;;f;8702636;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-65;Abancourt;abancourt;8731375;87313759;49.68528648603422;1.7740130424499512;;f;FR;f;Europe/Paris;t;FRABT;ABT;t;;f;8700251;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+65;Abancourt;abancourt;8731375;87313759;49.68528648603422;1.7740130424499512;;f;FR;f;Europe/Paris;t;FRABT;ABT;t;;f;8700251;f;;f;;f;;f;;;f;;f;8700885;f;;f;f;;;;;;;;;;;;;;;;;;
 66;Lunel;lunel;;;43.6833330000;4.1333330000;;t;FR;f;Europe/Paris;f;FRABV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 67;Lunel-Viel;lunel-viel;8777342;87773424;43.681174;4.093741;66;f;FR;f;Europe/Paris;t;FRIJC;;t;;f;8701461;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-68;Lunel;lunel;8777340;87773408;43.679601;4.131001;66;f;FR;t;Europe/Paris;t;FRIJB;LUN;t;;f;8702315;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-72;Moirans;moirans;8774732;87747329;45.32206908322778;5.582084655761719;4774;f;FR;t;Europe/Paris;t;FRABZ;MOA;t;;f;8700009;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+68;Lunel;lunel;8777340;87773408;43.679601;4.131001;66;f;FR;t;Europe/Paris;t;FRIJB;LUN;t;;f;8702315;f;;f;;f;;f;;;f;;f;8700276;f;;f;t;;;;;;;;;;;;;;;;;;
+72;Moirans;moirans;8774732;87747329;45.32206908322778;5.582084655761719;4774;f;FR;t;Europe/Paris;t;FRABZ;MOA;t;;f;8700009;f;;f;;f;;f;;;f;;f;8700010;f;;f;f;;;;;;;;;;;;;;;;;;
 73;Arc-et-Senans;arc-et-senans;8771884;87718841;47.0333330000;5.7666670000;;f;FR;f;Europe/Paris;t;FRACA;;t;;f;8702456;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 74;Accolay;accolay;8768365;87683656;47.6666670000;3.7166670000;;f;FR;f;Europe/Paris;t;FRACC;;t;;f;8702616;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-76;Dole Ville;dole-ville;8771341;87713412;47.09622856396676;5.488046407699585;1845;f;FR;t;Europe/Paris;t;FRACE;DLE;t;;f;8700116;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;Доля;;;
-77;Dax;dax;8767320;87673202;43.72076108921594;-1.0500365495681763;5776;f;FR;t;Europe/Paris;t;FRACG;DAX;t;ACG;t;8700043;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+76;Dole Ville;dole-ville;8771341;87713412;47.09622856396676;5.488046407699585;1845;f;FR;t;Europe/Paris;t;FRACE;DLE;t;;f;8700116;f;;f;;f;;f;;;f;;f;8700210;f;;f;t;;;;;;;;;;;;;;;Доля;;;
+77;Dax;dax;8767320;87673202;43.72076108921594;-1.0500365495681763;5776;f;FR;t;Europe/Paris;t;FRACG;DAX;t;ACG;t;8700043;f;;f;;f;;f;;;f;;f;8700052;f;;f;t;;;;;;;;;;;;;;;;;;
 80;Rezé;reze;;;47.2000000000;-1.5666670000;;t;FR;f;Europe/Paris;f;FRACJ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-82;Rezé—Pont-Rousseau;reze-pont-rousseau;8748103;87481036;47.193278;-1.549587;80;f;FR;t;Europe/Paris;t;FREFC;;t;;f;8704363;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-83;Cherbourg;cherbourg;8744487;87444877;49.633295372995704;-1.6210681200027466;;f;FR;f;Europe/Paris;t;FRACK;CBU;t;;f;8700227;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;Cherburgo-Octeville;;;;;;;シェルブール＝オクトヴィル;셰르부르옥트빌;;;Шербур-Октевиль;;;瑟堡-奥克特维尔
-84;Angers St-Laud;angers-st-laud;8748400;87484006;47.46440211188047;-0.5568641424179077;344;f;FR;t;Europe/Paris;t;FRACL;ASL;t;;f;8700022;f;;f;ACL;t;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アンジェ;앙제;;;Анже;;;昂热
-85;Saumur;saumur;8748760;87487603;47.268433556950825;-0.07103562355041504;5831;f;FR;t;Europe/Paris;t;FRACN;SUD;t;;f;8704969;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ソミュール;소뮈르;;;Сомюр;;;索米尔
+82;Rezé—Pont-Rousseau;reze-pont-rousseau;8748103;87481036;47.193278;-1.549587;80;f;FR;t;Europe/Paris;t;FREFC;;t;;f;8704363;f;;f;;f;;f;;;f;;f;8700230;f;;f;f;;;;;;;;;;;;;;;;;;
+83;Cherbourg;cherbourg;8744487;87444877;49.633295372995704;-1.6210681200027466;;f;FR;f;Europe/Paris;t;FRACK;CBU;t;;f;8700227;f;;f;;f;;f;;;f;;f;8700777;f;;f;t;;;;Cherburgo-Octeville;;;;;;;シェルブール＝オクトヴィル;셰르부르옥트빌;;;Шербур-Октевиль;;;瑟堡-奥克特维尔
+84;Angers St-Laud;angers-st-laud;8748400;87484006;47.46440211188047;-0.5568641424179077;344;f;FR;t;Europe/Paris;t;FRACL;ASL;t;;f;8700022;f;;f;ACL;t;;f;;;f;;f;8700026;f;;f;t;;;;;;;;;;;アンジェ;앙제;;;Анже;;;昂热
+85;Saumur;saumur;8748760;87487603;47.268433556950825;-0.07103562355041504;5831;f;FR;t;Europe/Paris;t;FRACN;SUD;t;;f;8704969;f;;f;;f;;f;;;f;;f;8700090;f;;f;t;;;;;;;;;;;ソミュール;소뮈르;;;Сомюр;;;索米尔
 87;Cérences Centre;cerences-centre;8738819;87388199;48.91686;-1.437824;9462;f;FR;f;Europe/Paris;t;FRDGZ;;t;;f;8703000;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-89;Reims;reims;8724856;;49.2500000000;4.0333330000;;t;FR;f;Europe/Paris;t;FRACQ;;t;;f;8796006;f;u0fb5v;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;Remeš;;;ランス;兰斯;;;Реймс;;;兰斯
+89;Reims;reims;8724856;;49.2500000000;4.0333330000;;t;FR;f;Europe/Paris;t;FRACQ;;t;;f;8796006;f;u0fb5v;t;;f;;f;;;f;;f;8700096;f;;f;f;;;;;;;;Remeš;;;ランス;兰斯;;;Реймс;;;兰斯
 90;Reims Maison Blanche;reims-maison-blanche;8717127;87171272;49.233685;4.022484;89;f;FR;f;Europe/Paris;t;FRBBX;;t;;f;8701874;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;Remeš;;;ランス;兰斯;;;Реймс;;;兰斯
-91;Champagne-Ardenne TGV;champagne-ardenne-tgv;8717192;87171926;49.214385;3.994248;89;f;FR;f;Europe/Paris;t;FREAH;CGV;t;;f;8705734;f;;f;;f;;f;;;f;;f;;f;;f;t;;8 km von Reims entfernt;8km from Reims;a 8 km de Reims;à 8 km de Reims;8km da Reims;;Remeš;;;ランス;兰斯;;;Реймс;;;兰斯
+91;Champagne-Ardenne TGV;champagne-ardenne-tgv;8717192;87171926;49.214385;3.994248;89;f;FR;f;Europe/Paris;t;FREAH;CGV;t;;f;8705734;f;;f;;f;;f;;;f;;f;8700781;f;;f;t;;8 km von Reims entfernt;8km from Reims;a 8 km de Reims;à 8 km de Reims;8km da Reims;;Remeš;;;ランス;兰斯;;;Реймс;;;兰斯
 92;Reims Ville;reims-ville;8717100;87171009;49.259241;4.024156;89;f;FR;t;Europe/Paris;t;FRRHE;RMS;t;;f;8700081;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;Remeš;;;ランス;兰斯;;;Реймс;;;兰斯
-93;Laval;laval;8747840;87478404;48.076405;-0.761089;4714;f;FR;t;Europe/Paris;t;FRACR;LAL;t;;f;8701470;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+93;Laval;laval;8747840;87478404;48.076405;-0.761089;4714;f;FR;t;Europe/Paris;t;FRACR;LAL;t;;f;8701470;f;;f;;f;;f;;;f;;f;8700716;f;;f;t;;;;;;;;;;;;;;;;;;
 94;Accous;accous;8767278;87672782;42.9833330000;-0.6000000000;;f;FR;f;Europe/Paris;t;FRACS;;t;;f;8702617;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 95;Achiet;achiet;8734204;87342048;50.1166670000;2.7500000000;;f;FR;f;Europe/Paris;t;FRACT;;t;;f;8700583;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 96;Louverné;louverne;;;48.1333330000;-0.7000000000;;t;FR;f;Europe/Paris;f;FRACU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -81,48 +81,48 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 105;Arnage;arnage;8739654;87396549;47.928236;0.190103;104;f;FR;t;Europe/Paris;t;FRDMK;;t;;f;8702332;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 106;Arnage Centre;arnage-centre;8736033;87360339;47.937288;0.163801;104;f;FR;f;Europe/Paris;t;FRDBM;;t;;f;8702686;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 107;Carnac;carnac;;;47.5833330000;-3.0833330000;;t;FR;f;Europe/Paris;f;FRADB;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-108;Plouharnel—Carnac;plouharnel-carnac;8747641;87476416;47.6043;-3.118456;107;f;FR;f;Europe/Paris;t;FRECR;;t;;f;8704244;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+108;Plouharnel—Carnac;plouharnel-carnac;8747641;87476416;47.6043;-3.118456;107;f;FR;f;Europe/Paris;t;FRECR;;t;;f;8704244;f;;f;;f;;f;;;f;;f;8700737;f;;f;f;;;;;;;;;;;;;;;;;;
 109;Les Sables-Blancs;les-sables-blancs;8747626;87476267;47.575598;-3.132453;107;f;FR;f;Europe/Paris;t;FRECL;;t;;f;8704937;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 110;Carnac;carnac;8728967;87289678;47.584558972342386;-3.0826091766357417;107;f;FR;t;Europe/Paris;t;FRRNC;;t;;f;8701865;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Alineamientos de Carnac;;;;;;;カルナック;;;;;;;卡尔纳克
 111;St-Pierre-Quiberon;st-pierre-quiberon;;;47.5166670000;-3.1333330000;;t;FR;f;Europe/Paris;f;FRADC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 112;L’Isthme;listhme;8747627;87476275;47.547102;-3.133549;111;f;FR;f;Europe/Paris;t;FRECM;;t;;f;8704936;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-113;St-Pierre-Quiberon;st-pierre-quiberon;8747644;87476440;47.52106;-3.138907;111;f;FR;t;Europe/Paris;t;FRECU;;t;;f;8704642;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;圣皮耶尔屈伊伯龙
-114;Metz;metz;8719203;87192039;49.109382;6.177665;4827;f;FR;t;Europe/Paris;t;FRADE;MZE;t;;f;8700019;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;Mety;;;メス;메스;;;Мец;;;梅斯
+113;St-Pierre-Quiberon;st-pierre-quiberon;8747644;87476440;47.52106;-3.138907;111;f;FR;t;Europe/Paris;t;FRECU;;t;;f;8704642;f;;f;;f;;f;;;f;;f;8700741;f;;f;f;;;;;;;;;;;;;;;;;;圣皮耶尔屈伊伯龙
+114;Metz;metz;8719203;87192039;49.109382;6.177665;4827;f;FR;t;Europe/Paris;t;FRADE;MZE;t;;f;8700019;f;;f;;f;;f;;;f;;f;8700023;f;;f;t;;;;;;;;Mety;;;メス;메스;;;Мец;;;梅斯
 115;Forbach;forbach;;;49.1833330000;6.9000000000;;t;FR;f;Europe/Paris;f;FRADF;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 117;Forbach;forbach-gare;8719300;87193003;49.189215;6.900254;115;f;FR;t;Europe/Paris;t;FRBQT;FOB;t;;f;8700271;t;;f;;f;;f;;;f;;f;;f;;f;t;;Frankreich;France;Francia;France;Francia;;;;;フォルバック;;;;Форбах;;;福尔巴克
 118;Sarreguemines;sarreguemines;;;49.1099500000;7.0674710000;;t;FR;f;Europe/Paris;f;FRADG;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 119;Sarreguemines Poste;sarreguemines-poste;8740690;;49.110155;7.054923;118;f;FR;f;Europe/Paris;t;FRZDB;;t;;f;8705509;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 121;Sarreguemines;sarreguemines;8719361;87193615;49.10741472240868;7.068398594856262;118;f;FR;t;Europe/Paris;t;FRSGS;SGS;t;;f;8700439;f;;f;;f;;f;;;f;;f;;f;;f;f;;Saargemünd;;;;;;;;;サルグミーヌ;;;;Саргемин;;;萨尔格米纳
-122;Dunkerque;dunkerque;8728100;87281006;51.03026865635461;2.3686105012893672;;f;FR;f;Europe/Paris;t;FRADI;DKQ;t;;f;8700004;f;u11dmf;t;;f;;f;;;f;;f;;f;;f;t;;Dünkirchen;Dunkirk;;;;Duinkerke;Dunkerk;;;ダンケルク;됭케르크;Dunkierka;Dunquerque;Дюнкерк;;;敦刻尔克
+122;Dunkerque;dunkerque;8728100;87281006;51.03026865635461;2.3686105012893672;;f;FR;f;Europe/Paris;t;FRADI;DKQ;t;;f;8700004;f;u11dmf;t;;f;;f;;;f;;f;8700005;f;;f;t;;Dünkirchen;Dunkirk;;;;Duinkerke;Dunkerk;;;ダンケルク;됭케르크;Dunkierka;Dunquerque;Дюнкерк;;;敦刻尔克
 123;Lille-Flandres;lille-flandres;8728600;87286005;50.637486;3.071128;4652;f;FR;f;Europe/Paris;t;FRADJ;LLF;t;;f;8700030;f;;f;ADJ;f;;f;;;f;;f;;f;;f;t;;;;;;Lilla;Rijsel;;;;リール;릴;;;Лилль;;;里尔
 124;Haubourdin;haubourdin;8728609;87286096;50.6069682482955;2.990228533744812;;f;FR;f;Europe/Paris;t;FRADK;;t;;f;8701242;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-125;Tourcoing;tourcoing;8728654;87286542;50.716573;3.168176;5840;f;FR;t;Europe/Paris;t;FRADM;TRG;t;;f;8700121;f;;f;ADM;t;;f;;;f;;f;;f;;f;t;;;;;;;Toerkonje;;;;トゥールコワン;;;;Туркуэн;;;图尔宽
+125;Tourcoing;tourcoing;8728654;87286542;50.716573;3.168176;5840;f;FR;t;Europe/Paris;t;FRADM;TRG;t;;f;8700121;f;;f;ADM;t;;f;;;f;;f;8700221;f;;f;t;;;;;;;Toerkonje;;;;トゥールコワン;;;;Туркуэн;;;图尔宽
 126;Nomain;nomain;;;50.5000000000;3.2500000000;;t;FR;f;Europe/Paris;f;FRADN;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 127;Nomain-Ouvignies;nomain-ouvignies;8728681;87286815;50.506063;3.230831;126;f;FR;f;Europe/Paris;f;FRCKM;;t;;f;8701679;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 128;Nomain;nomain;8728660;87286609;50.502423;3.206362;126;f;FR;t;Europe/Paris;t;FRCKC;;t;;f;8701678;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 129;Croix;croix;;;;;;t;FR;f;Europe/Paris;f;FRADO;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-130;Croix—Wasquehal;croix-wasquehal;8728671;87286716;50.678521;3.137765;129;f;FR;t;Europe/Paris;t;FRCKH;CRW;t;;f;8700512;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+130;Croix—Wasquehal;croix-wasquehal;8728671;87286716;50.678521;3.137765;129;f;FR;t;Europe/Paris;t;FRCKH;CRW;t;;f;8700512;f;;f;;f;;f;;;f;;f;8700839;f;;f;t;;;;;;;;;;;;;;;;;;
 131;Croix-l’Allumette;croix-lallumette;8728105;87281055;50.687115;3.151564;129;f;FR;f;Europe/Paris;t;FRCID;;t;;f;8700511;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-132;Roubaix;roubaix;8728673;87286732;50.6957168696774;3.1631076335906982;;f;FR;f;Europe/Paris;t;FRADP;RXB;t;;f;8700236;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;Robaais;;;;ルーベ;루베;;;Рубе;;;鲁贝
+132;Roubaix;roubaix;8728673;87286732;50.6957168696774;3.1631076335906982;;f;FR;f;Europe/Paris;t;FRADP;RXB;t;;f;8700236;f;;f;;f;;f;;;f;;f;8700838;f;;f;t;;;;;;;Robaais;;;;ルーベ;루베;;;Рубе;;;鲁贝
 136;Jeumont;jeumont;;;50.3000000000;4.1000000000;;t;FR;f;Europe/Paris;f;FRADR;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-137;Jeumont;jeumont;8729501;87295014;50.296237;4.086271;136;f;FR;t;Europe/Paris;t;FRCMA;JTJ;t;;f;8700118;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+137;Jeumont;jeumont;8729501;87295014;50.296237;4.086271;136;f;FR;t;Europe/Paris;t;FRCMA;JTJ;t;;f;8700118;f;;f;;f;;f;;;f;;f;8700216;f;;f;f;;;;;;;;;;;;;;;;;;
 139;Bellegarde-sur-Valserine;bellegarde-sur-valserine;;;46.1078740000;5.8242130000;;t;FR;f;Europe/Paris;f;FRADS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-140;Bellegarde-sur-Valserine;bellegarde-sur-valserine;8774500;87745000;46.110913;5.825962;139;f;FR;t;Europe/Paris;t;FRXBF;BGD;t;XBF;t;8700068;f;;f;;f;8774500;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+140;Bellegarde-sur-Valserine;bellegarde-sur-valserine;8774500;87745000;46.110913;5.825962;139;f;FR;t;Europe/Paris;t;FRXBF;BGD;t;XBF;t;8700068;f;;f;;f;8774500;f;;;f;;f;8700083;f;;f;t;;;;;;;;;;;;;;;;;;
 141;Bellegarde-sur-Valserine Lycée Musinens;bellegarde-sur-valserine-lycee-musinens;8774272;87742726;46.115336;5.794132;139;f;FR;f;Europe/Paris;t;FRAFH;;t;;f;8702801;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-143;Briouze;briouze;8744808;87448084;48.70183766127341;-0.3682136535644531;;f;FR;f;Europe/Paris;t;FRADV;BZN;t;;f;8700216;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-148;Calais Ville;calais-ville;8731726;87317263;50.953402;1.850177;1417;f;FR;t;Europe/Paris;t;FRAEA;CSV;t;;f;8700386;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;Kales;;;;カレー;칼레;;;Кале;;;加来
-149;Boulogne-sur-Mer Ville;boulogne-sur-mer-ville;8731758;87317586;50.71549602881634;1.610097885131836;5758;f;FR;t;Europe/Paris;t;FRAEB;BEM;t;;f;8700450;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ブローニュ＝シュル＝メール;불로뉴쉬르메르;;Bolonha-sobre-o-Mar;Булонь-сюр-Мер;;;滨海布洛涅
+143;Briouze;briouze;8744808;87448084;48.70183766127341;-0.3682136535644531;;f;FR;f;Europe/Paris;t;FRADV;BZN;t;;f;8700216;f;;f;;f;;f;;;f;;f;8700752;f;;f;f;;;;;;;;;;;;;;;;;;
+148;Calais Ville;calais-ville;8731726;87317263;50.953402;1.850177;1417;f;FR;t;Europe/Paris;t;FRAEA;CSV;t;;f;8700386;f;;f;;f;;f;;;f;;f;8700107;f;;f;t;;;;;;;Kales;;;;カレー;칼레;;;Кале;;;加来
+149;Boulogne-sur-Mer Ville;boulogne-sur-mer-ville;8731758;87317586;50.71549602881634;1.610097885131836;5758;f;FR;t;Europe/Paris;t;FRAEB;BEM;t;;f;8700450;f;;f;;f;;f;;;f;;f;8700101;f;;f;t;;;;;;;;;;;ブローニュ＝シュル＝メール;불로뉴쉬르메르;;Bolonha-sobre-o-Mar;Булонь-сюр-Мер;;;滨海布洛涅
 150;Allenc;allenc;8778365;87783654;44.5333330000;3.6666670000;;f;FR;f;Europe/Paris;t;FRAEC;;t;;f;8702645;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-151;Pau;pau;8767200;87672006;43.29155258667031;-0.3697478771209717;5006;f;FR;t;Europe/Paris;t;FRAEE;PAU;t;;f;8700106;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ポー;;;;Пау;;;
+151;Pau;pau;8767200;87672006;43.29155258667031;-0.3697478771209717;5006;f;FR;t;Europe/Paris;t;FRAEE;PAU;t;;f;8700106;f;;f;;f;;f;;;f;;f;8700185;f;;f;t;;;;;;;;;;;ポー;;;;Пау;;;
 152;Hendaye;hendaye;8767700;87677005;43.3531128691334;-1.7820382118225098;5785;f;FR;t;Europe/Paris;t;FRAEF;HED;t;AEF;t;8700149;f;;f;;f;;f;;;f;;f;11602;t;;f;t;;;;Hendaya;;;;;;;アンダイエ;;;;Андай;;;昂代伊
 153;Strasbourg;strasbourg;8721202;87212027;48.585338;7.734067;5260;f;FR;t;Europe/Paris;f;FRAEG;STG;t;AEG;f;8700023;t;;f;;f;8721202;f;;;f;;f;;f;;f;t;;Straßburg;;Estrasburgo;;Strasburgo;Straatsburg;Štrasburk;;;ストラスブール;스트라스부르;Strasburg;Estrasburgo;Страсбург;;Strazburg;斯特拉斯堡
 154;Mertzwiller;mertzwiller;;;48.8666670000;7.6833330000;;t;FR;f;Europe/Paris;f;FRAEH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 155;Mertzwiller;mertzwiller;8721320;87213207;48.871609;7.677704;154;f;FR;t;Europe/Paris;t;FRBVY;;t;;f;8701652;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-157;Colmar;colmar;8718201;87182014;48.07254485668853;7.346677780151368;1349;f;FR;t;Europe/Paris;t;FRAEJ;CMR;t;;f;8700178;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;コルマール;콜마르;;;Кольмар;;;科尔马
-158;Mulhouse;mulhouse;8718206;87182063;47.741952;7.343045;4753;f;FR;t;Europe/Paris;t;FRAEK;MSE;t;AEK;f;8700031;t;;f;;f;8718206;f;;;f;;f;;f;;f;t;;Mülhausen;;;;;;Mylhúzy;;;ミュルーズ;뮐루즈;Miluza;;Мюлуз;;;米卢斯
+157;Colmar;colmar;8718201;87182014;48.07254485668853;7.346677780151368;1349;f;FR;t;Europe/Paris;t;FRAEJ;CMR;t;;f;8700178;f;;f;;f;;f;;;f;;f;8700444;f;;f;t;;;;;;;;;;;コルマール;콜마르;;;Кольмар;;;科尔马
+158;Mulhouse;mulhouse;8718206;87182063;47.741952;7.343045;4753;f;FR;t;Europe/Paris;t;FRAEK;MSE;t;AEK;f;8700031;t;;f;;f;8718206;f;;;f;;f;8700036;f;;f;t;;Mülhausen;;;;;;Mylhúzy;;;ミュルーズ;뮐루즈;Miluza;;Мюлуз;;;米卢斯
 159;St-Louis (Haut Rhin);st-louis-haut-rhin;;;47.5833330000;7.5666670000;;t;FR;f;Europe/Paris;f;FRAEL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 160;St-Louis La-Chaussée;st-louis-la-chaussee;8718101;87181016;47.609442;7.531252;159;f;FR;f;Europe/Paris;t;FRBIH;SLU;t;;f;8701987;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-161;St-Louis;st-louis;8718213;87182139;47.590178;7.555379;159;f;FR;t;Europe/Paris;t;FRXLI;STL;t;;f;8700133;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+161;St-Louis;st-louis;8718213;87182139;47.590178;7.555379;159;f;FR;t;Europe/Paris;t;FRXLI;STL;t;;f;8700133;f;;f;;f;;f;;;f;;f;8700259;f;;f;t;;;;;;;;;;;;;;;;;;
 162;Thann;thann;;;;;;t;FR;f;Europe/Paris;f;FRAEM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 163;Thann;thann;8718256;87182568;47.80912;7.107051;162;f;FR;t;Europe/Paris;t;FRBKM;;t;;f;8700546;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 164;Thann—St-Jacques;thann-st-jacques;8718288;87182881;47.813273;7.093558;162;f;FR;f;Europe/Paris;t;FRBLI;;t;;f;8702114;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -130,57 +130,57 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 166;Aspach-le-Haut;aspach-le-haut;;;47.6500000000;7.2333330000;;t;FR;f;Europe/Paris;f;FRAEQ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 167;Aspach-le-Haut;aspach-le-haut;8767414;87674143;47.769396;7.142379;166;f;FR;t;Europe/Paris;t;FRGII;;t;;f;8704940;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 168;Aspach-le-Bas;aspach-le-bas;8721537;87215376;47.759832;7.152375;166;f;FR;f;Europe/Paris;t;FRCAQ;;t;;f;8704939;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-171;Avignon Centre;avignon-centre;8776500;87765008;43.941668244510936;4.8052096366882315;489;f;FR;f;Europe/Paris;t;FRAES;AVI;t;AES;t;8700172;f;;f;;f;8776501;f;;;f;;f;;f;;f;t;;;;Aviñón;;Avignone;;;;;アヴィニョン;아비뇽;Awinion;Avinhão;Авиньон;;;亞維農
-172;Le Mans;le-mans;8739600;87396002;47.995364119768475;0.1921534538269043;4661;f;FR;t;Europe/Paris;t;FRAET;LEN;t;;f;8700435;f;;f;AET;t;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ル・マン;르망;;;Ле-Ман;;;勒芒
+171;Avignon Centre;avignon-centre;8776500;87765008;43.941668244510936;4.8052096366882315;489;f;FR;f;Europe/Paris;t;FRAES;AVI;t;AES;t;8700172;f;;f;;f;8776501;f;;;f;;f;8700402;f;;f;t;;;;Aviñón;;Avignone;;;;;アヴィニョン;아비뇽;Awinion;Avinhão;Авиньон;;;亞維農
+172;Le Mans;le-mans;8739600;87396002;47.995364119768475;0.1921534538269043;4661;f;FR;t;Europe/Paris;t;FRAET;LEN;t;;f;8700435;f;;f;AET;t;;f;;;f;;f;8700001;f;;f;t;;;;;;;;;;;ル・マン;르망;;;Ле-Ман;;;勒芒
 173;Joué-lès-Tours Berthelot;joue-les-tours-berthelot;8711028;87110288;47.3500000000;0.6666670000;4580;f;FR;f;Europe/Paris;t;FRAEV;;t;;f;8703510;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 174;Eu;eu;;;50.0500000000;1.4166670000;;t;FR;f;Europe/Paris;f;FRAEX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 175;Eu-la-Mouillette;eu-la-mouillette;8731676;87316760;50.04890671485088;1.4253687858581543;174;f;FR;f;Europe/Paris;f;FRCVR;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-176;Eu;eu;8731753;87317537;50.054355;1.416771;174;f;FR;t;Europe/Paris;t;FREUX;;t;;f;8701093;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+176;Eu;eu;8731753;87317537;50.054355;1.416771;174;f;FR;t;Europe/Paris;t;FREUX;;t;;f;8701093;f;;f;;f;;f;;;f;;f;8700888;f;;f;f;;;;;;;;;;;;;;;;;;
 177;Alleyras;alleyras;8773188;87731885;44.90590260319495;3.6822491884231567;;f;FR;f;Europe/Paris;t;FRAEY;;t;;f;8704935;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-178;Le Havre;le-havre;8741301;87413013;49.492800002017034;0.12557029724121094;4630;f;FR;t;Europe/Paris;t;FRAEZ;LHA;t;;f;8700112;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;El Havre;;;;;;;ル・アーヴル;르아브르;Hawr;;Гавр;;;勒阿弗尔
+178;Le Havre;le-havre;8741301;87413013;49.492800002017034;0.12557029724121094;4630;f;FR;t;Europe/Paris;t;FRAEZ;LHA;t;;f;8700112;f;;f;;f;;f;;;f;;f;8700201;f;;f;t;;;;El Havre;;;;;;;ル・アーヴル;르아브르;Hawr;;Гавр;;;勒阿弗尔
 179;Harfleur;harfleur;;;49.5065960000;0.1982690000;;t;FR;f;Europe/Paris;f;FRAFA;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 180;Harfleur-Halte;harfleur-halte;8741370;87413708;49.505896;0.192081;179;f;FR;f;Europe/Paris;t;FRDOR;;t;;f;8703460;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-181;Harfleur;harfleur;8741330;87413302;49.513717;0.198976;179;f;FR;t;Europe/Paris;t;FRDOE;;t;;f;8703459;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+181;Harfleur;harfleur;8741330;87413302;49.513717;0.198976;179;f;FR;t;Europe/Paris;t;FRDOE;;t;;f;8703459;f;;f;;f;;f;;;f;;f;8700607;f;;f;f;;;;;;;;;;;;;;;;;;
 182;Montivilliers;montivilliers;;;49.5500000000;0.2000000000;;t;FR;f;Europe/Paris;f;FRAFB;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 184;Montivilliers;montivilliers;8741372;87413724;49.54313;0.189393;182;f;FR;t;Europe/Paris;t;FRDOT;;t;;f;8704042;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-186;Dieppe;dieppe;8741501;87415018;49.92147796871573;1.0811233520507812;1926;f;FR;t;Europe/Paris;t;FRAFD;DEV;t;;f;8700085;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Дьеп;;;
-187;Fontainebleau—Avon;fontainebleau-avon;8768221;;48.41621372071815;2.7264118194580074;;f;FR;f;Europe/Paris;t;FRAFE;;t;;f;8700535;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+186;Dieppe;dieppe;8741501;87415018;49.92147796871573;1.0811233520507812;1926;f;FR;t;Europe/Paris;t;FRAFD;DEV;t;;f;8700085;f;;f;;f;;f;;;f;;f;8700104;f;;f;f;;;;;;;;;;;;;;;Дьеп;;;
+187;Fontainebleau—Avon;fontainebleau-avon;8768221;;48.41621372071815;2.7264118194580074;;f;FR;f;Europe/Paris;t;FRAFE;;t;;f;8700535;f;;f;;f;;f;;;f;;f;8700254;f;;f;t;;;;;;;;;;;;;;;;;;
 188;Péronne;peronne;;;50.0000000000;2.6500000000;;t;FR;f;Europe/Paris;f;FRAFI;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 189;Péronne Centre;peronne-centre;8731341;87313411;49.934997;2.938987;188;f;FR;t;Europe/Paris;t;FRCRJ;;t;;f;8701752;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 190;Péronne La Chapelette;peronne-la-chapelette;8731386;87313866;49.924488;2.933359;188;f;FR;f;Europe/Paris;t;FRCSU;;t;;f;8701770;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-191;Albi Ville;albi-ville;8761500;87615005;43.922472;2.13785;4604;f;FR;t;Europe/Paris;t;FRAFJ;ALB;t;;f;8704917;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;Albé;;Albé;Albé;;;;アルビ;알비;Albé;Albé;Альбе;;;阿尔比
+191;Albi Ville;albi-ville;8761500;87615005;43.922472;2.13785;4604;f;FR;t;Europe/Paris;t;FRAFJ;ALB;t;;f;8704917;f;;f;;f;;f;;;f;;f;8700205;f;;f;t;;;;Albé;;Albé;Albé;;;;アルビ;알비;Albé;Albé;Альбе;;;阿尔比
 192;Orléans;orleans;8754300;87543009;47.90807935070001;1.9047331809997559;4894;f;FR;t;Europe/Paris;f;FRAFK;ORL;t;;f;8700404;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;オルレアン;오를레앙;Orlean;Orleães;Орлеан;;;奥尔良
 194;Vendôme;vendome;8757455;87574558;47.802198;1.067837;5846;f;FR;f;Europe/Paris;t;FRAFM;;t;;f;8702203;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-195;Fréjus;frejus;8775750;87757500;43.43200708149751;6.7329078912734985;4583;f;FR;t;Europe/Paris;t;FRAFN;FRJ;t;;f;8700472;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;フレジュス;;;;Фрежюс;;;弗雷瑞斯
+195;Fréjus;frejus;8775750;87757500;43.43200708149751;6.7329078912734985;4583;f;FR;t;Europe/Paris;t;FRAFN;FRJ;t;;f;8700472;f;;f;;f;;f;;;f;;f;8700301;f;;f;f;;;;;;;;;;;フレジュス;;;;Фрежюс;;;弗雷瑞斯
 196;Fontenay-le-Comte;fontenay-le-comte;8748561;87485615;46.46785957735252;-0.809592604637146;2776;f;FR;t;Europe/Paris;t;FRAFQ;;t;;f;8702433;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 197;Acheux-Franleu;acheux-franleu;8731674;87316745;50.082689;1.65761;;f;FR;f;Europe/Paris;t;FRAFR;;t;;f;8700573;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 198;St-Hilaire-de-Riez;st-hilaire-de-riez;;;;;;t;FR;f;Europe/Paris;f;FRAFS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-199;St-Hilaire-de-Riez;st-hilaire-de-riez;8748656;87486563;46.716669;-1.949679;198;f;FR;t;Europe/Paris;t;FREKO;;t;;f;8704586;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+199;St-Hilaire-de-Riez;st-hilaire-de-riez;8748656;87486563;46.716669;-1.949679;198;f;FR;t;Europe/Paris;t;FREKO;;t;;f;8704586;f;;f;;f;;f;;;f;;f;8700786;f;;f;f;;;;;;;;;;;;;;;;;;
 200;St-Hilaire-de-Riez Centre;st-hilaire-de-riez-centre;8738992;87389924;46.718728;-1.944618;198;f;FR;f;Europe/Paris;t;FRDHN;;t;;f;8704585;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-201;La Clayette—Baudemont;la-clayette-baudemont;8769473;87694737;46.28815158366065;4.29840624332428;;f;FR;f;Europe/Paris;t;FRAFT;;t;;f;8703559;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-203;Tours;tours;8757100;87571000;47.389458;0.693787;5338;f;FR;t;Europe/Paris;t;FRAFW;TRS;t;;f;8700161;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;トゥール;투르;;;Тур;;;图尔
-204;Cambrai;cambrai;8734552;87345520;50.17667825093541;3.2413101196289062;;f;FR;f;Europe/Paris;t;FRAFX;CAM;t;;f;8700842;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;カンブレー;;;;Камбре;;;康布雷
-205;Aiguebelle;aiguebelle;8774125;87741256;45.5333330000;6.3000000000;;f;FR;f;Europe/Paris;t;FRAGB;AEB;t;;f;8702385;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-207;Agen;agen;8758600;87586008;44.20834216628424;0.620952844619751;17433;f;FR;f;Europe/Paris;t;FRAGF;AGN;t;AGF;t;8700062;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アジャン;아쟁;;;Ажен;;;阿让
+201;La Clayette—Baudemont;la-clayette-baudemont;8769473;87694737;46.28815158366065;4.29840624332428;;f;FR;f;Europe/Paris;t;FRAFT;;t;;f;8703559;f;;f;;f;;f;;;f;;f;8700435;f;;f;f;;;;;;;;;;;;;;;;;;
+203;Tours;tours;8757100;87571000;47.389458;0.693787;5338;f;FR;t;Europe/Paris;t;FRAFW;TRS;t;;f;8700161;f;;f;;f;;f;;;f;;f;8700347;f;;f;t;;;;;;;;;;;トゥール;투르;;;Тур;;;图尔
+204;Cambrai;cambrai;8734552;87345520;50.17667825093541;3.2413101196289062;;f;FR;f;Europe/Paris;t;FRAFX;CAM;t;;f;8700842;f;;f;;f;;f;;;f;;f;8700871;f;;f;t;;;;;;;;;;;カンブレー;;;;Камбре;;;康布雷
+205;Aiguebelle;aiguebelle;8774125;87741256;45.5333330000;6.3000000000;;f;FR;f;Europe/Paris;t;FRAGB;AEB;t;;f;8702385;f;;f;;f;;f;;;f;;f;8700472;f;;f;f;;;;;;;;;;;;;;;;;;
+207;Agen;agen;8758600;87586008;44.20834216628424;0.620952844619751;17433;f;FR;f;Europe/Paris;t;FRAGF;AGN;t;AGF;t;8700062;f;;f;;f;;f;;;f;;f;8700074;f;;f;t;;;;;;;;;;;アジャン;아쟁;;;Ажен;;;阿让
 208;Ervy-le-Châtel Halles;ervy-le-chatel-halles;8711034;87110346;48.0333330000;3.9166670000;5684;f;FR;f;Europe/Paris;t;FRAGJ;;t;;f;8701075;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 209;Fays-la-Chapelle;fays-la-chapelle;8711037;87110379;48.1333330000;4.0166670000;;f;FR;f;Europe/Paris;t;FRAGK;;t;;f;8701170;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 210;Agonac;agonac;8759515;87595157;45.2833330000;0.7500000000;;f;FR;f;Europe/Paris;t;FRAGO;;t;;f;8702621;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;阿戈纳克
-211;Limoges Bénédictins;limoges-benedictins;8759200;87592006;45.836419;1.267245;4651;f;FR;t;Europe/Paris;t;FRAGQ;LIM;t;;f;8700029;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;リモージュ;리모주;;;Лимож;;;利摩日
-212;Modane;modane;8774200;87742007;45.193500116356404;6.659023761749268;;f;FR;f;Europe/Paris;t;FRAGR;MOD;t;;f;8700127;f;;f;;f;8774200;f;S00201;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+211;Limoges Bénédictins;limoges-benedictins;8759200;87592006;45.836419;1.267245;4651;f;FR;t;Europe/Paris;t;FRAGQ;LIM;t;;f;8700029;f;;f;;f;;f;;;f;;f;87034;f;;f;t;;;;;;;;;;;リモージュ;리모주;;;Лимож;;;利摩日
+212;Modane;modane;8774200;87742007;45.193500116356404;6.659023761749268;;f;FR;f;Europe/Paris;t;FRAGR;MOD;t;;f;8700127;f;;f;;f;8774200;f;S00201;;f;;f;8700242;f;;f;f;;;;;;;;;;;;;;;;;;
 213;Agos;agos;8762007;87620070;43.0333330000;-0.0666670000;;f;FR;f;Europe/Paris;t;FRAGS;;t;;f;8702622;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 214;Argenton-sur-Creuse;argenton-sur-creuse;;;46.5833330000;1.5166670000;;t;FR;f;Europe/Paris;f;FRAGT;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-215;Argenton-sur-Creuse;argenton-sur-creuse;8759712;87597120;46.592394;1.518628;214;f;FR;t;Europe/Paris;t;FRFMT;AGC;t;;f;8702299;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Аржантон-сюр-Крёз;;;克勒斯河畔阿尔让通
+215;Argenton-sur-Creuse;argenton-sur-creuse;8759712;87597120;46.592394;1.518628;214;f;FR;t;Europe/Paris;t;FRFMT;AGC;t;;f;8702299;f;;f;;f;;f;;;f;;f;8700499;f;;f;f;;;;;;;;;;;;;;;Аржантон-сюр-Крёз;;;克勒斯河畔阿尔让通
 216;Argenton-sur-Creuse Gare Routière;argenton-sur-creuse-gare-routiere;8720156;87201566;46.587009;1.503158;214;f;FR;f;Europe/Paris;f;FRNCR;;t;;f;8705087;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 217;Roye;roye;8731350;87313502;49.69805004945369;2.7897226810455322;17478;f;FR;t;Europe/Paris;t;FRAGU;;t;;f;8701860;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 218;Agay;agay;8775755;87757559;43.431382;6.856513;;f;FR;f;Europe/Paris;t;FRAGY;;t;;f;8700588;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 220;Versailles;versailles;9903008;;;;;t;FR;f;Europe/Paris;f;FRAHB;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-223;Versailles-Chantiers;versailles-chantiers;8739300;87393009;48.795542444758766;2.1359503269195557;220;f;FR;t;Europe/Paris;t;FRDHT;VCR;t;;f;8700079;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+223;Versailles-Chantiers;versailles-chantiers;8739300;87393009;48.795542444758766;2.1359503269195557;220;f;FR;t;Europe/Paris;t;FRDHT;VCR;t;;f;8700079;f;;f;;f;;f;;;f;;f;8700094;f;;f;t;;;;;;;;;;;;;;;;;;
 224;Villeneuve-au-Chemin;villeneuve-au-chemin;8711036;87110361;48.082895;3.844281;;f;FR;f;Europe/Paris;t;FRAHC;;t;;f;8702200;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 230;Salvagnac;salvagnac;8711015;87110155;43.9166670000;1.7000000000;;f;FR;f;Europe/Paris;t;FRAHY;;t;;f;8704441;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 232;Maussac;maussac;8715241;;45.4833330000;2.1500000000;;f;FR;f;Europe/Paris;t;FRAIC;;t;;f;8703951;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-233;Aix-en-Provence TGV;aix-en-provence-tgv;8731901;87319012;43.455167;5.317227;23614;f;FR;f;Europe/Paris;t;FRAIE;AXV;t;AIE;t;8704980;t;;f;AIE;t;8731901;f;;;f;;f;;f;;f;t;;;;;;;;;;;エクス＝アン＝プロヴァンス;엑상프로방스;;;Экс-ан-Прованс;;;普罗旺斯地区艾克斯
+233;Aix-en-Provence TGV;aix-en-provence-tgv;8731901;87319012;43.455167;5.317227;23614;f;FR;f;Europe/Paris;t;FRAIE;AXV;t;AIE;t;8704980;t;;f;AIE;t;8731901;f;;;f;;f;8700912;f;;f;t;;;;;;;;;;;エクス＝アン＝プロヴァンス;엑상프로방스;;;Экс-ан-Прованс;;;普罗旺斯地区艾克斯
 234;Moustéru;mousteru;8747351;87473512;48.5166670000;-3.2333330000;;f;FR;f;Europe/Paris;t;FRAIG;;t;;f;8704068;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-239;Aillevillers;aillevillers;8718562;87185629;47.9166670000;6.3333330000;;f;FR;f;Europe/Paris;t;FRAIL;;t;;f;8700256;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+239;Aillevillers;aillevillers;8718562;87185629;47.9166670000;6.3333330000;;f;FR;f;Europe/Paris;t;FRAIL;;t;;f;8700256;f;;f;;f;;f;;;f;;f;8700899;f;;f;f;;;;;;;;;;;;;;;;;;
 241;Ailly-sur-Noye;ailly-sur-noye;8731322;87313221;49.7500000000;2.3666670000;;f;FR;f;Europe/Paris;t;FRAIN;;t;;f;8700605;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 246;Ailly-sur-Somme;ailly-sur-somme;8731309;87313098;49.9166670000;2.2000000000;;f;FR;f;Europe/Paris;t;FRAIS;AYS;t;;f;8700634;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 249;Aigues-Vives (Gard);aigues-vives-gard;8777512;;43.7333330000;4.1666670000;;f;FR;f;Europe/Paris;t;FRAIV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -191,17 +191,17 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 267;Azay-sur-Indre;azay-sur-indre;8711533;87115337;47.2000000000;0.9500000000;;f;FR;f;Europe/Paris;t;FRAJY;;t;;f;8702750;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 286;Mouroux;mouroux;8711628;;48.8166670000;3.0333330000;;f;FR;f;Europe/Paris;t;FRAKV;;t;;f;8704067;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 292;Alet-les-Bains;alet-les-bains;8761518;87615187;43.0000000000;2.2666670000;;f;FR;f;Europe/Paris;t;FRALB;;t;;f;8702640;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-293;Allassac;allassac;8759423;87594234;45.2500000000;1.4833330000;;f;FR;f;Europe/Paris;t;FRALC;AAA;t;;f;8700598;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+293;Allassac;allassac;8759423;87594234;45.2500000000;1.4833330000;;f;FR;f;Europe/Paris;t;FRALC;AAA;t;;f;8700598;f;;f;;f;;f;;;f;;f;8700513;f;;f;f;;;;;;;;;;;;;;;;;;
 295;Albens;albens;8774611;87746115;45.7833330000;5.9500000000;;f;FR;f;Europe/Paris;t;FRALE;ABN;t;;f;8702637;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 302;Pierre-Buffière Ville;pierre-buffiere-ville;8740899;87408997;45.7000000000;1.3500000000;5349;f;FR;f;Europe/Paris;t;FRALL;;t;;f;8704217;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 303;Aix La Marsalouse;aix-la-marsalouse;8759429;;45.614206266734726;2.3984473943710327;;f;FR;f;Europe/Paris;t;FRALM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-304;La Ferté-sous-Jouarre;la-ferte-sous-jouarre;8711651;;48.950915549215985;3.1255245208740234;;f;FR;f;Europe/Paris;f;FRALN;;t;;f;8701378;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+304;La Ferté-sous-Jouarre;la-ferte-sous-jouarre;8711651;;48.950915549215985;3.1255245208740234;;f;FR;f;Europe/Paris;f;FRALN;;t;;f;8701378;f;;f;;f;;f;;;f;;f;8700958;f;;f;f;;;;;;;;;;;;;;;;;;
 311;Merten;merten;8719321;87193219;49.2500000000;6.6666670000;;f;FR;f;Europe/Paris;t;FRALV;;t;;f;8701579;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 313;La Ferté-Milon;la-ferte-milon;8711667;;49.1666670000;3.1166670000;;f;FR;f;Europe/Paris;t;FRALX;;t;;f;8701379;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 314;Neuilly-St-Front;neuilly-st-front;8711668;87116681;49.1666670000;3.2666670000;;f;FR;f;Europe/Paris;t;FRALY;;t;;f;8701686;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 315;Oulchy-Breny;oulchy-breny;8711669;87116699;49.186806;3.347555;;f;FR;f;Europe/Paris;t;FRALZ;;t;;f;8701712;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-316;Albi Madeleine;albi-madeleine;8761519;87615195;43.938005;2.14096;4604;f;FR;f;Europe/Paris;t;FRAMA;ALM;t;;f;8702638;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-317;Ambérieu;amberieu;8774371;87743716;45.953954370107795;5.342316627502441;;f;FR;f;Europe/Paris;t;FRAMB;AMB;t;;f;8700045;f;;f;;f;8774371;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+316;Albi Madeleine;albi-madeleine;8761519;87615195;43.938005;2.14096;4604;f;FR;f;Europe/Paris;t;FRAMA;ALM;t;;f;8702638;f;;f;;f;;f;;;f;;f;8700200;f;;f;f;;;;;;;;;;;;;;;;;;
+317;Ambérieu;amberieu;8774371;87743716;45.953954370107795;5.342316627502441;;f;FR;f;Europe/Paris;t;FRAMB;AMB;t;;f;8700045;f;;f;;f;8774371;f;;;f;;f;8700055;f;;f;f;;;;;;;;;;;;;;;;;;
 322;Auxon Église;auxon-eglise;8711711;87117119;48.092235;3.923863;9587;f;FR;t;Europe/Paris;t;FRAMH;;t;;f;8702734;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 323;Rehainviller;rehainviller;8711713;87117135;48.5666670000;6.4666670000;;f;FR;f;Europe/Paris;t;FRAMI;;t;;f;8701870;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 324;St-Pierremont;st-pierremont;8711714;87117143;48.4333330000;6.5833330000;;f;FR;f;Europe/Paris;t;FRAMJ;;t;;f;8702025;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -218,11 +218,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 340;Pisseloup;pisseloup;8711732;87117325;47.8333330000;5.7333330000;;f;FR;f;Europe/Paris;t;FRANA;;t;;f;8704225;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 341;Bétoncourt-sur-Mance;betoncourt-sur-mance;8711733;87117333;47.830622;5.759083;;f;FR;f;Europe/Paris;t;FRANB;;t;;f;8702827;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 342;Vernois-sur-Mance;vernois-sur-mance;8711734;87117341;47.851944;5.794042;;f;FR;f;Europe/Paris;t;FRANC;;t;;f;8702217;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-343;Andelot;andelot;8771510;87715102;46.8594671;5.923584;;f;FR;f;Europe/Paris;t;FRAND;;t;;f;8700155;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+343;Andelot;andelot;8771510;87715102;46.8594671;5.923584;;f;FR;f;Europe/Paris;t;FRAND;;t;;f;8700155;f;;f;;f;;f;;;f;;f;8700322;f;;f;f;;;;;;;;;;;;;;;;;;
 344;Angers;angers;;;47.4666670000;-0.5500000000;;t;FR;f;Europe/Paris;t;FRANE;;t;;f;;f;gbrw53;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 345;Angers Maître École;angers-maitre-ecole;8748404;87484048;47.467089;-0.531891;344;f;FR;f;Europe/Paris;t;FREHA;;t;;f;8700610;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 346;Blondefontaine;blondefontaine;8711736;87117366;47.8833330000;5.8666670000;;f;FR;f;Europe/Paris;t;FRANF;;t;;f;8700692;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-347;Angoulême;angouleme;8758300;87583005;45.653603206036394;0.16449451446533203;;f;FR;f;Europe/Paris;t;FRANG;ANG;t;ANG;f;8700063;f;u005eq;t;;f;;f;;;f;;f;;f;;f;t;;;;Angulema;;;;;;;アングレーム;앙굴렘;;;Ангулем;;;昂古莱姆
+347;Angoulême;angouleme;8758300;87583005;45.653603206036394;0.16449451446533203;;f;FR;f;Europe/Paris;t;FRANG;ANG;t;ANG;f;8700063;f;u005eq;t;;f;;f;;;f;;f;8700076;f;;f;t;;;;Angulema;;;;;;;アングレーム;앙굴렘;;;Ангулем;;;昂古莱姆
 348;Raincourt;raincourt;8711737;87117374;47.859879227409714;5.885946750640868;;f;FR;f;Europe/Paris;t;FRANH;;t;;f;8701836;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 349;Gévigney;gevigney;8711738;87117382;47.8000000000;5.9333330000;;f;FR;f;Europe/Paris;t;FRANI;;t;;f;8701227;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 350;Baulay;baulay;8711739;87117390;47.7833330000;6.0166670000;;f;FR;f;Europe/Paris;t;FRANJ;;t;;f;8700667;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -244,7 +244,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 372;Hertzing;hertzing;8711768;87117689;48.6833330000;6.9500000000;;f;FR;f;Europe/Paris;t;FRAOH;;t;;f;8701287;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 373;Bébing;bebing;8711769;87117697;48.7000000000;7.0000000000;;f;FR;f;Europe/Paris;t;FRAOI;;t;;f;8700669;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 376;Drouilly;drouilly;8711778;87117788;48.7666670000;4.5166670000;;f;FR;f;Europe/Paris;t;FRAOM;;t;;f;8701051;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-377;Aiguillon;aiguillon;8758669;87586693;44.29837546640074;0.3352653980255127;;f;FR;f;Europe/Paris;t;FRAON;;t;;f;8702627;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+377;Aiguillon;aiguillon;8758669;87586693;44.29837546640074;0.3352653980255127;;f;FR;f;Europe/Paris;t;FRAON;;t;;f;8702627;f;;f;;f;;f;;;f;;f;8700698;f;;f;f;;;;;;;;;;;;;;;;;;
 378;St-Martin-aux-Champs;st-martin-aux-champs;8711779;87117796;48.8166670000;4.4833330000;;f;FR;f;Europe/Paris;t;FRAOO;;t;;f;8701998;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 379;Bouilly;bouilly;8711790;;48.2000000000;4.0000000000;;f;FR;f;Europe/Paris;t;FRAOP;;t;;f;8700727;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 380;Chamoy;chamoy;8711791;87117911;48.1166670000;3.9666670000;;f;FR;f;Europe/Paris;t;FRAOQ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -263,12 +263,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 393;Vallant-St-Georges;vallant-st-georges;8711811;87118117;48.466168;3.899331;;f;FR;f;Europe/Paris;t;FRAPE;;t;;f;8702226;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 394;Châtres;chatres;8711813;87118133;48.5000000000;3.8500000000;;f;FR;f;Europe/Paris;t;FRAPG;;t;;f;8700875;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 395;Maizières-La Grande-Paroisse;maizieres-la-grande-paroisse;8711814;87118141;48.5166670000;3.7833330000;;f;FR;f;Europe/Paris;t;FRAPH;;t;;f;8701483;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-396;Romilly-sur-Seine;romilly-sur-seine;8711815;87118158;48.5142874748866;3.72887134552002;5092;f;FR;t;Europe/Paris;t;FRAPI;RMY;t;;f;8700274;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+396;Romilly-sur-Seine;romilly-sur-seine;8711815;87118158;48.5142874748866;3.72887134552002;5092;f;FR;t;Europe/Paris;t;FRAPI;RMY;t;;f;8700274;f;;f;;f;;f;;;f;;f;8700943;f;;f;t;;;;;;;;;;;;;;;;;;
 399;Marnay-sur-Seine;marnay-sur-seine;8711818;87118182;48.5166670000;3.5500000000;;f;FR;f;Europe/Paris;t;FRAPL;;t;;f;8701604;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-400;Nogent-sur-Seine;nogent-sur-seine;8711819;87118190;48.497945530121164;3.4938132762908936;4864;f;FR;t;Europe/Paris;t;FRAPM;NOG;t;;f;8701691;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+400;Nogent-sur-Seine;nogent-sur-seine;8711819;87118190;48.497945530121164;3.4938132762908936;4864;f;FR;t;Europe/Paris;t;FRAPM;NOG;t;;f;8701691;f;;f;;f;;f;;;f;;f;8700944;f;;f;f;;;;;;;;;;;;;;;;;;
 401;Aigueperse;aigueperse;8773412;87734129;46.0166670000;3.2000000000;;f;FR;f;Europe/Paris;t;FRAPS;;t;;f;8702625;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Егепер;;;
-402;Vendeuvre;vendeuvre;8711825;87118257;48.240296;4.467782;5625;f;FR;t;Europe/Paris;t;FRAPU;;t;;f;8702199;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-403;Bar-sur-Aube;bar-sur-aube;8711829;87118299;48.23863729674553;4.706697463989258;5132;f;FR;t;Europe/Paris;t;FRAPX;;t;;f;8700506;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;バール＝シュル＝オーブ;;;;Бар-сюр-Об;;;奥布河畔巴尔
+402;Vendeuvre;vendeuvre;8711825;87118257;48.240296;4.467782;5625;f;FR;t;Europe/Paris;t;FRAPU;;t;;f;8702199;f;;f;;f;;f;;;f;;f;8700941;f;;f;f;;;;;;;;;;;;;;;;;;
+403;Bar-sur-Aube;bar-sur-aube;8711829;87118299;48.23863729674553;4.706697463989258;5132;f;FR;t;Europe/Paris;t;FRAPX;;t;;f;8700506;f;;f;;f;;f;;;f;;f;8700939;f;;f;f;;;;;;;;;;;バール＝シュル＝オーブ;;;;Бар-сюр-Об;;;奥布河畔巴尔
 404;St-Florentin Hôtel de Ville;st-florentin-hotel-de-ville;8711861;87118612;48.0000000000;3.7333330000;5193;f;FR;f;Europe/Paris;f;FRAQV;;t;;f;8704562;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 405;Laroche-Migennes Hôtel Terminus;laroche-migennes-hotel-terminus;8711862;;;;9150;f;FR;f;Europe/Paris;f;FRAQW;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 406;Foug;foug;8714103;87141036;48.6833330000;5.7833330000;;f;FR;f;Europe/Paris;t;FRARB;;t;;f;8701128;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -278,17 +278,17 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 410;Laneuveville-devant-Nancy;laneuveville-devant-nancy;8714109;87141093;48.6500000000;6.2333330000;;f;FR;f;Europe/Paris;t;FRARF;LNV;t;;f;8701469;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 411;Argèles-Gazost;argeles-gazost;8767174;87671743;43.1000000000;-0.0500000000;;f;FR;f;Europe/Paris;t;FRARG;;t;;f;8702681;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 412;Arches;arches;8714441;87144410;48.1166670000;6.5333330000;;f;FR;f;Europe/Paris;t;FRARH;ARH;t;;f;8700581;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-413;Varangéville—St-Nicolas;varangeville-st-nicolas;8714110;87141101;48.635309;6.313232;;f;FR;f;Europe/Paris;t;FRARI;VRA;t;;f;8702174;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-414;Dombasle-sur-Meurthe;dombasle-sur-meurthe;8714111;87141119;48.623335525763665;6.34335458278656;;f;FR;f;Europe/Paris;t;FRARJ;DBS;t;;f;8701003;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+413;Varangéville—St-Nicolas;varangeville-st-nicolas;8714110;87141101;48.635309;6.313232;;f;FR;f;Europe/Paris;t;FRARI;VRA;t;;f;8702174;f;;f;;f;;f;;;f;;f;8700938;f;;f;f;;;;;;;;;;;;;;;;;;
+414;Dombasle-sur-Meurthe;dombasle-sur-meurthe;8714111;87141119;48.623335525763665;6.34335458278656;;f;FR;f;Europe/Paris;t;FRARJ;DBS;t;;f;8701003;f;;f;;f;;f;;;f;;f;8700162;f;;f;f;;;;;;;;;;;;;;;;;;
 415;Rosières-aux-Salines;rosieres-aux-salines;8714112;87141127;48.60533325613824;6.350526809692383;;f;FR;f;Europe/Paris;t;FRARK;ROI;t;;f;8701838;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-416;Argelès-sur-Mer;argeles-sur-mer;8778423;87784231;42.543778;3.022101;;f;FR;f;Europe/Paris;t;FRARM;AMR;t;;f;8700487;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+416;Argelès-sur-Mer;argeles-sur-mer;8778423;87784231;42.543778;3.022101;;f;FR;f;Europe/Paris;t;FRARM;AMR;t;;f;8700487;f;;f;;f;;f;;;f;;f;8700448;f;;f;f;;;;;;;;;;;;;;;;;;
 417;Marainviller;marainviller;8714116;87141168;48.5833330000;6.6000000000;;f;FR;f;Europe/Paris;t;FRARN;;t;;f;8701626;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 419;Embermenil;embermenil;8714118;87141184;48.6333330000;6.7000000000;;f;FR;f;Europe/Paris;t;FRARP;;t;;f;8701052;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 421;Einvaux;einvaux;8714120;87141200;48.4833330000;6.4000000000;;f;FR;f;Europe/Paris;t;FRARR;;t;;f;8701098;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 422;Bayon;bayon;8714121;87141218;48.46809847085216;6.3231682777404785;;f;FR;f;Europe/Paris;t;FRARS;BYN;t;;f;8700755;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-423;Argentan;argentan;8744453;87444539;48.73848156910216;-0.02537906169891357;;f;FR;f;Europe/Paris;t;FRART;ARG;t;;f;8700215;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;アルジャンタン;;;;Аржантан;;;阿尔让唐
+423;Argentan;argentan;8744453;87444539;48.73848156910216;-0.02537906169891357;;f;FR;f;Europe/Paris;t;FRART;ARG;t;;f;8700215;f;;f;;f;;f;;;f;;f;8700751;f;;f;f;;;;;;;;;;;アルジャンタン;;;;Аржантан;;;阿尔让唐
 424;Xermamenil—Lamath;xermamenil-lamath;8714122;87141226;48.534981;6.457553;;f;FR;f;Europe/Paris;t;FRARU;;t;;f;8702287;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-425;Arvant;arvant;8773425;87734251;45.365439879366356;3.3104681968688965;;f;FR;f;Europe/Paris;t;FRARV;ARV;t;;f;8700089;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+425;Arvant;arvant;8773425;87734251;45.365439879366356;3.3104681968688965;;f;FR;f;Europe/Paris;t;FRARV;ARV;t;;f;8700089;f;;f;;f;;f;;;f;;f;8700117;f;;f;f;;;;;;;;;;;;;;;;;;
 426;Gerbeviller;gerbeviller;8714123;87141234;48.5000000000;6.5166670000;;f;FR;f;Europe/Paris;t;FRARW;;t;;f;8701226;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 427;Moyen;moyen;8714124;87141242;48.4833330000;6.5666670000;;f;FR;f;Europe/Paris;t;FRARX;;t;;f;8701504;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 428;Soulosse;soulosse;8714125;87141259;48.40923;5.739127;;f;FR;f;Europe/Paris;t;FRARY;;t;;f;8701993;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -296,7 +296,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 430;Ascq;ascq;8728686;87286864;50.6166870000;3.1666370000;;f;FR;f;Europe/Paris;t;FRASC;;t;;f;8700509;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 432;Coussey;coussey;8714134;;48.4166670000;5.6833330000;;f;FR;f;Europe/Paris;t;FRASE;;t;;f;8700966;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 433;Domremy-la-Pucelle;domremy-la-pucelle;8714136;;48.4500000000;5.6833330000;;f;FR;f;Europe/Paris;t;FRASF;;t;;f;8701041;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-434;Auxerre-St-Gervais;auxerre-st-gervais;8768357;87683573;47.797618310856116;3.5852980613708496;26819;f;FR;f;Europe/Paris;t;FRASG;AUX;t;;f;8702732;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+434;Auxerre-St-Gervais;auxerre-st-gervais;8768357;87683573;47.797618310856116;3.5852980613708496;26819;f;FR;f;Europe/Paris;t;FRASG;AUX;t;;f;8702732;f;;f;;f;;f;;;f;;f;8700397;f;;f;f;;;;;;;;;;;;;;;;;;
 435;Aspres-sur-Buëch;aspres-sur-buech;8776325;87763250;44.51943627948484;5.75459361076355;;f;FR;f;Europe/Paris;t;FRASH;;t;;f;8702471;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 436;St-Clément-Laronxe;st-clement-laronxe;8714137;87141374;48.531169;6.608428;;f;FR;f;Europe/Paris;t;FRASI;SCX;t;;f;8701935;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 437;Chenevières;chenevieres;8714138;87141382;48.51949673914582;6.632566452026367;;f;FR;f;Europe/Paris;t;FRASJ;;t;;f;8700851;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -330,22 +330,22 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 466;Marbache;marbache;8714179;87141796;48.8000000000;6.0833330000;;f;FR;f;Europe/Paris;t;FRATT;;t;;f;8701580;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 467;Belleville;belleville;8714180;87141804;48.8166670000;6.1000000000;;f;FR;f;Europe/Paris;t;FRATU;;t;;f;8700330;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 468;Dieulouard;dieulouard;8714181;87141812;48.84364264812584;6.071577072143555;;f;FR;f;Europe/Paris;t;FRATV;;t;;f;8700340;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-469;Pont-à-Mousson;pont-a-mousson;8714182;87141820;48.90021020338177;6.05069875717163;;f;FR;f;Europe/Paris;t;FRATW;PAM;t;;f;8700366;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ポンタ＝ムッソン;;;;Понт-а-Муссон;;;蓬阿穆松
+469;Pont-à-Mousson;pont-a-mousson;8714182;87141820;48.90021020338177;6.05069875717163;;f;FR;f;Europe/Paris;t;FRATW;PAM;t;;f;8700366;f;;f;;f;;f;;;f;;f;8700949;f;;f;f;;;;;;;;;;;ポンタ＝ムッソン;;;;Понт-а-Муссон;;;蓬阿穆松
 470;Luzy-sur-Marne;luzy-sur-marne;8714204;87142042;48.0500000000;5.1833330000;;f;FR;f;Europe/Paris;t;FRATZ;;t;;f;8701475;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 471;Chaudenay;chaudenay;8714213;87142133;47.8333330000;5.5000000000;;f;FR;f;Europe/Paris;t;FRAUE;;t;;f;8700974;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 472;Hortes;hortes;8714214;87142141;47.838739;5.553454;;f;FR;f;Europe/Paris;t;FRAUF;;t;;f;8701279;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 473;Charmoy—Fayl-Billot;charmoy-fayl-billot;8714215;87142158;47.809308;5.604145;;f;FR;f;Europe/Paris;t;FRAUG;;t;;f;8700903;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 474;Auch;auch;8761174;87611749;43.64728656934141;0.5968666076660156;;f;FR;f;Europe/Paris;t;FRAUH;AUH;t;;f;8702713;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;オーシュ;;;;Ош;;;欧什
 475;Laferté-sur-Amance;laferte-sur-amance;8714216;87142166;47.8333330000;5.7000000000;;f;FR;f;Europe/Paris;t;FRAUI;;t;;f;8701348;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-476;Vitrey—Vernois;vitrey-vernois;8714217;87142174;47.830406;5.779407;;f;FR;f;Europe/Paris;t;FRAUJ;;t;;f;8702240;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+476;Vitrey—Vernois;vitrey-vernois;8714217;87142174;47.830406;5.779407;;f;FR;f;Europe/Paris;t;FRAUJ;;t;;f;8702240;f;;f;;f;;f;;;f;;f;8700948;f;;f;f;;;;;;;;;;;;;;;;;;
 477;Barges;barges;8714218;87142182;47.8666670000;5.8500000000;;f;FR;f;Europe/Paris;t;FRAUK;;t;;f;8700691;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 479;Bologne;bologne;8714222;87142224;48.2000000000;5.1333330000;4640;f;FR;t;Europe/Paris;t;FRAUP;;t;;f;8700754;f;;f;;f;;f;;;f;;f;;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;;;;;;;;
 480;Vignory;vignory;8714223;87142232;48.270113;5.124264;5672;f;FR;t;Europe/Paris;t;FRAUQ;;t;;f;8702171;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-481;Aurillac;aurillac;8764500;87645002;44.92094262161991;2.4358856678009033;;f;FR;f;Europe/Paris;t;FRAUR;AUC;t;;f;8702724;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;オーリヤック;;;;Орийак;;;欧里亚克
+481;Aurillac;aurillac;8764500;87645002;44.92094262161991;2.4358856678009033;;f;FR;f;Europe/Paris;t;FRAUR;AUC;t;;f;8702724;f;;f;;f;;f;;;f;;f;8700536;f;;f;f;;;;;;;;;;;オーリヤック;;;;Орийак;;;欧里亚克
 482;Froncles;froncles;8714224;87142240;48.3000000000;5.1500000000;;f;FR;f;Europe/Paris;t;FRAUS;;t;;f;8701111;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 483;Gudmont;gudmont;8714226;87142265;48.3500000000;5.1333330000;5551;f;FR;t;Europe/Paris;t;FRAUT;;t;;f;8701183;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 484;Donjeux;donjeux;8714227;87142273;48.3666670000;5.1500000000;;f;FR;f;Europe/Paris;t;FRAUU;;t;;f;8701035;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-485;Avignon TGV;avignon-tgv;8731896;87318964;43.92160621687953;4.785983562469482;489;f;FR;f;Europe/Paris;t;FRAVG;AVV;t;AVG;t;8704918;t;;f;AVG;t;8731896;f;;;f;;f;;f;;f;t;;;;Aviñón;;Avignone;;;;;アヴィニョン;아비뇽;Awinion;Avinhão;Авиньон;;;亞維農
+485;Avignon TGV;avignon-tgv;8731896;87318964;43.92160621687953;4.785983562469482;489;f;FR;f;Europe/Paris;t;FRAVG;AVV;t;AVG;t;8704918;t;;f;AVG;t;8731896;f;;;f;;f;8700814;f;;f;t;;;;Aviñón;;Avignone;;;;;アヴィニョン;아비뇽;Awinion;Avinhão;Авиньон;;;亞維農
 486;Avail;avail;8730469;87304691;46.960187;2.05319;;f;FR;f;Europe/Paris;t;FRAVI;;t;;f;8700463;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 487;Damblain;damblain;8714249;87142497;48.09373173734836;5.656414031982422;;f;FR;f;Europe/Paris;t;FRAVL;;t;;f;8700997;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 488;Châtillon-sur-Seine;chatillon-sur-seine;8714255;87142554;47.86126131518925;4.574829339981079;;f;FR;f;Europe/Paris;t;FRAVM;;t;;f;8703071;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;シャティヨン＝シュル＝セーヌ;;;;Шатийон-сюр-Сен;;;塞纳河畔沙蒂隆
@@ -375,20 +375,20 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 520;Roville-aux-Chênes;roville-aux-chenes;8714359;87143594;48.3833330000;6.6000000000;;f;FR;f;Europe/Paris;t;FRAXJ;;t;;f;8701842;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 521;Docelles—Cheniménil;docelles-chenimenil;8714403;87144030;48.143635;6.610586;;f;FR;f;Europe/Paris;t;FRAXM;;t;;f;8701005;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 522;Lépanges;lepanges;8714404;87144048;48.1666670000;6.6666670000;;f;FR;f;Europe/Paris;t;FRAXN;;t;;f;8701372;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-523;Charmes;charmes;8714405;87144055;48.37857304087979;6.301560401916504;;f;FR;f;Europe/Paris;t;FRAXO;;t;;f;8700862;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+523;Charmes;charmes;8714405;87144055;48.37857304087979;6.301560401916504;;f;FR;f;Europe/Paris;t;FRAXO;;t;;f;8700862;f;;f;;f;;f;;;f;;f;8700935;f;;f;f;;;;;;;;;;;;;;;;;;
 524;Vincey;vincey;8714406;87144063;48.343645;6.335516;;f;FR;f;Europe/Paris;t;FRAXP;VCY;t;;f;8702160;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-525;Châtel—Nomexy;chatel-nomexy;8714407;87144071;48.307158;6.387788;;f;FR;f;Europe/Paris;t;FRAXQ;CEO;t;;f;8700917;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+525;Châtel—Nomexy;chatel-nomexy;8714407;87144071;48.307158;6.387788;;f;FR;f;Europe/Paris;t;FRAXQ;CEO;t;;f;8700917;f;;f;;f;;f;;;f;;f;8700936;f;;f;f;;;;;;;;;;;;;;;;;;
 526;Igney;igney;8714408;87144089;48.2833330000;6.4000000000;;f;FR;f;Europe/Paris;t;FRAXR;IYA;t;;f;8701303;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-527;Thaon;thaon;8714409;87144097;48.245006;6.415826;;f;FR;f;Europe/Paris;t;FRAXS;TAO;t;;f;8702098;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+527;Thaon;thaon;8714409;87144097;48.245006;6.415826;;f;FR;f;Europe/Paris;t;FRAXS;TAO;t;;f;8702098;f;;f;;f;;f;;;f;;f;8700937;f;;f;f;;;;;;;;;;;;;;;;;;
 528;Raves—Ban-de-Laveline;raves-ban-de-laveline;8714410;87144105;48.265736;7.037852;;f;FR;f;Europe/Paris;t;FRAXT;;t;;f;8701841;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 529;Xertigny;xertigny;8714412;87144121;48.053042;6.376749;;f;FR;f;Europe/Paris;t;FRAXU;;t;;f;8702288;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-530;Bains-les-Bains;bains-les-bains;8714414;87144147;48.0000000000;6.2666670000;;f;FR;f;Europe/Paris;t;FRAXW;;t;;f;8700524;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+530;Bains-les-Bains;bains-les-bains;8714414;87144147;48.0000000000;6.2666670000;;f;FR;f;Europe/Paris;t;FRAXW;;t;;f;8700524;f;;f;;f;;f;;;f;;f;8700898;f;;f;f;;;;;;;;;;;;;;;;;;
 531;Laveline-devant-Bruyères;laveline-devant-bruyeres;8714416;87144162;48.1833330000;6.7500000000;;f;FR;f;Europe/Paris;t;FRAXX;;t;;f;8700318;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 532;Biffontaine;biffontaine;8714418;87144188;48.2166670000;6.8000000000;;f;FR;f;Europe/Paris;t;FRAXZ;;t;;f;8700700;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 533;Corcieux—Vanémont;corcieux-vanemont;8714419;87144196;48.19829;6.877485;;f;FR;f;Europe/Paris;t;FRAYA;;t;;f;8700981;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-535;Mirecourt;mirecourt;8714421;87144212;48.3000000000;6.1333330000;5691;f;FR;t;Europe/Paris;t;FRAYC;;t;;f;8701494;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-536;Contrexéville;contrexeville;8714428;87144287;48.17964396330601;5.890570878982544;;f;FR;f;Europe/Paris;t;FRAYG;;t;;f;8700521;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-537;Martigny-les-Bains;martigny-les-bains;8714429;87144295;48.1000000000;5.8166670000;;f;FR;f;Europe/Paris;t;FRAYH;;t;;f;8701536;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+535;Mirecourt;mirecourt;8714421;87144212;48.3000000000;6.1333330000;5691;f;FR;t;Europe/Paris;t;FRAYC;;t;;f;8701494;f;;f;;f;;f;;;f;;f;8700360;f;;f;f;;;;;;;;;;;;;;;;;;
+536;Contrexéville;contrexeville;8714428;87144287;48.17964396330601;5.890570878982544;;f;FR;f;Europe/Paris;t;FRAYG;;t;;f;8700521;f;;f;;f;;f;;;f;;f;8700380;f;;f;f;;;;;;;;;;;;;;;;;;
+537;Martigny-les-Bains;martigny-les-bains;8714429;87144295;48.1000000000;5.8166670000;;f;FR;f;Europe/Paris;t;FRAYH;;t;;f;8701536;f;;f;;f;;f;;;f;;f;8700132;f;;f;f;;;;;;;;;;;;;;;;;;
 538;Lamarche;lamarche;8714430;87144303;48.09011997695286;5.760354995727539;;f;FR;f;Europe/Paris;t;FRAYI;;t;;f;8701412;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 539;Rozières-sur-Mouzon;rozieres-sur-mouzon;8714431;87144311;48.1166670000;5.7000000000;;f;FR;f;Europe/Paris;t;FRAYJ;;t;;f;8701896;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 540;Provenchères-sur-Fave;provencheres-sur-fave;8714434;87144345;48.3166670000;7.0833330000;;f;FR;f;Europe/Paris;t;FRAYL;;t;;f;8701805;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -445,7 +445,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 604;Bazoches;bazoches;8717134;87171348;49.3166670000;3.6166670000;;f;FR;f;Europe/Paris;t;FRBCC;;t;;f;8700819;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 605;Mont-Notre-Dame;mont-notre-dame;8717135;87171355;49.3000000000;3.5833330000;;f;FR;f;Europe/Paris;t;FRBCD;;t;;f;8701559;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 606;Fère-en-Tardenois;fere-en-tardenois;8717137;87171371;49.2000000000;3.5166670000;;f;FR;f;Europe/Paris;t;FRBCE;;t;;f;8701058;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-607;Dormans;dormans;8717151;87171512;49.07906657476165;3.6417317390441895;;f;FR;f;Europe/Paris;t;FRBCG;;t;;f;8701027;f;;f;;f;;f;;;f;;f;;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;フォルバック;;;;Форбах;;;福尔巴克
+607;Dormans;dormans;8717151;87171512;49.07906657476165;3.6417317390441895;;f;FR;f;Europe/Paris;t;FRBCG;;t;;f;8701027;f;;f;;f;;f;;;f;;f;8700955;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;フォルバック;;;;Форбах;;;福尔巴克
 608;Aÿ;ay;8717156;87171561;49.04872984024946;4.001592993736267;;f;FR;f;Europe/Paris;t;FRBCJ;;t;;f;8701109;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 609;Avenay;avenay;8717157;87171579;49.06476341245391;4.043816328048706;;f;FR;f;Europe/Paris;t;FRBCK;;t;;f;8700653;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 610;Germaine;germaine;8717158;87171587;49.1166670000;4.0333330000;;f;FR;f;Europe/Paris;t;FRBCL;;t;;f;8701197;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -459,7 +459,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 618;Loivre;loivre;8717172;87171728;49.3500000000;3.9833330000;;f;FR;f;Europe/Paris;t;FRBCU;;t;;f;8701430;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 619;Guignicourt;guignicourt;8717173;87171736;49.43538487983269;3.9609575271606445;;f;FR;f;Europe/Paris;t;FRBCV;;t;;f;8701223;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 620;Amifontaine;amifontaine;8717174;87171744;49.484718957199924;3.910580277442932;;f;FR;f;Europe/Paris;t;FRBCW;;t;;f;8700609;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-621;St-Erme;st-erme;8717175;87171751;49.5166670000;3.8500000000;;f;FR;f;Europe/Paris;t;FRBCX;;t;;f;8701953;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+621;St-Erme;st-erme;8717175;87171751;49.5166670000;3.8500000000;;f;FR;f;Europe/Paris;t;FRBCX;;t;;f;8701953;f;;f;;f;;f;;;f;;f;8700982;f;;f;f;;;;;;;;;;;;;;;;;;
 622;Coucy-lès-Eppes;coucy-les-eppes;8717176;87171769;49.5500000000;3.7666670000;;f;FR;f;Europe/Paris;t;FRBCY;;t;;f;8700853;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 623;Nouzonville;nouzonville;8717202;87172023;49.8166670000;4.7500000000;;f;FR;f;Europe/Paris;t;FRBCZ;NOU;t;;f;8701701;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 624;Joigny-sur-Meuse;joigny-sur-meuse;8717203;87172031;49.8333330000;4.7666670000;;f;FR;f;Europe/Paris;t;FRBDA;JGY;t;;f;8701327;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -477,32 +477,32 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 636;Nouvion-sur-Meuse;nouvion-sur-meuse;8717221;87172213;49.7000000000;4.8000000000;;f;FR;f;Europe/Paris;t;FRBDP;NSM;t;;f;8701689;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 637;Vrigne-Meuse;vrigne-meuse;8717222;87172221;49.701115;4.845086;;f;FR;f;Europe/Paris;t;FRBDQ;;t;;f;8702195;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 638;Donchery;donchery;8717223;87172239;49.7000000000;4.8666670000;;f;FR;f;Europe/Paris;t;FRBDR;;t;;f;8701007;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-639;Amagne—Lucquy;amagne-lucquy;8717226;87172262;49.523839;4.473877;;f;FR;f;Europe/Paris;t;FRBDS;;t;;f;8700600;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-640;Rethel;rethel;8717227;87172270;49.50432163386268;4.369618892669677;;f;FR;f;Europe/Paris;t;FRBDT;RTL;t;;f;8700278;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ルテル;;;;Ретель;;;勒泰勒
+639;Amagne—Lucquy;amagne-lucquy;8717226;87172262;49.523839;4.473877;;f;FR;f;Europe/Paris;t;FRBDS;;t;;f;8700600;f;;f;;f;;f;;;f;;f;8700961;f;;f;f;;;;;;;;;;;;;;;;;;
+640;Rethel;rethel;8717227;87172270;49.50432163386268;4.369618892669677;;f;FR;f;Europe/Paris;t;FRBDT;RTL;t;;f;8700278;f;;f;;f;;f;;;f;;f;8700959;f;;f;t;;;;;;;;;;;ルテル;;;;Ретель;;;勒泰勒
 641;Pont-Maugis;pont-maugis;8717230;87172304;49.6666670000;4.9500000000;;f;FR;f;Europe/Paris;t;FRBDU;;t;;f;8701778;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 642;Bazeilles;bazeilles;8717231;87172312;49.6666670000;4.9833330000;;f;FR;f;Europe/Paris;t;FRBDV;;t;;f;8700818;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Базей;;;巴泽耶
 643;Douzy;douzy;8717232;87172320;49.6666670000;5.0500000000;;f;FR;f;Europe/Paris;t;FRBDW;;t;;f;8703242;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 644;Pouru-St-Rémy;pouru-st-remy;8717233;87172338;49.6833330000;5.0833330000;;f;FR;f;Europe/Paris;t;FRBDX;;t;;f;8704304;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 645;Sachy;sachy;8717234;87172346;49.6666670000;5.1333330000;;f;FR;f;Europe/Paris;t;FRBDY;;t;;f;8701973;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-646;Carignan;carignan;8717235;87172353;49.6333330000;5.1666670000;5076;f;FR;t;Europe/Paris;t;FRBDZ;CAG;t;;f;8700507;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+646;Carignan;carignan;8717235;87172353;49.6333330000;5.1666670000;5076;f;FR;t;Europe/Paris;t;FRBDZ;CAG;t;;f;8700507;f;;f;;f;;f;;;f;;f;8700975;f;;f;f;;;;;;;;;;;;;;;;;;
 647;Blagny;blagny;8717238;87172387;49.6166670000;5.1833330000;;f;FR;f;Europe/Paris;t;FRBEB;;t;;f;8700739;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 648;Linay;linay;8717239;87172395;49.6166670000;5.2166670000;;f;FR;f;Europe/Paris;t;FRBEC;;t;;f;8701422;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 649;Margut Fromy;margut-fromy;8717241;87172411;49.590323;5.254995;4789;f;FR;t;Europe/Paris;t;FRBED;;t;;f;8701516;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 650;Liart;liart;8717254;87172544;49.7666670000;4.3333330000;;f;FR;f;Europe/Paris;t;FRBEK;;t;;f;8701397;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 651;Beauchastel;beauchastel;8776152;87761528;44.8333330000;4.8000000000;;f;FR;f;Europe/Paris;t;FRBEL;;t;;f;8705003;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 652;Remilly-Aillicourt;remilly-aillicourt;8717270;87172700;49.6518;4.993642;;f;FR;f;Europe/Paris;t;FRBEM;;t;;f;8704985;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-653;Bénestroff;benestroff;8719230;87192302;48.90673365608428;6.753201484680176;;f;FR;f;Europe/Paris;t;FRBEN;;t;;f;8700557;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+653;Bénestroff;benestroff;8719230;87192302;48.90673365608428;6.753201484680176;;f;FR;f;Europe/Paris;t;FRBEN;;t;;f;8700557;f;;f;;f;;f;;;f;;f;8700217;f;;f;f;;;;;;;;;;;;;;;;;;
 654;Bagnoles-de-l’Orne;bagnoles-de-lorne;;;;;;t;FR;f;Europe/Paris;f;FRBEO;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 656;Anchamps;anchamps;8717285;87172858;49.9333330000;4.6833330000;;f;FR;f;Europe/Paris;t;FRBEP;ACP;t;;f;8700575;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 657;Fépin;fepin;8717287;87172874;50.0166670000;4.7333330000;;f;FR;f;Europe/Paris;t;FRBEQ;FEP;t;;f;8701121;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-659;Brest;brest;8747400;87474007;48.387722202086024;-4.480211734771728;;f;FR;f;Europe/Paris;t;FRBES;BRT;t;BES;t;8700434;f;gbsg3f;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ブレスト;;;;Брест;;;布雷斯特
+659;Brest;brest;8747400;87474007;48.387722202086024;-4.480211734771728;;f;FR;f;Europe/Paris;t;FRBES;BRT;t;BES;t;8700434;f;gbsg3f;t;;f;;f;;;f;;f;8700746;f;;f;t;;;;;;;;;;;ブレスト;;;;Брест;;;布雷斯特
 660;Wadelincourt;wadelincourt;8717330;87173302;49.682651;4.937918;;f;FR;f;Europe/Paris;t;FRBFB;;t;;f;8702267;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 661;La Ferté-sur-Chiers;la-ferte-sur-chiers;8717340;87173401;49.5666670000;5.2333330000;;f;FR;f;Europe/Paris;t;FRBFC;;t;;f;8701375;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 664;Songy;songy;8717424;87174243;48.801708;4.495397;;f;FR;f;Europe/Paris;t;FRBFL;;t;;f;8701969;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 665;Loisy-sur-Marne;loisy-sur-marne;8717425;87174250;48.7666670000;4.5500000000;;f;FR;f;Europe/Paris;t;FRBFM;;t;;f;8701448;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 666;Pringy (Marne);pringy-marne;8717426;87174268;48.7833330000;4.5166670000;;f;FR;f;Europe/Paris;t;FRBFN;;t;;f;8701757;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-667;Vitry-le-François;vitry-le-francois;8717427;87174276;48.717641;4.587411;5655;f;FR;t;Europe/Paris;t;FRBFO;VYF;t;;f;8700082;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;Витри-ле-Франсуа;;;维特里勒弗朗索瓦
-668;Mourmelon-le-Petit;mourmelon-le-petit;8717440;87174409;49.13131013165602;4.318034648895264;;f;FR;f;Europe/Paris;t;FRBFV;MLP;t;;f;8701543;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+667;Vitry-le-François;vitry-le-francois;8717427;87174276;48.717641;4.587411;5655;f;FR;t;Europe/Paris;t;FRBFO;VYF;t;;f;8700082;f;;f;;f;;f;;;f;;f;8700097;f;;f;t;;;;;;;;;;;;;;;Витри-ле-Франсуа;;;维特里勒弗朗索瓦
+668;Mourmelon-le-Petit;mourmelon-le-petit;8717440;87174409;49.13131013165602;4.318034648895264;;f;FR;f;Europe/Paris;t;FRBFV;MLP;t;;f;8701543;f;;f;;f;;f;;;f;;f;8700981;f;;f;f;;;;;;;;;;;;;;;;;;
 669;Uxegney;uxegney;8717442;87174425;48.193876;6.370727;;f;FR;f;Europe/Paris;t;FRBFW;;t;;f;8702146;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 670;Bouy;bouy;8717443;87174433;49.0833330000;4.3500000000;;f;FR;f;Europe/Paris;t;FRBFX;;t;;f;8700758;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 671;Darnieulles;darnieulles;8717445;87174458;48.2000000000;6.3500000000;;f;FR;f;Europe/Paris;t;FRBFY;;t;;f;8701029;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -511,18 +511,18 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 674;St-Âme—Le Syndicat;st-ame-le-syndicat;8717450;87174508;48.024474;6.686994;;f;FR;f;Europe/Paris;t;FRBGB;;t;;f;8703734;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 677;Suippes;suippes;8717482;87174821;49.120151;4.543885;;f;FR;f;Europe/Paris;t;FRBGH;;t;;f;8702026;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 678;Ste-Ménéhould;ste-menehould;8717487;87174870;49.1000000000;4.8666670000;;f;FR;f;Europe/Paris;f;FRBGI;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-679;St-Dizier;st-dizier;8717500;87175000;48.64250109742425;4.947913885116577;5167;f;FR;t;Europe/Paris;t;FRBGJ;SDZ;t;;f;8700175;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝ディジエ;;;;Сен-Дизье;;;聖迪濟耶
-680;Revigny;revigny;8717501;87175018;48.8333330000;4.9833330000;;f;FR;f;Europe/Paris;t;FRBGK;;t;;f;8700519;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+679;St-Dizier;st-dizier;8717500;87175000;48.64250109742425;4.947913885116577;5167;f;FR;t;Europe/Paris;t;FRBGJ;SDZ;t;;f;8700175;f;;f;;f;;f;;;f;;f;8700431;f;;f;f;;;;;;;;;;;サン＝ディジエ;;;;Сен-Дизье;;;聖迪濟耶
+680;Revigny;revigny;8717501;87175018;48.8333330000;4.9833330000;;f;FR;f;Europe/Paris;t;FRBGK;;t;;f;8700519;f;;f;;f;;f;;;f;;f;8700956;f;;f;f;;;;;;;;;;;;;;;;;;
 681;Nançois-Tronville;nancois-tronville;8717506;87175067;48.718019;5.291383;;f;FR;f;Europe/Paris;t;FRBGL;;t;;f;8701659;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 682;Fronville;fronville;8717507;87175075;48.4000000000;5.1500000000;4868;f;FR;t;Europe/Paris;t;FRBGM;;t;;f;8701169;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-683;Joinville;joinville;8717509;87175091;48.44429073367578;5.143361091613769;;f;FR;f;Europe/Paris;t;FRBGN;JQI;t;;f;8700312;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+683;Joinville;joinville;8717509;87175091;48.44429073367578;5.143361091613769;;f;FR;f;Europe/Paris;t;FRBGN;JQI;t;;f;8700312;f;;f;;f;;f;;;f;;f;8700979;f;;f;f;;;;;;;;;;;;;;;;;;
 685;Curel;curel;8717510;87175109;48.5000000000;5.1333330000;;f;FR;f;Europe/Paris;t;FRBGP;;t;;f;8700940;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 686;Chevillon;chevillon;8717511;87175117;48.5333330000;5.1333330000;;f;FR;f;Europe/Paris;t;FRBGQ;;t;;f;8700854;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 687;Bayard;bayard;8717513;87175133;48.5500000000;5.0666670000;;f;FR;f;Europe/Paris;t;FRBGR;;t;;f;8700815;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 688;Eurville;eurville;8717514;87175141;48.5833330000;5.0333330000;5606;f;FR;t;Europe/Paris;t;FRBGS;;t;;f;8701095;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 690;Villiers-en-Lieu;villiers-en-lieu;8717520;87175208;48.661135;4.896801;;f;FR;f;Europe/Paris;t;FRBGW;;t;;f;8702165;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 691;St-Eulien;st-eulien;8717521;87175216;48.6833330000;4.8833330000;;f;FR;f;Europe/Paris;t;FRBGX;;t;;f;8701952;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-692;Commercy;commercy;8717525;87175257;48.76360086856069;5.5935752391815186;;f;FR;f;Europe/Paris;t;FRBHA;;t;;f;8700445;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;コメルシー;;;;Коммерси;;;科梅尔西
+692;Commercy;commercy;8717525;87175257;48.76360086856069;5.5935752391815186;;f;FR;f;Europe/Paris;t;FRBHA;;t;;f;8700445;f;;f;;f;;f;;;f;;f;8700919;f;;f;f;;;;;;;;;;;コメルシー;;;;Коммерси;;;科梅尔西
 693;Berthelming;berthelming;8721533;87215335;48.8166670000;7.0000000000;;f;FR;f;Europe/Paris;t;FRBHN;;t;;f;8700765;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 694;Bouin;bouin;8732072;87320721;46.9666670000;-2.0000000000;;f;FR;f;Europe/Paris;t;FRBHT;;t;;f;8700681;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 695;Les Islettes;les-islettes;8717571;87175711;49.1000000000;5.0000000000;;f;FR;f;Europe/Paris;t;FRBHW;;t;;f;8701401;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -540,7 +540,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 710;Tagolsheim;tagolsheim;8718105;87181057;47.655026;7.264102;;f;FR;f;Europe/Paris;t;FRBIN;;t;;f;8702095;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 711;Walheim;walheim;8718106;87181065;47.641695;7.263391;;f;FR;f;Europe/Paris;t;FRBIO;;t;;f;8702261;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 712;Ballersdorf;ballersdorf;8718107;;47.6333330000;7.1666670000;;f;FR;f;Europe/Paris;t;FRBIP;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-713;Biarritz;biarritz;8767340;87673400;43.45921166498582;-1.5458643436431885;;f;FR;f;Europe/Paris;t;FRBIQ;BIZ;t;BIQ;t;8700114;f;ezwzke;t;;f;;f;;;f;;f;;f;;f;t;;;;Biarriz;;;;;;;ビアリッツ;;;;Биарриц;;;比亚里茨
+713;Biarritz;biarritz;8767340;87673400;43.45921166498582;-1.5458643436431885;;f;FR;f;Europe/Paris;t;FRBIQ;BIZ;t;BIQ;t;8700114;f;ezwzke;t;;f;;f;;;f;;f;8700206;f;;f;t;;;;Biarriz;;;;;;;ビアリッツ;;;;Биарриц;;;比亚里茨
 714;Valdieu;valdieu;8718108;;47.631315550149495;7.056044340133667;;f;FR;f;Europe/Paris;t;FRBIR;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 715;Graffenwald;graffenwald;8718113;87181131;47.780839;7.224774;;f;FR;f;Europe/Paris;t;FRBIS;;t;;f;8701212;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 716;St-André (Haut Rhin);st-andre-haut-rhin;8718114;87181149;47.79097;7.155053;;f;FR;f;Europe/Paris;t;FRBIT;;t;;f;8704971;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -548,15 +548,15 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 718;Colmar St-Joseph;colmar-st-joseph;8718122;87181222;48.081664;7.345409;1349;f;FR;f;Europe/Paris;t;FRBIV;CXJ;t;;f;8700924;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 719;St-Gilles;st-gilles;8718155;87181552;48.075865;7.261027;;f;FR;f;Europe/Paris;t;FRBIW;GLL;t;;f;8703401;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 723;Mulhouse—Dornach;mulhouse-dornach;8718205;87182055;47.746824;7.308212;4753;f;FR;f;Europe/Paris;t;FRBJA;;t;;f;8700564;f;;f;;f;;f;;;f;;f;;f;;f;f;;Mülhausen;;;;;;;;;;;;;;;;
-724;Rixheim;rixheim;8718207;87182071;47.74887540048889;7.406115531921388;;f;FR;f;Europe/Paris;t;FRBJB;RHE;t;;f;8701910;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+724;Rixheim;rixheim;8718207;87182071;47.74887540048889;7.406115531921388;;f;FR;f;Europe/Paris;t;FRBJB;RHE;t;;f;8701910;f;;f;;f;;f;;;f;;f;8700129;f;;f;f;;;;;;;;;;;;;;;;;;
 725;Habsheim;habsheim;8718208;87182089;47.7333330000;7.4166670000;;f;FR;f;Europe/Paris;t;FRBJC;HAB;t;;f;8701261;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-726;Sierentz;sierentz;8718210;87182105;47.6666670000;7.4666670000;;f;FR;f;Europe/Paris;t;FRBJE;SEZ;t;;f;8702060;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+726;Sierentz;sierentz;8718210;87182105;47.6666670000;7.4666670000;;f;FR;f;Europe/Paris;t;FRBJE;SEZ;t;;f;8702060;f;;f;;f;;f;;;f;;f;8700122;f;;f;f;;;;;;;;;;;;;;;;;;
 727;Bartenheim;bartenheim;8718211;87182113;47.6333330000;7.4666670000;;f;FR;f;Europe/Paris;t;FRBJF;BTK;t;;f;8700789;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 728;Zillisheim;zillisheim;8718219;87182196;47.694507;7.294476;;f;FR;f;Europe/Paris;t;FRBJG;;t;;f;8702297;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 729;Illfurth;illfurth;8718220;87182204;47.6666670000;7.2666670000;;f;FR;f;Europe/Paris;t;FRBJH;;t;;f;8701304;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-730;Altkirch;altkirch;8718223;87182238;47.62707851142537;7.2390568256378165;;f;FR;f;Europe/Paris;t;FRBJI;ALK;t;;f;8700282;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;アルトキルシュ;;;;Альткирш;;;阿尔特基克
+730;Altkirch;altkirch;8718223;87182238;47.62707851142537;7.2390568256378165;;f;FR;f;Europe/Paris;t;FRBJI;ALK;t;;f;8700282;f;;f;;f;;f;;;f;;f;8700966;f;;f;f;;;;;;;;;;;アルトキルシュ;;;;Альткирш;;;阿尔特基克
 731;Dannemarie;dannemarie;8718225;87182253;47.6333330000;7.1333330000;;f;FR;f;Europe/Paris;t;FRBJJ;;t;;f;8700302;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-732;Ribeauvillé;ribeauville;8718227;87182279;48.1975900000;7.2215800000;;f;FR;f;Europe/Paris;t;FRBJL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;Rappoltsweiler;;;;;;;;;リボヴィレ;;;;Рибовилле;;;里博维莱
+732;Ribeauvillé;ribeauville;8718227;87182279;48.1975900000;7.2215800000;;f;FR;f;Europe/Paris;t;FRBJL;;t;;f;;f;;f;;f;;f;;;f;;f;8700963;f;;f;f;;Rappoltsweiler;;;;;;;;;リボヴィレ;;;;Рибовилле;;;里博维莱
 735;Herrlisheim-près-Colmar;herrlisheim-pres-colmar;8718232;87182329;48.01661864754956;7.320773005485534;;f;FR;f;Europe/Paris;t;FRBJP;;t;;f;8701281;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 736;Rouffach;rouffach;8718233;87182337;47.96030122288125;7.312817573547363;;f;FR;f;Europe/Paris;t;FRBJQ;;t;;f;8701862;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 737;Logelbach;logelbach;8718234;87182345;48.0833330000;7.3333330000;;f;FR;f;Europe/Paris;t;FRBJR;LOJ;t;;f;8701385;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -598,28 +598,28 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 773;Metzéral;metzeral;8718281;87182816;48.01358282267317;7.073328495025635;;f;FR;f;Europe/Paris;t;FRBLF;MZL;t;;f;8700541;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 774;Sundhoffen;sundhoffen;;;;;;f;FR;f;Europe/Paris;f;FRBLH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 775;Bas-Evette;bas-evette;8718420;87184200;47.680969;6.80682;;f;FR;f;Europe/Paris;t;FRBLL;;t;;f;8700779;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-778;Bort-les-Orgues;bort-les-orgues;8764570;87645705;45.40645751045886;2.502157688140869;;f;FR;f;Europe/Paris;t;FRBLO;;t;;f;8702876;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+778;Bort-les-Orgues;bort-les-orgues;8764570;87645705;45.40645751045886;2.502157688140869;;f;FR;f;Europe/Paris;t;FRBLO;;t;;f;8702876;f;;f;;f;;f;;;f;;f;8700564;f;;f;f;;;;;;;;;;;;;;;;;;
 779;Trois-Chênes;trois-chenes;8718424;87184242;47.648087;6.846274;;f;FR;f;Europe/Paris;t;FRBLP;;t;;f;8702132;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 780;Chèvremont;chevremont;8718425;87184259;47.6333330000;6.9166670000;;f;FR;f;Europe/Paris;t;FRBLQ;;t;;f;8700982;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 781;Petit-Croix;petit-croix;8718426;87184267;47.6166670000;6.9833330000;;f;FR;f;Europe/Paris;t;FRBLR;;t;;f;8701817;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 782;Montreux-Vieux;montreux-vieux;8718427;87184275;47.6166670000;7.0333330000;;f;FR;f;Europe/Paris;t;FRBLS;;t;;f;8701631;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-783;Blainville—Damelevières;blainville-damelevieres;8714113;87141135;48.565031;6.385846;;f;FR;f;Europe/Paris;t;FRBLV;BLV;t;;f;8700804;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-784;Héricourt;hericourt;8718450;87184507;47.5833330000;6.7500000000;;f;FR;f;Europe/Paris;t;FRBLY;;t;;f;8702515;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-785;Voujeaucourt;voujeaucourt;8718453;87184531;47.478973;6.769965;;f;FR;f;Europe/Paris;t;FRBLZ;;t;;f;8702452;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+783;Blainville—Damelevières;blainville-damelevieres;8714113;87141135;48.565031;6.385846;;f;FR;f;Europe/Paris;t;FRBLV;BLV;t;;f;8700804;f;;f;;f;;f;;;f;;f;8700933;f;;f;f;;;;;;;;;;;;;;;;;;
+784;Héricourt;hericourt;8718450;87184507;47.5833330000;6.7500000000;;f;FR;f;Europe/Paris;t;FRBLY;;t;;f;8702515;f;;f;;f;;f;;;f;;f;8700972;f;;f;f;;;;;;;;;;;;;;;;;;
+785;Voujeaucourt;voujeaucourt;8718453;87184531;47.478973;6.769965;;f;FR;f;Europe/Paris;t;FRBLZ;;t;;f;8702452;f;;f;;f;;f;;;f;;f;8700211;f;;f;f;;;;;;;;;;;;;;;;;;
 786;Bourg-Madame;bourg-madame;8778487;87784876;42.432411;1.948672;;f;FR;f;Europe/Paris;t;FRBMA;;t;;f;8702888;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Бур-Мадам;;;
-787;Colombier-Fontaine;colombier-fontaine;8718455;87184556;47.4500000000;6.7000000000;;f;FR;f;Europe/Paris;t;FRBMB;;t;;f;8702490;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-789;L’Isle-sur-le-Doubs;lisle-sur-le-doubs;8718457;87184572;47.44727449425335;6.5814220905303955;;f;FR;f;Europe/Paris;t;FRBMD;;t;;f;8700310;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;莱-杜布河畔利斯尔
-792;Clerval;clerval;8718462;87184622;47.39666431544759;6.491975784301758;;f;FR;f;Europe/Paris;t;FRBMG;;t;;f;8700087;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+787;Colombier-Fontaine;colombier-fontaine;8718455;87184556;47.4500000000;6.7000000000;;f;FR;f;Europe/Paris;t;FRBMB;;t;;f;8702490;f;;f;;f;;f;;;f;;f;8700432;f;;f;f;;;;;;;;;;;;;;;;;;
+789;L’Isle-sur-le-Doubs;lisle-sur-le-doubs;8718457;87184572;47.44727449425335;6.5814220905303955;;f;FR;f;Europe/Paris;t;FRBMD;;t;;f;8700310;f;;f;;f;;f;;;f;;f;8700515;f;;f;f;;;;;;;;;;;;;;;;;;莱-杜布河畔利斯尔
+792;Clerval;clerval;8718462;87184622;47.39666431544759;6.491975784301758;;f;FR;f;Europe/Paris;t;FRBMG;;t;;f;8700087;f;;f;;f;;f;;;f;;f;8700110;f;;f;f;;;;;;;;;;;;;;;;;;
 793;Port-sur-Saône;port-sur-saone;8718512;87185124;47.6833330000;6.0500000000;;f;FR;f;Europe/Paris;t;FRBMK;;t;;f;8701789;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 795;Grattery;grattery;8718515;87185157;47.6666670000;6.0833330000;;f;FR;f;Europe/Paris;t;FRBMO;;t;;f;8701205;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 796;Noidans-lès-Vesoul;noidans-les-vesoul;8718517;87185173;47.6166670000;6.1333330000;;f;FR;f;Europe/Paris;t;FRBMP;;t;;f;8701660;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 800;Montureux-lès-Baulay;montureux-les-baulay;8718528;87185280;47.8166670000;5.9833330000;;f;FR;f;Europe/Paris;t;FRBMT;;t;;f;8701636;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 801;Ronchamp;ronchamp;8718531;87185314;47.699075899924146;6.623210906982421;;f;FR;f;Europe/Paris;t;FRBMU;;t;;f;8701847;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 802;Champagney;champagney;8718534;87185348;47.7000000000;6.6833330000;;f;FR;f;Europe/Paris;t;FRBMV;;t;;f;8700939;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-803;Jussey;jussey;8718535;87185355;47.8166670000;5.9000000000;4568;f;FR;t;Europe/Paris;t;FRBMW;;t;;f;8701329;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+803;Jussey;jussey;8718535;87185355;47.8166670000;5.9000000000;4568;f;FR;t;Europe/Paris;t;FRBMW;;t;;f;8701329;f;;f;;f;;f;;;f;;f;8700911;f;;f;f;;;;;;;;;;;;;;;;;;
 804;Masseret Ville;masseret-ville;8745004;87450049;45.5333330000;1.5166670000;4798;f;FR;f;Europe/Paris;t;FRBMX;;t;;f;8703934;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 805;Barberey Route de Méry;barberey-route-de-mery;8713953;87139535;48.3500000000;4.0166670000;5072;f;FR;t;Europe/Paris;t;FRBMY;;t;;f;8705063;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-807;Béning;bening;8719325;87193250;49.13814029067959;6.828528642654419;;f;FR;f;Europe/Paris;t;FRBNG;;t;;f;8700270;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+807;Béning;bening;8719325;87193250;49.13814029067959;6.828528642654419;;f;FR;f;Europe/Paris;t;FRBNG;;t;;f;8700270;f;;f;;f;;f;;;f;;f;8700929;f;;f;f;;;;;;;;;;;;;;;;;;
 809;Mont-le-Vernois;mont-le-vernois;8718540;87185405;47.6000000000;6.0666670000;;f;FR;f;Europe/Paris;t;FRBNI;;t;;f;8701572;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 810;Luxeuil-les-Bains;luxeuil-les-bains;8718559;87185595;47.8166670000;6.3833330000;;f;FR;f;Europe/Paris;t;FRBNJ;;t;;f;8700390;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 811;Basel SBB;basel-sbb;8718791;;;;5877;f;CH;f;Europe/Zurich;f;FRBNL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Basilea;Bâle;Basilea;Bazel;Basilej;;Bázel;バーゼル;바젤;Bazylea;Basileia;Базель;;;巴塞尔
@@ -628,7 +628,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 814;Maizières-lès-Metz;maizieres-les-metz;8719110;87191106;49.215572;6.158258;;f;FR;f;Europe/Paris;t;FRBNP;MMZ;t;;f;8701650;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 815;Uckange;uckange;8719113;87191130;49.303432;6.156325;;f;FR;f;Europe/Paris;t;FRBNR;UCK;t;;f;8700377;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 816;Knutange—Nilvange;knutange-nilvange;8719121;87191213;49.340801;6.047762;;f;FR;f;Europe/Paris;t;FRBNS;;t;;f;8700555;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-817;Hayange;hayange;8719123;87191239;49.33056200315637;6.073036193847656;;f;FR;f;Europe/Paris;t;FRBNT;HAY;t;;f;8700350;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;艾昂格
+817;Hayange;hayange;8719123;87191239;49.33056200315637;6.073036193847656;;f;FR;f;Europe/Paris;t;FRBNT;HAY;t;;f;8700350;f;;f;;f;;f;;;f;;f;8700330;f;;f;f;;;;;;;;;;;;;;;;;;艾昂格
 818;Aubusson Gare Routière;aubusson-gare-routiere;8741778;87417782;45.95500608979646;2.1708834171295166;5604;f;FR;f;Europe/Paris;f;FRBNU;;t;;f;8705654;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 819;Metzeresche;metzeresche;8719129;87191296;49.3000000000;6.3166670000;;f;FR;f;Europe/Paris;t;FRBNV;;t;;f;8701648;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 820;Yutz;yutz;8719130;87191304;49.354051;6.170393;;f;FR;f;Europe/Paris;t;FRBNW;;t;;f;8702292;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -638,7 +638,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 824;Kédange;kedange;8719134;87191346;49.3166670000;6.3333330000;9047;f;FR;f;Europe/Paris;t;FRBOA;;t;;f;8701333;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 825;Hombourg-Budange;hombourg-budange;8719135;87191353;49.28237811811285;6.350741386413574;3641;f;FR;t;Europe/Paris;t;FRBOB;;t;;f;8701240;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 827;Bordeaux;bordeaux;;;44.83773065393117;-0.577431321144104;;t;FR;f;Europe/Paris;t;FRBOD;;t;;f;;f;ezzx51;t;;f;;f;;;f;;f;;f;;f;f;;;;Burdeos;;;;;;;ボルドー;보르도;;Bordéus;Бордо;;;波尔多
-828;Bordeaux St-Jean;bordeaux-st-jean;8758100;87581009;44.82649;-0.555919;827;f;FR;t;Europe/Paris;t;FRBOJ;BXJ;t;BOJ;t;8700047;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;Burdeos;;;;;;;ボルドー;보르도;;Bordéus;Бордо;;;波尔多
+828;Bordeaux St-Jean;bordeaux-st-jean;8758100;87581009;44.82649;-0.555919;827;f;FR;t;Europe/Paris;t;FRBOJ;BXJ;t;BOJ;t;8700047;f;;f;;f;;f;;;f;;f;8700058;f;;f;t;;;;Burdeos;;;;;;;ボルドー;보르도;;Bordéus;Бордо;;;波尔多
 829;Boé;boe;8758234;87582346;44.1666670000;0.6333330000;;f;FR;f;Europe/Paris;t;FRBOE;;t;;f;8702849;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 830;Ébersviller;ebersviller;8719137;87191379;49.2833330000;6.4000000000;9046;f;FR;f;Europe/Paris;f;FRBOF;;f;;f;8701097;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 831;Anzeling;anzeling;8719138;87191387;49.262343603905244;6.459746360778809;;f;FR;f;Europe/Paris;t;FRBOG;;t;;f;8700657;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -648,12 +648,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 835;Koenigsmacker;koenigsmacker;8719161;87191619;49.396543;6.273418;;f;FR;f;Europe/Paris;t;FRBOM;;t;;f;8701341;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 836;Malling;malling;8719162;87191627;49.4166670000;6.3000000000;;f;FR;f;Europe/Paris;t;FRBON;;t;;f;8701481;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 837;Sierck-les-Bains;sierck-les-bains;8719163;87191635;49.4333330000;6.3500000000;;f;FR;f;Europe/Paris;t;FRBOO;;t;;f;8700526;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-838;Apach;apach;8719164;87191643;49.4500000000;6.3666670000;4960;f;FR;t;Europe/Paris;t;FRBOP;;t;;f;8700187;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+838;Apach;apach;8719164;87191643;49.4500000000;6.3666670000;4960;f;FR;t;Europe/Paris;t;FRBOP;;t;;f;8700187;t;;f;;f;;f;;;f;;f;8700479;f;;f;f;;;;;;;;;;;;;;;;;;
 839;Homécourt;homecourt;8719169;87191692;49.218367973424456;5.9992218017578125;;f;FR;f;Europe/Paris;t;FRBOQ;;t;;f;8701246;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-840;Belfort-Ville;belfort-ville;8718400;87184002;47.63290977356112;6.85370922088623;10610;f;FR;f;Europe/Paris;t;FRBOR;BFT;t;;f;8700024;f;;f;;f;8718400;f;;;f;;f;;f;;f;t;;;;;;;;;;;ベルフォール;벨포르;;;Бельфор;;;贝尔福
+840;Belfort-Ville;belfort-ville;8718400;87184002;47.63290977356112;6.85370922088623;10610;f;FR;f;Europe/Paris;t;FRBOR;BFT;t;;f;8700024;f;;f;;f;8718400;f;;;f;;f;8700028;f;;f;t;;;;;;;;;;;ベルフォール;벨포르;;;Бельфор;;;贝尔福
 841;Jœuf;joeuf;8719170;87191700;49.22505299921394;6.017675399780273;;f;FR;f;Europe/Paris;t;FRBOS;;t;;f;8701317;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 842;Moyeuvre-Grande;moyeuvre-grande;8719171;87191718;49.2500000000;6.0333330000;;f;FR;f;Europe/Paris;t;FRBOT;;t;;f;8700364;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-843;Bourges;bourges;8757620;87576207;47.09431857034381;2.3944616317749023;10690;f;FR;f;Europe/Paris;t;FRBOU;BGS;t;;f;8700042;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ブールジュ;부르주;;;Бурж;;;布尔日
+843;Bourges;bourges;8757620;87576207;47.09431857034381;2.3944616317749023;10690;f;FR;f;Europe/Paris;t;FRBOU;BGS;t;;f;8700042;f;;f;;f;;f;;;f;;f;8700051;f;;f;t;;;;;;;;;;;ブールジュ;부르주;;;Бурж;;;布尔日
 844;Boves;boves;8731321;87313213;49.8500000000;2.3833330000;;f;FR;f;Europe/Paris;t;FRBOV;;t;;f;8700808;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 845;Rombas—Clouange;rombas-clouange;8719173;87191734;49.255987;6.099972;;f;FR;f;Europe/Paris;t;FRBOW;;t;;f;8700369;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 846;Gandrange—Amnéville;gandrange-amneville;8719174;87191742;49.260877;6.135785;;f;FR;f;Europe/Paris;t;FRBOX;;t;;f;8700344;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -675,9 +675,9 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 865;Morhange;morhange;8719228;87192286;48.936906763454125;6.658787727355956;9222;f;FR;t;Europe/Paris;t;FRBPV;;t;;f;8700284;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 866;Ars-sur-Moselle;ars-sur-moselle;8719240;87192401;49.0833330000;6.0666670000;;f;FR;f;Europe/Paris;t;FRBPY;;t;;f;8700627;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 867;Ancy-sur-Moselle;ancy-sur-moselle;8719241;87192419;49.0500000000;6.0666670000;;f;FR;f;Europe/Paris;t;FRBPZ;;t;;f;8700633;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-868;Pagny-sur-Moselle;pagny-sur-moselle;8719246;87192468;48.9853992931413;6.025443077087402;;f;FR;f;Europe/Paris;t;FRBQA;PMO;t;;f;8700276;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+868;Pagny-sur-Moselle;pagny-sur-moselle;8719246;87192468;48.9853992931413;6.025443077087402;;f;FR;f;Europe/Paris;t;FRBQA;PMO;t;;f;8700276;f;;f;;f;;f;;;f;;f;8700951;f;;f;f;;;;;;;;;;;;;;;;;;
 869;Vandières;vandieres;8719247;87192476;48.95217;6.039231;;f;FR;f;Europe/Paris;t;FRBQB;;t;;f;8702149;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-870;Baroncourt;baroncourt;8719265;87192658;49.2833330000;5.7000000000;;f;FR;f;Europe/Paris;t;FRBQJ;;t;;f;8700684;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+870;Baroncourt;baroncourt;8719265;87192658;49.2833330000;5.7000000000;;f;FR;f;Europe/Paris;t;FRBQJ;;t;;f;8700684;f;;f;;f;;f;;;f;;f;8700953;f;;f;f;;;;;;;;;;;;;;;;;;
 871;Hatrize;hatrize;8719272;87192724;49.2000000000;5.9166670000;;f;FR;f;Europe/Paris;t;FRBQL;;t;;f;8701296;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 872;Valleroy—Moineville;valleroy-moineville;8719273;87192732;49.205693;5.936026;;f;FR;f;Europe/Paris;t;FRBQM;;t;;f;8702254;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 873;Bourges Gare Routière;bourges-gare-routiere;8745424;87454249;47.0833330000;2.4000000000;10690;f;FR;f;Europe/Paris;f;FRBQZ;;t;;f;8706495;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -688,12 +688,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 878;Brettnach;brettnach;8719316;87193169;49.2500000000;6.5666670000;;f;FR;f;Europe/Paris;t;FRBRE;;t;;f;8700766;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 879;Bouzonville;bouzonville;8719317;87193177;49.3000000000;6.5333330000;9042;f;FR;t;Europe/Paris;t;FRBRF;;t;;f;8700333;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 880;Hombourg-Budange Haut;hombourg-budange-haut;8719327;87193276;49.1333330000;6.7666670000;3641;f;FR;f;Europe/Paris;t;FRBRI;;t;;f;8700525;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-881;St-Avold;st-avold;8719331;87193318;49.10538487281865;6.70741081237793;;f;FR;f;Europe/Paris;t;FRBRJ;;t;;f;8700269;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+881;St-Avold;st-avold;8719331;87193318;49.10538487281865;6.70741081237793;;f;FR;f;Europe/Paris;t;FRBRJ;;t;;f;8700269;f;;f;;f;;f;;;f;;f;8700928;f;;f;f;;;;;;;;;;;;;;;;;;
 882;Teting;teting;8719334;87193342;49.051707;6.66373;;f;FR;f;Europe/Paris;t;FRBRK;;t;;f;8700556;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-883;Faulquemont;faulquemont;8719335;87193359;49.04545288521868;6.604124307632446;;f;FR;f;Europe/Paris;t;FRBRL;;t;;f;8700268;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+883;Faulquemont;faulquemont;8719335;87193359;49.04545288521868;6.604124307632446;;f;FR;f;Europe/Paris;t;FRBRL;;t;;f;8700268;f;;f;;f;;f;;;f;;f;8700927;f;;f;f;;;;;;;;;;;;;;;;;;
 884;Herny;herny;8719338;87193383;49.0000000000;6.4833330000;;f;FR;f;Europe/Paris;t;FRBRN;;t;;f;8701294;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 887;Breil-sur-Roya;breil-sur-roya;8775683;87756833;43.94407461505342;7.516365051269531;;f;FR;f;Europe/Paris;t;FRBRR;BRE;t;;f;8702908;f;;f;;f;8775683;f;S00622;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;鲁瓦阿河畔布雷
-888;Bressuire;bressuire;8748724;87487249;46.838471550969494;-0.4963159561157226;;f;FR;f;Europe/Paris;t;FRBRS;;t;;f;8702910;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ブレシュイール;;;;Брессюир;;;布雷敘爾
+888;Bressuire;bressuire;8748724;87487249;46.838471550969494;-0.4963159561157226;;f;FR;f;Europe/Paris;t;FRBRS;;t;;f;8702910;f;;f;;f;;f;;;f;;f;8700613;f;;f;f;;;;;;;;;;;ブレシュイール;;;;Брессюир;;;布雷敘爾
 890;Theding;theding;8719350;87193508;49.126686;6.895238;;f;FR;f;Europe/Paris;t;FRBRV;;t;;f;8702092;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 891;Farébersviller;farebersviller;8719351;87193516;49.1166670000;6.8500000000;9130;f;FR;t;Europe/Paris;t;FRBRW;;t;;f;8700534;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 892;Farschviller;farschviller;8719352;87193524;49.1000000000;6.9000000000;9131;f;FR;t;Europe/Paris;t;FRBRX;;t;;f;8701107;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -708,20 +708,20 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 902;Wittring;wittring;8719365;87193656;49.056013;7.140689;;f;FR;f;Europe/Paris;t;FRBSJ;;t;;f;8702282;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 903;Herbitzheim;herbitzheim;8719367;87193672;49.0166670000;7.0833330000;;f;FR;f;Europe/Paris;t;FRBSK;;t;;f;8701297;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 904;Ravezies;ravezies;8723531;87235317;44.86645087819083;-0.5769538879394531;;f;FR;f;Europe/Paris;t;FRBSL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-905;Boussens;boussens;8761109;87611095;43.17983662564996;0.9723919630050658;;f;FR;f;Europe/Paris;t;FRBSS;BQY;t;;f;8700474;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+905;Boussens;boussens;8761109;87611095;43.17983662564996;0.9723919630050658;;f;FR;f;Europe/Paris;t;FRBSS;BQY;t;;f;8700474;f;;f;;f;;f;;;f;;f;8700312;f;;f;f;;;;;;;;;;;;;;;;;;
 906;Woelfling-lès-Sarreguemines;woelfling-les-sarreguemines;8719377;87193771;49.094928;7.190597;;f;FR;f;Europe/Paris;t;FRBSV;;t;;f;8702276;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 907;Rohrbach-lès-Bitche;rohrbach-les-bitche;8719378;87193789;49.0500000000;7.2666670000;9060;f;FR;t;Europe/Paris;t;FRBSW;;t;;f;8701840;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 908;Petit-Réderching;petit-rederching;8719379;87193797;49.0500000000;7.3000000000;;f;FR;f;Europe/Paris;t;FRBSX;;t;;f;8701815;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-909;Busigny;busigny;8729624;87296244;50.039722339360004;3.4461128711700435;;f;FR;f;Europe/Paris;t;FRBSY;BSY;t;;f;8700016;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+909;Busigny;busigny;8729624;87296244;50.039722339360004;3.4461128711700435;;f;FR;f;Europe/Paris;t;FRBSY;BSY;t;;f;8700016;f;;f;;f;;f;;;f;;f;8700020;f;;f;f;;;;;;;;;;;;;;;;;;
 910;Enchenberg;enchenberg;8719380;87193805;49.0166670000;7.3333330000;9062;f;FR;t;Europe/Paris;t;FRBSZ;;t;;f;8701069;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 911;Lemberg;lemberg;8719381;87193813;49.0000000000;7.3833330000;;f;FR;f;Europe/Paris;t;FRBTA;;t;;f;8700539;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-912;Bréauté—Beuzeville;breaute-beuzeville;8741334;87413344;49.603582;0.417441;;f;FR;f;Europe/Paris;t;FRBTB;BTB;t;;f;8700234;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+912;Bréauté—Beuzeville;breaute-beuzeville;8741334;87413344;49.603582;0.417441;;f;FR;f;Europe/Paris;t;FRBTB;BTB;t;;f;8700234;f;;f;;f;;f;;;f;;f;8700812;f;;f;f;;;;;;;;;;;;;;;;;;
 913;Bitche;bitche;8719382;87193821;49.0500000000;7.4333330000;5273;f;FR;t;Europe/Paris;t;FRBTC;;t;;f;8700530;f;;f;;f;;f;;;f;;f;;f;;f;f;;Bitsch;;;;;;;;;;;;;;;;比特克
 914;Bitche Camp;bitche-camp;8719383;;49.04875093582687;7.432331442832946;5273;f;FR;f;Europe/Paris;t;FRBTD;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 916;Ebring;ebring;8719401;87194019;49.121311;6.914583;;f;FR;f;Europe/Paris;t;FRBTH;;t;;f;8705475;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-917;Montmédy;montmedy;8719420;87194209;49.5166670000;5.3666670000;5697;f;FR;t;Europe/Paris;t;FRBTI;MDY;t;;f;8700243;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;蒙梅迪
+917;Montmédy;montmedy;8719420;87194209;49.5166670000;5.3666670000;5697;f;FR;t;Europe/Paris;t;FRBTI;MDY;t;;f;8700243;f;;f;;f;;f;;;f;;f;8700856;f;;f;f;;;;;;;;;;;;;;;;;;蒙梅迪
 918;Charency-Vezin;charency-vezin;8719425;87194258;49.4833330000;5.5166670000;;f;FR;f;Europe/Paris;t;FRBTK;;t;;f;8700951;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-919;Audun-le-Roman;audun-le-roman;8719435;87194357;49.3666670000;5.8833330000;;f;FR;f;Europe/Paris;t;FRBTL;;t;;f;8700527;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+919;Audun-le-Roman;audun-le-roman;8719435;87194357;49.3666670000;5.8833330000;;f;FR;f;Europe/Paris;t;FRBTL;;t;;f;8700527;f;;f;;f;;f;;;f;;f;8700304;f;;f;f;;;;;;;;;;;;;;;;;;
 920;Fontoy;fontoy;8719436;87194365;49.3500000000;6.0000000000;;f;FR;f;Europe/Paris;t;FRBTM;;t;;f;8701163;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 921;Rehon;rehon;8719444;87194449;49.5000000000;5.7500000000;;f;FR;f;Europe/Paris;t;FRBTN;;t;;f;8704350;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 922;Cons-la-Grandville;cons-la-grandville;8719445;87194456;49.4833330000;5.7000000000;5699;f;FR;t;Europe/Paris;t;FRBTO;;t;;f;8703149;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -730,7 +730,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 927;Gros-Rederching;gros-rederching;8719960;87199604;49.0666670000;7.2166670000;;f;FR;f;Europe/Paris;t;FRBTU;;t;;f;8701220;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 928;Destry;destry;8719962;87199620;48.9500000000;6.5833330000;;f;FR;f;Europe/Paris;t;FRBTV;;t;;f;8701013;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 929;Mundolsheim;mundolsheim;8721210;87212100;48.6421540000;7.7137760000;;f;FR;f;Europe/Paris;t;FRBUB;MUM;t;;f;8701497;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-930;Busseau-sur-Creuse;busseau-sur-creuse;8759770;87597708;46.123067;2.023085;;f;FR;f;Europe/Paris;t;FRBUC;;t;;f;8700802;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+930;Busseau-sur-Creuse;busseau-sur-creuse;8759770;87597708;46.123067;2.023085;;f;FR;f;Europe/Paris;t;FRBUC;;t;;f;8700802;f;;f;;f;;f;;;f;;f;8700461;f;;f;f;;;;;;;;;;;;;;;;;;
 931;Stephansfeld;stephansfeld;8721212;87212126;48.717776;7.704483;;f;FR;f;Europe/Paris;t;FRBUD;;t;;f;8702021;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 932;Bueil;bueil;8738709;87387092;48.925312013206096;1.4434254169464111;;f;FR;f;Europe/Paris;t;FRBUE;BUE;t;;f;8702936;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 933;Brumath;brumath;8721213;87212134;48.73271459610169;7.7002787590026855;;f;FR;f;Europe/Paris;t;FRBUF;BAH;t;;f;8700294;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ブリュマト;;;;;;;布吕马
@@ -751,13 +751,13 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 948;Gambsheim;gambsheim;8721233;87212332;48.6951069192798;7.879214286804199;;f;FR;f;Europe/Paris;t;FRBUV;;t;;f;8701177;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 949;Herrlisheim;herrlisheim;8721234;87212340;48.72772545390374;7.91018843650818;;f;FR;f;Europe/Paris;t;FRBUW;;t;;f;8700308;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 950;Drusenheim;drusenheim;8721235;87212357;48.765991180855394;7.947680354118347;;f;FR;f;Europe/Paris;t;FRBUX;;t;;f;8701020;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-951;Bruyères;bruyeres;8714415;87144154;48.2000000000;6.7166670000;;f;FR;f;Europe/Paris;t;FRBUY;;t;;f;8700295;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;布吕伊埃雷勒沙特
+951;Bruyères;bruyeres;8714415;87144154;48.2000000000;6.7166670000;;f;FR;f;Europe/Paris;t;FRBUY;;t;;f;8700295;f;;f;;f;;f;;;f;;f;8700971;f;;f;f;;;;;;;;;;;;;;;;;;布吕伊埃雷勒沙特
 952;Buzy-en-Béarn;buzy-en-bearn;8767263;87672634;43.148177;-0.455905;;f;FR;f;Europe/Paris;t;FRBUZ;;t;;f;8702945;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-953;Beauvais;beauvais;8731351;87313510;49.42640463611349;2.088700532913208;;f;FR;f;Europe/Paris;t;FRBVA;BVS;t;;f;8700250;f;u0c3pq;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ボーヴェ;보베;;;Бове-сюр-Мата;;;马塔河畔博韦
+953;Beauvais;beauvais;8731351;87313510;49.42640463611349;2.088700532913208;;f;FR;f;Europe/Paris;t;FRBVA;BVS;t;;f;8700250;f;u0c3pq;t;;f;;f;;;f;;f;8700884;f;;f;t;;;;;;;;;;;ボーヴェ;보베;;;Бове-сюр-Мата;;;马塔河畔博韦
 954;Sessenheim;sessenheim;8721236;87212365;48.8000000000;7.9833330000;;f;FR;f;Europe/Paris;t;FRBVB;;t;;f;8701970;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 955;Rountzenheim;rountzenheim;8721237;87212373;48.8207670000;8.0056000000;;f;FR;f;Europe/Paris;t;FRBVC;;t;;f;8701914;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 956;Roeschwoog;roeschwoog;8721240;87212407;48.8267570000;8.0368420000;;f;FR;f;Europe/Paris;t;FRBVD;;t;;f;8700412;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-957;Brive-la-Gaillarde;brive-la-gaillarde;8759400;87594002;45.15250599694204;1.5285372734069824;;f;FR;f;Europe/Paris;t;FRBVE;BLG;t;;f;8700036;f;u010fv;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ブリーヴ＝ラ＝ガイヤルド;;;;Брив-ла-Гайард;;;布里夫拉盖亚尔德
+957;Brive-la-Gaillarde;brive-la-gaillarde;8759400;87594002;45.15250599694204;1.5285372734069824;;f;FR;f;Europe/Paris;t;FRBVE;BLG;t;;f;8700036;f;u010fv;t;;f;;f;;;f;;f;8700044;f;;f;t;;;;;;;;;;;ブリーヴ＝ラ＝ガイヤルド;;;;Брив-ла-Гайард;;;布里夫拉盖亚尔德
 958;Roppenheim;roppenheim;8721241;87212415;48.8432540000;8.0553820000;;f;FR;f;Europe/Paris;t;FRBVF;;t;;f;8701892;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 960;Seltz;seltz;8721243;87212431;48.8951950000;8.1075670000;;f;FR;f;Europe/Paris;t;FRBVH;;t;;f;8700456;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 961;Munchhausen;munchhausen;8721244;87212449;48.9166670000;8.1500000000;;f;FR;f;Europe/Paris;t;FRBVI;;t;;f;8701522;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -795,7 +795,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 997;Wimmenau;wimmenau;8721376;87213769;48.911413;7.427948;;f;FR;f;Europe/Paris;t;FRBWY;;t;;f;8702256;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 998;Ingwiller;ingwiller;8721378;87213785;48.8728450000;7.4798010000;;f;FR;f;Europe/Paris;t;FRBWZ;IGW;t;;f;8700309;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 999;Menchhoffen;menchhoffen;8721381;87213819;48.8592940000;7.4961950000;;f;FR;f;Europe/Paris;t;FRBXA;;t;;f;8701521;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1000;Bretenoux—Biars;bretenoux-biars;8759476;87594762;44.927367;1.843687;10702;f;FR;f;Europe/Paris;t;FRBXB;;t;;f;8702912;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1000;Bretenoux—Biars;bretenoux-biars;8759476;87594762;44.927367;1.843687;10702;f;FR;f;Europe/Paris;t;FRBXB;;t;;f;8702912;f;;f;;f;;f;;;f;;f;8700534;f;;f;f;;;;;;;;;;;;;;;;;;
 1001;Ettendorf;ettendorf;8721382;87213827;48.8127990000;7.5824550000;;f;FR;f;Europe/Paris;t;FRBXC;;t;;f;8701087;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;埃唐多尔
 1002;Alteckendorf;alteckendorf;8721383;87213835;48.7916550000;7.5970460000;;f;FR;f;Europe/Paris;t;FRBXD;;t;;f;8700582;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;阿尔泰康多尔
 1003;Tauxigny;tauxigny;8746572;87465724;47.251986;0.840095;;f;FR;f;Europe/Paris;t;FRBXE;;t;;f;8706358;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -803,9 +803,9 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1005;Niedermodern;niedermodern;8721388;87213884;48.84345200561577;7.614008188247681;;f;FR;f;Europe/Paris;t;FRBXH;;t;;f;8701677;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1006;Ebersheim;ebersheim;8721410;87214106;48.3043790000;7.4990270000;;f;FR;f;Europe/Paris;t;FRBXI;EBH;t;;f;8701054;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1007;Kogenheim;kogenheim;8721411;87214114;48.3373670000;7.5429730000;;f;FR;f;Europe/Paris;t;FRBXJ;KEN;t;;f;8701340;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1008;Benfeld;benfeld;8721412;87214122;48.373645065949134;7.583962082862853;;f;FR;f;Europe/Paris;t;FRBXK;BFD;t;;f;8700551;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ベンフェルド;;;;;;;邦弗尔
+1008;Benfeld;benfeld;8721412;87214122;48.373645065949134;7.583962082862853;;f;FR;f;Europe/Paris;t;FRBXK;BFD;t;;f;8700551;f;;f;;f;;f;;;f;;f;8700964;f;;f;f;;;;;;;;;;;ベンフェルド;;;;;;;邦弗尔
 1009;Matzenheim;matzenheim;8721413;87214130;48.3945050000;7.6218510000;;f;FR;f;Europe/Paris;t;FRBXL;MHW;t;;f;8701622;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1010;Erstein;erstein;8721414;87214148;48.423163229284256;7.638330459594727;;f;FR;f;Europe/Paris;t;FRBXM;EEN;t;;f;8700281;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;エルスタン;;;;;;;埃尔斯坦
+1010;Erstein;erstein;8721414;87214148;48.423163229284256;7.638330459594727;;f;FR;f;Europe/Paris;t;FRBXM;EEN;t;;f;8700281;f;;f;;f;;f;;;f;;f;8700965;f;;f;f;;;;;;;;;;;エルスタン;;;;;;;埃尔斯坦
 1011;Scherwiller;scherwiller;8721420;87214205;48.2871340000;7.4213500000;;f;FR;f;Europe/Paris;t;FRBXN;;t;;f;8701933;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1012;Dambach-la-Ville;dambach-la-ville;8721421;87214213;48.321774;7.435751;;f;FR;f;Europe/Paris;t;FRBXO;;t;;f;8700301;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1013;Epfig;epfig;8721422;87214221;48.3593290000;7.4642660000;;f;FR;f;Europe/Paris;t;FRBXP;;t;;f;8701072;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -830,7 +830,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1044;Mullerhof;mullerhof;8721464;87214643;48.52467;7.311861;;f;FR;f;Europe/Paris;t;FRBYU;;t;;f;8701539;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1045;Lutzelhouse;lutzelhouse;8721465;87214650;48.5166670000;7.2833330000;;f;FR;f;Europe/Paris;t;FRBYV;;t;;f;8701455;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1046;Wisches;wisches;8721467;87214676;48.507465;7.270178;;f;FR;f;Europe/Paris;t;FRBYW;;t;;f;8702279;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1047;Bayeux;bayeux;8744406;87444067;49.26962473190915;-0.6983613967895508;;f;FR;f;Europe/Paris;t;FRBYX;BAY;t;;f;8700224;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;バイユー;;;;Байё;;;巴约
+1047;Bayeux;bayeux;8744406;87444067;49.26962473190915;-0.6983613967895508;;f;FR;f;Europe/Paris;t;FRBYX;BAY;t;;f;8700224;f;;f;;f;;f;;;f;;f;8700772;f;;f;t;;;;;;;;;;;バイユー;;;;Байё;;;巴约
 1048;Russ—Hersbach;russ-hersbach;8721468;87214684;48.498448;7.251966;;f;FR;f;Europe/Paris;t;FRBYY;;t;;f;8701864;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1049;Schirmeck—La Broque;schirmeck-la-broque;8721469;87214692;48.480056;7.215704;;f;FR;f;Europe/Paris;t;FRBYZ;;t;;f;8700419;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1050;Rothau;rothau;8721472;87214726;48.4568720000;7.2077180000;;f;FR;f;Europe/Paris;t;FRBZA;;t;;f;8700416;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -844,15 +844,15 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1059;Lièpvre;liepvre;8721483;87214833;48.2666670000;7.2833330000;;f;FR;f;Europe/Paris;t;FRBZJ;;t;;f;8703800;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1060;Ste-Croix-aux-Mines;ste-croix-aux-mines;8721484;87214841;48.258535;7.246591;;f;FR;f;Europe/Paris;t;FRBZK;;t;;f;8704927;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1061;Ste-Marie-aux-Mines;ste-marie-aux-mines;8721485;87214858;48.2500000000;7.1833330000;;f;FR;f;Europe/Paris;t;FRBZL;;t;;f;8700423;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1062;Réding;reding;8721507;87215079;48.742748;7.095653;;f;FR;f;Europe/Paris;t;FRBZM;RDG;t;;f;8700452;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1062;Réding;reding;8721507;87215079;48.742748;7.095653;;f;FR;f;Europe/Paris;t;FRBZM;RDG;t;;f;8700452;f;;f;;f;;f;;;f;;f;8700976;f;;f;f;;;;;;;;;;;;;;;;;;
 1063;Igney—Avricourt;igney-avricourt;8721510;87215103;48.647031;6.80531;;f;FR;f;Europe/Paris;t;FRBZO;;t;;f;8701299;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1064;Nouvel-Avricourt;nouvel-avricourt;8721511;87215111;48.646806;6.819252;;f;FR;f;Europe/Paris;t;FRBZP;;t;;f;8701696;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1065;Rechicourt-le-Château;rechicourt-le-chateau;8721512;87215129;48.6666670000;6.8500000000;;f;FR;f;Europe/Paris;t;FRBZQ;;t;;f;8701844;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1066;Béziers;beziers;8778100;87781005;43.33616601403274;3.2188332080841064;;f;FR;f;Europe/Paris;t;FRBZR;BZS;t;BZR;t;8700064;f;spdq95;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ベジエ;베지에;;;Безье;;;贝济耶
+1066;Béziers;beziers;8778100;87781005;43.33616601403274;3.2188332080841064;;f;FR;f;Europe/Paris;t;FRBZR;BZS;t;BZR;t;8700064;f;spdq95;t;;f;;f;;;f;;f;8700078;f;;f;t;;;;;;;;;;;ベジエ;베지에;;;Безье;;;贝济耶
 1067;Gondrexange;gondrexange;8721513;;48.6833330000;6.9333330000;;f;FR;f;Europe/Paris;t;FRBZS;;t;;f;8771654;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1068;Heming;heming;8721514;87215145;48.7000000000;6.9500000000;;f;FR;f;Europe/Paris;t;FRBZT;;t;;f;8701267;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1069;Arzviller;arzviller;8721515;;48.7166670000;7.1666670000;17437;f;FR;f;Europe/Paris;t;FRBZU;;t;;f;8700647;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1070;Lutzelbourg;lutzelbourg;8721516;87215160;48.7333330000;7.2500000000;;f;FR;f;Europe/Paris;t;FRBZV;;t;;f;8700505;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1070;Lutzelbourg;lutzelbourg;8721516;87215160;48.7333330000;7.2500000000;;f;FR;f;Europe/Paris;t;FRBZV;;t;;f;8700505;f;;f;;f;;f;;;f;;f;8700934;f;;f;f;;;;;;;;;;;;;;;;;;
 1071;Hommarting;hommarting;8721517;87215178;48.7333330000;7.1500000000;;f;FR;f;Europe/Paris;t;FRBZW;;t;;f;8701269;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1072;St-Jean-de-Bassel;st-jean-de-bassel;8721523;87215236;48.80223;6.990722;;f;FR;f;Europe/Paris;t;FRBZZ;;t;;f;8704591;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1073;Gosselming;gosselming;8721524;87215244;48.7833330000;7.0000000000;;f;FR;f;Europe/Paris;t;FRCAB;;t;;f;8703415;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -886,25 +886,25 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1111;Aulus-les-Bains;aulus-les-bains;8723215;;42.8000000000;1.3333330000;;f;FR;f;Europe/Paris;t;FRCBU;;t;;f;8702719;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1112;Latrape;latrape;8723216;;43.24488229847452;1.2880772352218628;;f;FR;f;Europe/Paris;t;FRCBV;;t;;f;8703669;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1113;Alaï;alai;8772274;87722744;45.751875;4.771833;;f;FR;f;Europe/Paris;t;FRCBY;ALA;t;;f;8702635;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1114;Cravant-Bazarnes;cravant-bazarnes;8768364;87683649;47.678542;3.680929;;f;FR;f;Europe/Paris;t;FRCBZ;;t;;f;8703183;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1114;Cravant-Bazarnes;cravant-bazarnes;8768364;87683649;47.678542;3.680929;;f;FR;f;Europe/Paris;t;FRCBZ;;t;;f;8703183;f;;f;;f;;f;;;f;;f;8700398;f;;f;f;;;;;;;;;;;;;;;;;;
 1115;Lamure-sur-Azergues;lamure-sur-azergues;8772186;87721860;46.0666670000;4.5000000000;;f;FR;f;Europe/Paris;t;FRCCB;;t;;f;8703638;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1116;Sorèze;soreze;8723565;87235655;43.454232;2.072912;;f;FR;f;Europe/Paris;t;FRCCC;;t;;f;8704507;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1119;Carcassonne;carcassonne;8761528;87615286;43.21817571610827;2.3518198728561397;;f;FR;f;Europe/Paris;t;FRCCF;CNE;t;;f;8700100;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;Carcasona;;;;;;;カルカソンヌ;카르카손;;;Каркасон;;;卡尔卡松
+1119;Carcassonne;carcassonne;8761528;87615286;43.21817571610827;2.3518198728561397;;f;FR;f;Europe/Paris;t;FRCCF;CNE;t;;f;8700100;f;;f;;f;;f;;;f;;f;8700176;f;;f;t;;;;Carcasona;;;;;;;カルカソンヌ;카르카손;;;Каркасон;;;卡尔卡松
 1120;Balsièges;balsieges;8711186;87111864;44.482167;3.45637;;f;FR;f;Europe/Paris;t;FRCCG;;t;;f;8702765;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1121;Tournai Frontière;tournai-frontiere;8724164;;;;;f;BE;f;Europe/Brussels;f;FRCCH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1122;Froyennes;froyennes;8724175;;;;;f;BE;f;Europe/Brussels;f;FRCCK;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1123;Châlons-en-Champagne;chalons-en-champagne;;;48.8333330000;4.0833330000;;t;FR;f;Europe/Paris;f;FRCCL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 1124;Châlons-en-Champagne Tissier;chalons-en-champagne-tissier;8732641;87326413;48.939702;4.36064;1123;f;FR;f;Europe/Paris;t;FRTCC;;t;;f;8703771;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1125;Châlons-en-Champagne;chalons-en-champagne;8717400;87174003;48.955241411580765;4.348762035369873;1123;f;FR;t;Europe/Paris;t;FRXCR;CMP;t;;f;8700002;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;シャロン＝アン＝シャンパーニュ;샬롱앙샹파뉴;;;Шалон-ан-Шампань;;;香槟沙隆
+1125;Châlons-en-Champagne;chalons-en-champagne;8717400;87174003;48.955241411580765;4.348762035369873;1123;f;FR;t;Europe/Paris;t;FRXCR;CMP;t;;f;8700002;f;;f;;f;;f;;;f;;f;8700003;f;;f;t;;;;;;;;;;;シャロン＝アン＝シャンパーニュ;샬롱앙샹파뉴;;;Шалон-ан-Шампань;;;香槟沙隆
 1126;Châlons-en-Champagne Bagatelle;chalons-en-champagne-bagatelle;8732642;;48.925562;4.371831;1123;f;FR;f;Europe/Paris;t;FRLCC;;t;;f;8703756;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1128;Paris-Gare-du-Nord;paris-gare-du-nord;8727102;;;;4916;f;FR;f;Europe/Paris;f;FRCCO;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1129;Paris-Gare-du-Nord;paris-gare-du-nord;8727103;;48.880849;2.355308;4916;f;FR;f;Europe/Paris;f;FRCCP;;f;;f;8703374;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1137;Culmont-Chalindrey;culmont-chalindrey;8714212;87142125;47.809956;5.443166;;f;FR;f;Europe/Paris;t;FRCCY;CYN;t;;f;8700008;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1139;Capdenac;capdenac;8761310;87613109;44.57830228982263;2.078261375427246;;f;FR;f;Europe/Paris;t;FRCDC;CDC;t;;f;8700190;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1143;Aéroport-Paris-Roissy-Charles-de-Gaulle CDG;aeroport-paris-roissy-charles-de-gaulle-cdg;9903148;;49.00412433626132;2.5707364082336426;;t;FR;f;Europe/Paris;t;FRCDG;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;Flughafen;Airport;Aeropuerto;;Aeroporto;;;;;;;;;;;;
+1137;Culmont-Chalindrey;culmont-chalindrey;8714212;87142125;47.809956;5.443166;;f;FR;f;Europe/Paris;t;FRCCY;CYN;t;;f;8700008;f;;f;;f;;f;;;f;;f;8700009;f;;f;f;;;;;;;;;;;;;;;;;;
+1139;Capdenac;capdenac;8761310;87613109;44.57830228982263;2.078261375427246;;f;FR;f;Europe/Paris;t;FRCDC;CDC;t;;f;8700190;f;;f;;f;;f;;;f;;f;8700522;f;;f;f;;;;;;;;;;;;;;;;;;
+1143;Aéroport-Paris-Roissy-Charles-de-Gaulle CDG;aeroport-paris-roissy-charles-de-gaulle-cdg;9903148;;49.00412433626132;2.5707364082336426;;t;FR;f;Europe/Paris;t;FRCDG;;t;;f;;f;;f;;f;;f;;;f;;f;8700610;f;;f;t;;Flughafen;Airport;Aeropuerto;;Aeroporto;;;;;;;;;;;;
 1144;Aéroport-Paris-Roissy-Charles-de-Gaulle CDG;aeroport-paris-roissy-charles-de-gaulle-cdg;8727149;87001479;49.004047;2.57113;1143;f;FR;t;Europe/Paris;f;FRMLW;RYT;t;MLW;f;8704997;f;;f;MLW;t;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 1150;Coudekerque-Branche;coudekerque-branche;8728140;87281402;51.0333330000;2.4000000000;;f;FR;f;Europe/Paris;t;FRCDK;;t;;f;8700890;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1151;Château-du-Loir;chateau-du-loir;8739660;87396606;47.6952704158369;0.41825294494628906;4832;f;FR;t;Europe/Paris;t;FRCDL;CDL;t;;f;8700210;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1151;Château-du-Loir;chateau-du-loir;8739660;87396606;47.6952704158369;0.41825294494628906;4832;f;FR;t;Europe/Paris;t;FRCDL;CDL;t;;f;8700210;f;;f;;f;;f;;;f;;f;8700726;f;;f;f;;;;;;;;;;;;;;;;;;
 1159;Nanteuil-le-Haudouin;nanteuil-le-haudouin;8727157;;49.1333330000;2.8000000000;;f;FR;f;Europe/Paris;t;FRCDU;;t;;f;8704083;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1160;Ormoy-Villers;ormoy-villers;8727158;;49.2000000000;2.8333330000;;f;FR;f;Europe/Paris;t;FRCDV;;t;;f;8704156;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1161;Crépy-en-Valois;crepy-en-valois;8727159;;49.23107155166836;2.8865182399749756;;f;FR;f;Europe/Paris;t;FRCDW;;t;;f;8700387;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Крепи-ан-Валуа;;;瓦卢瓦地区克雷皮
@@ -921,42 +921,42 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1177;Courteuil;courteuil;8727211;87272112;49.2000000000;2.5333330000;;f;FR;f;Europe/Paris;t;FRCEO;;t;;f;8703177;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1178;St-Nicolas-Aumont;st-nicolas-aumont;8727212;87272120;49.202097;2.549574;;f;FR;f;Europe/Paris;t;FRCEP;;t;;f;8704113;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1179;Cannes;cannes;;;43.5500000000;7.0166670000;;t;FR;f;Europe/Paris;f;FRCEQ;;t;;f;;f;spszz8;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-1180;Cannes;cannes;8775762;87757625;43.554192;7.020323;1179;f;FR;t;Europe/Paris;t;FRJCA;CAN;t;JCA;t;8700144;f;;f;;f;8775762;t;;;f;;f;;f;;f;t;;;;;;;;;;;カンヌ;칸;;;Канны;;;戛纳
+1180;Cannes;cannes;8775762;87757625;43.554192;7.020323;1179;f;FR;t;Europe/Paris;t;FRJCA;CAN;t;JCA;t;8700144;f;;f;;f;8775762;t;;;f;;f;8700285;f;;f;t;;;;;;;;;;;カンヌ;칸;;;Канны;;;戛纳
 1181;Cannes—La Bocca;cannes-la-bocca;8775761;87757617;43.548673;6.98673;1179;f;FR;f;Europe/Paris;t;FRIBH;;t;;f;8700911;f;;f;;f;8775761;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1182;St-Jean-le-Centenier;st-jean-le-centenier;8776471;87764712;44.5833330000;4.5333330000;;f;FR;f;Europe/Paris;t;FRCES;;t;;f;8705223;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1183;Cholet;cholet;8748430;87484303;47.06602950031552;-0.8701086044311522;;f;FR;f;Europe/Paris;t;FRCET;CHT;t;;f;8703103;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 1185;Longueil-Annel;longueil-annel;8727219;87272195;49.4666670000;2.8666670000;;f;FR;f;Europe/Paris;t;FRCEV;;t;;f;8701423;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1187;Corcy;corcy;8727228;87272286;49.25510341721897;3.2156896591186523;;f;FR;f;Europe/Paris;t;FRCEY;;t;;f;8700846;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1188;Paris-Gare-du-Nord-2;paris-gare-du-nord-2;8727401;;;;4916;f;FR;f;Europe/Paris;f;FRCEZ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1193;Clermont-Ferrand;clermont-ferrand;8773400;87734004;45.7788976778522;3.10063362121582;1557;f;FR;t;Europe/Paris;t;FRCFE;CLF;t;;f;8700038;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;クレルモン＝フェラン;클레르몽페랑;;;Клермон-Ферран;;;克莱蒙费朗
-1198;Conflans—Jarny;conflans-jarny;8719266;87192666;49.166482;5.868113;;f;FR;f;Europe/Paris;t;FRCFJ;;t;;f;8700277;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1193;Clermont-Ferrand;clermont-ferrand;8773400;87734004;45.7788976778522;3.10063362121582;1557;f;FR;t;Europe/Paris;t;FRCFE;CLF;t;;f;8700038;f;;f;;f;;f;;;f;;f;8700046;f;;f;t;;;;;;;;;;;クレルモン＝フェラン;클레르몽페랑;;;Клермон-Ферран;;;克莱蒙费朗
+1198;Conflans—Jarny;conflans-jarny;8719266;87192666;49.166482;5.868113;;f;FR;f;Europe/Paris;t;FRCFJ;;t;;f;8700277;f;;f;;f;;f;;;f;;f;8700952;f;;f;f;;;;;;;;;;;;;;;;;;
 1205;Laigneville;laigneville;8727620;87276204;49.292623235663456;2.4493396282196045;;f;FR;f;Europe/Paris;t;FRCFQ;;t;;f;8701349;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1206;Caen;caen;8744400;87444000;49.17648541406607;-0.3475284576416015;;f;FR;f;Europe/Paris;t;FRCFR;CAE;t;;f;8700223;f;gbxxzd;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;カーン;캉;;;Кан;;;卡昂
+1206;Caen;caen;8744400;87444000;49.17648541406607;-0.3475284576416015;;f;FR;f;Europe/Paris;t;FRCFR;CAE;t;;f;8700223;f;gbxxzd;t;;f;;f;;;f;;f;8700771;f;;f;t;;;;;;;;;;;カーン;캉;;;Кан;;;卡昂
 1207;Liancourt-Rantigny;liancourt-rantigny;8727621;87276212;49.324791;2.445587;;f;FR;f;Europe/Paris;t;FRCFS;;t;;f;8701398;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1213;Orry-la-Ville—Coye;orry-la-ville-coye;8727627;;49.138076;2.490398;;f;FR;f;Europe/Paris;t;FRCFY;;t;;f;8701713;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1215;Longueil-Ste-Marie;longueil-ste-marie;8727630;87276303;49.34250274925314;2.7175498008728027;;f;FR;f;Europe/Paris;t;FRCGA;;t;;f;8701369;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1216;Chevrières;chevrieres;8727631;87276311;49.3500000000;2.6833330000;;f;FR;f;Europe/Paris;t;FRCGB;;t;;f;8700983;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1217;Pont-Ste-Maxence;pont-ste-maxence;8727632;87276329;49.309847588038345;2.602837085723877;;f;FR;f;Europe/Paris;t;FRCGC;PXE;t;;f;8701786;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1217;Pont-Ste-Maxence;pont-ste-maxence;8727632;87276329;49.309847588038345;2.602837085723877;;f;FR;f;Europe/Paris;t;FRCGC;PXE;t;;f;8701786;f;;f;;f;;f;;;f;;f;8700863;f;;f;f;;;;;;;;;;;;;;;;;;
 1219;Rieux-Angicourt;rieux-angicourt;8727635;87276352;49.297832;2.519874;;f;FR;f;Europe/Paris;t;FRCGE;;t;;f;8701909;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1221;Villers-St-Paul;villers-st-paul;8727637;87276378;49.282461;2.489589;;f;FR;f;Europe/Paris;t;FRCGG;;t;;f;8702229;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1239;Chagny;chagny;8771357;87713578;46.90746283013065;4.74958062171936;;f;FR;f;Europe/Paris;t;FRCGY;CHY;t;;f;8700160;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1239;Chagny;chagny;8771357;87713578;46.90746283013065;4.74958062171936;;f;FR;f;Europe/Paris;t;FRCGY;CHY;t;;f;8700160;f;;f;;f;;f;;;f;;f;8700344;f;;f;f;;;;;;;;;;;;;;;;;;
 1243;Montataire;montataire;8727661;87276618;49.2666670000;2.4333330000;;f;FR;f;Europe/Paris;t;FRCHC;;t;;f;8701618;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1250;Bornel—Belle-Église;bornel-belle-eglise;8727671;87276717;49.194186;2.207382;;f;FR;f;Europe/Paris;t;FRCHK;;t;;f;8700671;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1250;Bornel—Belle-Église;bornel-belle-eglise;8727671;87276717;49.194186;2.207382;;f;FR;f;Europe/Paris;t;FRCHK;;t;;f;8700671;f;;f;;f;;f;;;f;;f;8700505;f;;f;f;;;;;;;;;;;;;;;;;;
 1251;Chaulnes;chaulnes;8731347;87313478;49.807409026641054;2.8010308742523193;;f;FR;f;Europe/Paris;t;FRCHL;;t;;f;8700856;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1252;Chambly;chambly;8727672;87276725;49.16348016683021;2.2403687238693237;;f;FR;f;Europe/Paris;t;FRCHM;;t;;f;8700909;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1252;Chambly;chambly;8727672;87276725;49.16348016683021;2.2403687238693237;;f;FR;f;Europe/Paris;t;FRCHM;;t;;f;8700909;f;;f;;f;;f;;;f;;f;8700660;f;;f;f;;;;;;;;;;;;;;;;;;
 1253;Le Meux-la-Croix-St-Ouen;le-meux-la-croix-st-ouen;8727673;87276733;49.359291;2.752937;;f;FR;f;Europe/Paris;t;FRCHN;;t;;f;8701638;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1254;Thourotte;thourotte;8727674;87276741;49.476142;2.883164;;f;FR;f;Europe/Paris;t;FRCHO;;t;;f;8702134;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1256;Ribécourt;ribecourt;8727676;87276766;49.5166670000;2.9166670000;;f;FR;f;Europe/Paris;t;FRCHQ;;t;;f;8701843;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1257;Châteauroux;chateauroux;8759700;87597005;46.80948881144354;1.6996622085571287;1503;f;FR;t;Europe/Paris;t;FRCHR;CTX;t;;f;8700181;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;シャトールー;샤토루;;;Шатору;;;沙托鲁
+1257;Châteauroux;chateauroux;8759700;87597005;46.80948881144354;1.6996622085571287;1503;f;FR;t;Europe/Paris;t;FRCHR;CTX;t;;f;8700181;f;;f;;f;;f;;;f;;f;8700456;f;;f;t;;;;;;;;;;;シャトールー;샤토루;;;Шатору;;;沙托鲁
 1258;Ourscamps;ourscamps;8727677;87276774;49.53423;2.953963;;f;FR;f;Europe/Paris;t;FRCHS;;t;;f;8701704;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1259;Noyon;noyon;8727678;87276782;49.5773008727336;3.006305694580078;;f;FR;f;Europe/Paris;t;FRCHT;NOY;t;;f;8700247;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ノワイヨン;;;;Нуайон;;;努瓦永
+1259;Noyon;noyon;8727678;87276782;49.5773008727336;3.006305694580078;;f;FR;f;Europe/Paris;t;FRCHT;NOY;t;;f;8700247;f;;f;;f;;f;;;f;;f;8700865;f;;f;f;;;;;;;;;;;ノワイヨン;;;;Нуайон;;;努瓦永
 1261;Avilly—St-Léonard;avilly-st-leonard;8727826;;49.2000000000;2.5333330000;;f;FR;f;Europe/Paris;t;FRCHX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1262;Plainval;plainval;8727910;87279109;49.5333330000;2.4500000000;;f;FR;f;Europe/Paris;t;FRCHY;;t;;f;8701776;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1263;Domfront Domélien;domfront-domelien;8727911;87279117;49.603052;2.527254;;f;FR;f;Europe/Paris;t;FRCHZ;;t;;f;8701030;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1264;Bergues;bergues;8728110;87281105;50.96886992020453;2.4255108833312984;;f;FR;f;Europe/Paris;t;FRCIE;;t;;f;8700707;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;Sint-Winoksbergen;;;;;;;;Берг;;;贝尔格
+1264;Bergues;bergues;8728110;87281105;50.96886992020453;2.4255108833312984;;f;FR;f;Europe/Paris;t;FRCIE;;t;;f;8700707;f;;f;;f;;f;;;f;;f;8700426;f;;f;f;;;;;;;Sint-Winoksbergen;;;;;;;;Берг;;;贝尔格
 1265;Esquelbecq;esquelbecq;8728111;87281113;50.8833330000;2.4333330000;;f;FR;f;Europe/Paris;t;FRCIF;;t;;f;8701084;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1266;Arnèke;arneke;8728112;87281121;50.83152250898692;2.408280372619629;;f;FR;f;Europe/Paris;t;FRCIG;;t;;f;8700626;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1267;Cassel;cassel;8728113;87281139;50.78756;2.459781;;f;FR;f;Europe/Paris;t;FRCIH;;t;;f;8700831;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;Kassel;;;;;;;;;;;
+1267;Cassel;cassel;8728113;87281139;50.78756;2.459781;;f;FR;f;Europe/Paris;t;FRCIH;;t;;f;8700831;f;;f;;f;;f;;;f;;f;8700424;f;;f;f;;;;;;;Kassel;;;;;;;;;;;
 1268;Gravelines;gravelines;8728124;87281246;50.9833330000;2.1166670000;;f;FR;f;Europe/Paris;t;FRCIJ;;t;;f;8701231;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Gravelinas;;;Grevelingen;;;;グラヴリーヌ;;;;Гравлин;;;格拉沃利讷
 1269;Bourbourg;bourbourg;8728127;87281279;50.9500000000;2.2000000000;;f;FR;f;Europe/Paris;t;FRCIK;;t;;f;8700672;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1270;Grande-Synthe;grande-synthe;8728131;87281311;51.0125000000;2.2833330000;;f;FR;f;Europe/Paris;t;FRCIL;;t;;f;8701213;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -991,7 +991,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1306;Pont-de-Bois;pont-de-bois;8728683;87286831;50.624235;3.128048;;f;FR;f;Europe/Paris;t;FRCKN;;t;;f;8700515;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1307;Lesquin;lesquin;8728684;87286849;50.5833330000;3.1166670000;;f;FR;f;Europe/Paris;t;FRCKO;;t;;f;8701450;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1308;Annappes;annappes;8728685;87286856;50.622833;3.14759;;f;FR;f;Europe/Paris;t;FRCKP;;t;;f;8700508;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1309;Baisieux;baisieux;8728687;87286872;50.6000000000;3.2500000000;;f;FR;f;Europe/Paris;t;FRCKQ;;t;;f;8700510;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1309;Baisieux;baisieux;8728687;87286872;50.6000000000;3.2500000000;;f;FR;f;Europe/Paris;t;FRCKQ;;t;;f;8700510;f;;f;;f;;f;;;f;;f;8700220;f;;f;f;;;;;;;;;;;;;;;;;;
 1313;Mouscron;mouscron;8728698;;;;;f;BE;f;Europe/Brussels;f;FRCKU;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;Moeskroen;;;;;;;;;;;
 1314;Lezennes;lezennes;8728710;87287102;50.6166670000;3.1166670000;;f;FR;f;Europe/Paris;t;FRCKY;;t;;f;8700514;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1315;Mont-de-Terre;mont-de-terre;8728712;87287128;50.632766;3.070706;;f;FR;f;Europe/Paris;t;FRCLA;;t;;f;8701502;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1001,42 +1001,42 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1319;Marquette;marquette;8728716;87287169;50.6724;3.0510;;f;FR;f;Europe/Paris;t;FRCLE;;t;;f;8701593;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1320;Deûlémont;deulemont;8728718;87287185;50.7333330000;2.9500000000;;f;FR;f;Europe/Paris;t;FRCLG;;t;;f;8701011;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1321;Ste-Marguerite;ste-marguerite;8728719;87287193;50.735684;3.006388;;f;FR;f;Europe/Paris;t;FRCLH;;t;;f;8701067;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1322;Clisson;clisson;8748144;87481440;47.085907209788495;-1.2865322828292847;;f;FR;f;Europe/Paris;t;FRCLI;CLI;t;;f;8700910;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Клиссон;;;克利松
+1322;Clisson;clisson;8748144;87481440;47.085907209788495;-1.2865322828292847;;f;FR;f;Europe/Paris;t;FRCLI;CLI;t;;f;8700910;f;;f;;f;;f;;;f;;f;8700672;f;;f;f;;;;;;;;;;;;;;;Клиссон;;;克利松
 1323;Anstaing;anstaing;8728721;87287219;50.6000000000;3.2000000000;;f;FR;f;Europe/Paris;t;FRCLK;;t;;f;8700631;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1324;Bouvines;bouvines;8728723;87287235;50.5833330000;3.1833330000;;f;FR;f;Europe/Paris;t;FRCLM;;t;;f;8700786;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1325;Cobrieux;cobrieux;8728724;87287243;50.5500000000;3.2333330000;;f;FR;f;Europe/Paris;t;FRCLN;;t;;f;8700920;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1326;Lille Porte de Douai;lille-porte-de-douai;8728725;87287250;50.6333330000;3.0666670000;4652;f;FR;f;Europe/Paris;t;FRCLO;;t;;f;8701434;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Lilla;Rijsel;;;;リール;릴;;;Лилль;;;里尔
 1328;Ennevelin;ennevelin;8728727;87287276;50.5333330000;3.1333330000;;f;FR;f;Europe/Paris;t;FRCLQ;;t;;f;8701070;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1329;Challans;challans;8748139;87481390;46.843975624468435;-1.8717098236083982;;f;FR;f;Europe/Paris;t;FRCLS;CLS;t;;f;8703015;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;沙朗
+1329;Challans;challans;8748139;87481390;46.843975624468435;-1.8717098236083982;;f;FR;f;Europe/Paris;t;FRCLS;CLS;t;;f;8703015;f;;f;;f;;f;;;f;;f;8700785;f;;f;t;;;;;;;;;;;;;;;;;;沙朗
 1330;Nortkerque;nortkerque;8728729;87287292;50.8833330000;2.0333330000;;f;FR;f;Europe/Paris;t;FRCLT;;t;;f;8701670;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1331;Ruminghem;ruminghem;8728730;87287300;50.8666670000;2.1500000000;;f;FR;f;Europe/Paris;t;FRCLU;;t;;f;8701877;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1332;Casino—Lacroix-Laval;casino-lacroix-laval;8720855;87208553;45.787877;4.730807;4862;f;FR;f;Europe/Paris;t;FRCLV;CCL;t;;f;8705093;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1335;Recquignies;recquignies;8729502;87295022;50.2839650000;4.0372180000;;f;FR;f;Europe/Paris;t;FRCMB;;t;;f;8701856;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1337;Anor;anor;8729505;87295055;50.0000000000;4.1000000000;;f;FR;f;Europe/Paris;t;FRCMD;;t;;f;8700617;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1338;Charmes-sur-Rhône;charmes-sur-rhone;8776151;87761510;44.8666670000;4.8333330000;;f;FR;f;Europe/Paris;t;FRCME;;t;;f;8705224;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1339;Chambéry Challes-les-Eaux;chambery-challes-les-eaux;8774100;87741009;45.571498;5.919756;26828;f;FR;f;Europe/Paris;t;FRCMF;CRL;t;CMF;t;8700055;f;;f;;f;8774100;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-1340;Le Cateau;le-cateau;8729522;87295220;50.1000000000;3.5500000000;;f;FR;f;Europe/Paris;t;FRCMG;LCA;t;;f;8700824;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1339;Chambéry Challes-les-Eaux;chambery-challes-les-eaux;8774100;87741009;45.571498;5.919756;26828;f;FR;f;Europe/Paris;t;FRCMF;CRL;t;CMF;t;8700055;f;;f;;f;8774100;f;;;f;;f;8700066;f;;f;t;;;;;;;;;;;;;;;;;;
+1340;Le Cateau;le-cateau;8729522;87295220;50.1000000000;3.5500000000;;f;FR;f;Europe/Paris;t;FRCMG;LCA;t;;f;8700824;f;;f;;f;;f;;;f;;f;8700872;f;;f;f;;;;;;;;;;;;;;;;;;
 1341;Louvroil;louvroil;8729553;87295535;50.2642720000;3.9627170000;;f;FR;f;Europe/Paris;t;FRCMI;;t;;f;8701408;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1342;Hautmont;hautmont;8729556;87295568;50.2507720000;3.9214320000;;f;FR;f;Europe/Paris;t;FRCMJ;;t;;f;8701272;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1343;Landrecies;landrecies;8729564;87295642;50.1333330000;3.7000000000;;f;FR;f;Europe/Paris;t;FRCMK;;t;;f;8700501;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1342;Hautmont;hautmont;8729556;87295568;50.2507720000;3.9214320000;;f;FR;f;Europe/Paris;t;FRCMJ;;t;;f;8701272;f;;f;;f;;f;;;f;;f;8700874;f;;f;f;;;;;;;;;;;;;;;;;;
+1343;Landrecies;landrecies;8729564;87295642;50.1333330000;3.7000000000;;f;FR;f;Europe/Paris;t;FRCMK;;t;;f;8700501;f;;f;;f;;f;;;f;;f;8700873;f;;f;f;;;;;;;;;;;;;;;;;;
 1344;Sains-du-Nord;sains-du-nord;8729570;87295709;50.1000000000;4.0000000000;;f;FR;f;Europe/Paris;t;FRCML;;t;;f;8701944;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1345;Avesnelles;avesnelles;8729572;87295725;50.1166670000;3.9500000000;;f;FR;f;Europe/Paris;t;FRCMN;;t;;f;8700651;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1346;Avesnes;avesnes;8729573;87295733;50.12683762541366;3.9331912994384766;;f;FR;f;Europe/Paris;t;FRCMO;;t;;f;8700239;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1346;Avesnes;avesnes;8729573;87295733;50.12683762541366;3.9331912994384766;;f;FR;f;Europe/Paris;t;FRCMO;;t;;f;8700239;f;;f;;f;;f;;;f;;f;8700852;f;;f;f;;;;;;;;;;;;;;;;;;
 1347;Dompierre;dompierre;8729577;87295774;50.1424000000;3.8636000000;;f;FR;f;Europe/Paris;t;FRCMP;;t;;f;8701038;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1348;Velle-le-Châtel;velle-le-chatel;8718542;87185421;47.602035;6.047214;;f;FR;f;Europe/Paris;t;FRCMQ;;t;;f;8702177;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1349;Colmar;colmar;;;48.0833330000;7.3666670000;;t;FR;f;Europe/Paris;f;FRCMR;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 1350;Leval;leval;8729579;87295790;50.1833330000;3.8333330000;;f;FR;f;Europe/Paris;t;FRCMS;;t;;f;8701347;f;;f;;f;;f;;;f;;f;;f;;f;f;;Frankreich;France;Francia;France;Francia;Frankrijk;;;;;;;;;;;
 1351;Berlaimont;berlaimont;8729580;87295808;50.1977331836537;3.8109683990478516;;f;FR;f;Europe/Paris;t;FRCMT;;t;;f;8700768;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1352;Le Quesnoy;le-quesnoy;8729585;87295857;50.2503607826595;3.645529747009277;;f;FR;f;Europe/Paris;t;FRCMU;;t;;f;8701829;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1352;Le Quesnoy;le-quesnoy;8729585;87295857;50.2503607826595;3.645529747009277;;f;FR;f;Europe/Paris;t;FRCMU;;t;;f;8701829;f;;f;;f;;f;;;f;;f;8700913;f;;f;f;;;;;;;;;;;;;;;;;;
 1354;Quevy Frontière;quevy-frontiere;8729592;;;;6003;f;BE;f;Europe/Brussels;f;FRCMX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1355;Marle-sur-Serre;marle-sur-serre;8729609;87296095;49.747194;3.769572;;f;FR;f;Europe/Paris;t;FRCNA;;t;;f;8701544;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1356;Vervins;vervins;8729612;87296129;49.830101;3.893569;;f;FR;f;Europe/Paris;t;FRCNC;;t;;f;8702244;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1357;Origny-en-Thiérache;origny-en-thierache;8729614;87296145;49.89065322749145;4.024128913879394;;f;FR;f;Europe/Paris;t;FRCND;;t;;f;8701720;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1358;Crépy-Couvron;crepy-couvron;8729615;87296152;49.623376;3.516768;;f;FR;f;Europe/Paris;t;FRCNE;;t;;f;8700933;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1359;Cognac;cognac;8749144;87491449;45.68446971913285;-0.3259742259979248;;f;FR;f;Europe/Paris;t;FRCNG;COG;t;;f;8702337;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;Коньяк;Konjak;;
+1359;Cognac;cognac;8749144;87491449;45.68446971913285;-0.3259742259979248;;f;FR;f;Europe/Paris;t;FRCNG;COG;t;;f;8702337;f;;f;;f;;f;;;f;;f;8700578;f;;f;t;;;;;;;;;;;;;;;Коньяк;Konjak;;
 1360;Clacy-Mons;clacy-mons;8729617;87296178;49.543777;3.576529;;f;FR;f;Europe/Paris;t;FRCNH;;t;;f;8700907;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1361;Bohain;bohain;8729626;87296269;49.9833330000;3.4500000000;;f;FR;f;Europe/Paris;t;FRCNK;;t;;f;8700752;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1362;Fresnoy-le-Grand;fresnoy-le-grand;8729629;87296293;49.949683887096896;3.432149291038513;;f;FR;f;Europe/Paris;t;FRCNL;;t;;f;8701159;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1361;Bohain;bohain;8729626;87296269;49.9833330000;3.4500000000;;f;FR;f;Europe/Paris;t;FRCNK;;t;;f;8700752;f;;f;;f;;f;;;f;;f;8700868;f;;f;f;;;;;;;;;;;;;;;;;;
+1362;Fresnoy-le-Grand;fresnoy-le-grand;8729629;87296293;49.949683887096896;3.432149291038513;;f;FR;f;Europe/Paris;t;FRCNL;;t;;f;8701159;f;;f;;f;;f;;;f;;f;8700867;f;;f;f;;;;;;;;;;;;;;;;;;
 1363;Athiès-sous-Laon;athies-sous-laon;8729632;87296327;49.610126;3.610166;;f;FR;f;Europe/Paris;t;FRCNM;;t;;f;8700632;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1364;Samoussy;samoussy;8729634;87296343;49.583932;3.730954;;f;FR;f;Europe/Paris;t;FRCNO;;t;;f;8702005;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1366;Bucy-Les-Pierrepont;bucy-les-pierrepont;8729636;87296368;49.645058;3.898882;;f;FR;f;Europe/Paris;t;FRCNQ;;t;;f;8700685;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1047,8 +1047,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1372;Appilly;appilly;8729645;87296459;49.5833330000;3.1166670000;;f;FR;f;Europe/Paris;t;FRCNW;;t;;f;8700623;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1373;Anizy-Pinon;anizy-pinon;8729656;87296566;49.496008;3.448765;;f;FR;f;Europe/Paris;t;FRCNY;;t;;f;8700597;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1374;Versigny;versigny;8729660;87296608;49.657517;3.433196;;f;FR;f;Europe/Paris;t;FRCNZ;;t;;f;8702230;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1375;Chauny;chauny;8729661;87296616;49.61105058707904;3.2239937782287598;;f;FR;f;Europe/Paris;t;FRCOA;CNY;t;;f;8700336;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1377;La Fère;la-fere;8729663;87296632;49.6666670000;3.3666670000;;f;FR;f;Europe/Paris;t;FRCOC;;t;;f;8701123;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1375;Chauny;chauny;8729661;87296616;49.61105058707904;3.2239937782287598;;f;FR;f;Europe/Paris;t;FRCOA;CNY;t;;f;8700336;f;;f;;f;;f;;;f;;f;8700866;f;;f;f;;;;;;;;;;;;;;;;;;
+1377;La Fère;la-fere;8729663;87296632;49.6666670000;3.3666670000;;f;FR;f;Europe/Paris;t;FRCOC;;t;;f;8701123;f;;f;;f;;f;;;f;;f;8700983;f;;f;f;;;;;;;;;;;;;;;;;;
 1378;Flavy-le-Martel;flavy-le-martel;8729687;87296871;49.7166670000;3.2000000000;;f;FR;f;Europe/Paris;t;FRCOD;;t;;f;8701136;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1380;Collonges—Fontaines;collonges-fontaines;8772122;87721225;45.8166670000;4.8333330000;;f;FR;f;Europe/Paris;t;FRCOF;COF;t;;f;8700923;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1382;Viry-Noureuil;viry-noureuil;8729705;87297051;49.627529;3.250427;;f;FR;f;Europe/Paris;t;FRCOI;;t;;f;8702218;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1057,7 +1057,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1386;Verneuil-sur-Serre;verneuil-sur-serre;8729711;87297119;49.64867069085164;3.6677062511444096;;f;FR;f;Europe/Paris;t;FRCON;;t;;f;8704809;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1387;Dercy-Froidmont;dercy-froidmont;8729714;87297143;49.702544;3.691842;;f;FR;f;Europe/Paris;t;FRCOQ;;t;;f;8701008;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1389;Voyenne;voyenne;8729715;87297150;49.726069;3.720257;;f;FR;f;Europe/Paris;t;FRCOS;;t;;f;8702255;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1391;Coutras;coutras;8758451;87584516;45.036519226925556;-0.13129949569702148;;f;FR;f;Europe/Paris;t;FRCOU;COU;t;;f;8700184;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1391;Coutras;coutras;8758451;87584516;45.036519226925556;-0.13129949569702148;;f;FR;f;Europe/Paris;t;FRCOU;COU;t;;f;8700184;f;;f;;f;;f;;;f;;f;8700465;f;;f;f;;;;;;;;;;;;;;;;;;
 1392;Gizy;gizy;8729717;87297176;49.597092;3.770777;;f;FR;f;Europe/Paris;t;FRCOV;;t;;f;8701235;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1393;Chivres-en-Laonnois;chivres-en-laonnois;8729719;87297192;49.632761;3.843346;;f;FR;f;Europe/Paris;t;FRCOW;;t;;f;8700821;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1394;Chaourse;chaourse;8729720;87297200;49.70405588474763;3.998165130615234;;f;FR;f;Europe/Paris;t;FRCOX;;t;;f;8700927;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1080,28 +1080,28 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1415;Royaucourt;royaucourt;8729989;;49.6000000000;2.5333330000;;f;FR;f;Europe/Paris;f;FRCQC;;f;;f;8701913;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1416;Ste-Geneviève;ste-genevieve;8729990;87299909;49.71968;4.07414;;f;FR;f;Europe/Paris;t;FRCQD;;t;;f;8701968;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1417;Calais;calais;8724851;;50.95345262552378;1.850595474243164;;t;FR;f;Europe/Paris;t;FRCQF;;t;;f;8796004;f;u113f5;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;Kales;;;;カレー;칼레;;;Кале;;;加来
-1419;Calais Fréthun;calais-frethun;8728107;87281071;50.90195702840237;1.8114298582077024;1417;f;FR;f;Europe/Paris;t;FRSTH;FHS;t;;f;8701132;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;Kales;;;;カレー;칼레;;;Кале;;;加来
+1419;Calais Fréthun;calais-frethun;8728107;87281071;50.90195702840237;1.8114298582077024;1417;f;FR;f;Europe/Paris;t;FRSTH;FHS;t;;f;8701132;f;;f;;f;;f;;;f;;f;8700804;f;;f;t;;;;;;;Kales;;;;カレー;칼레;;;Кале;;;加来
 1420;Villers-Carbonnel;villers-carbonnel;8729992;87299925;49.872027;2.893357;;f;FR;f;Europe/Paris;t;FRCQG;;t;;f;8702154;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1421;Guer—Coëtquidan;guer-coetquidan;8733520;87335208;47.984355;-2.176522;;f;FR;f;Europe/Paris;t;FRCQI;;t;;f;8705227;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1422;Longueau;longueau;8731304;87313049;49.86373025573089;2.35257089138031;;f;FR;f;Europe/Paris;t;FRCQL;LUA;t;;f;8700188;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+1422;Longueau;longueau;8731304;87313049;49.86373025573089;2.35257089138031;;f;FR;f;Europe/Paris;t;FRCQL;LUA;t;;f;8700188;f;;f;;f;;f;;;f;;f;8700488;f;;f;t;;;;;;;;;;;;;;;;;;
 1423;Corbie;corbie;8731305;87313056;49.91174414973649;2.4995505809783936;;f;FR;f;Europe/Paris;t;FRCQM;;t;;f;8700838;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1424;Méricourt-Ribemont;mericourt-ribemont;8731306;87313064;49.955654;2.572739;;f;FR;f;Europe/Paris;t;FRCQN;;t;;f;8701581;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1425;Albert;albert;8731307;87313072;50.00551179641242;2.6444756984710693;;f;FR;f;Europe/Paris;t;FRCQO;;t;;f;8700599;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1425;Albert;albert;8731307;87313072;50.00551179641242;2.6444756984710693;;f;FR;f;Europe/Paris;t;FRCQO;;t;;f;8700599;f;;f;;f;;f;;;f;;f;8700881;f;;f;f;;;;;;;;;;;;;;;;;;
 1426;Picquigny;picquigny;8731310;87313106;49.94608353671535;2.1431922912597656;;f;FR;f;Europe/Paris;t;FRCQP;PIQ;t;;f;8701760;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1427;Hangest;hangest;8731311;87313114;49.9833330000;2.0666670000;;f;FR;f;Europe/Paris;t;FRCQQ;HAS;t;;f;8701258;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1428;Longpré-les-Corps-Saints;longpre-les-corps-saints;8731312;87313122;50.0166670000;1.9833330000;;f;FR;f;Europe/Paris;t;FRCQR;LGP;t;;f;8701437;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1428;Longpré-les-Corps-Saints;longpre-les-corps-saints;8731312;87313122;50.0166670000;1.9833330000;;f;FR;f;Europe/Paris;t;FRCQR;LGP;t;;f;8701437;f;;f;;f;;f;;;f;;f;8700849;f;;f;f;;;;;;;;;;;;;;;;;;
 1429;Pont-Remy;pont-remy;8731313;87313130;50.0500000000;1.9166670000;;f;FR;f;Europe/Paris;t;FRCQS;PRM;t;;f;8701788;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1430;La Faloise;la-faloise;8731323;87313239;49.7000000000;2.3500000000;;f;FR;f;Europe/Paris;t;FRCQU;;t;;f;8701104;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1431;Breteuil Embranchement;breteuil-embranchement;8731324;87313247;49.6333330000;2.3000000000;;f;FR;f;Europe/Paris;t;FRCQV;;t;;f;8700762;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1432;Gannes;gannes;8731326;87313262;49.5666670000;2.4333330000;;f;FR;f;Europe/Paris;t;FRCQW;;t;;f;8701173;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1433;St-Rémy-en-l’Eau;st-remy-en-leau;8731328;87313288;49.4833330000;2.4333330000;;f;FR;f;Europe/Paris;t;FRCQX;;t;;f;8702080;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1434;Avrechy;avrechy;8731329;87313296;49.4500000000;2.4333330000;;f;FR;f;Europe/Paris;t;FRCQY;;t;;f;8700650;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1435;Clermont-de-l’Oise;clermont-de-loise;8731330;87313304;49.385495;2.4179;;f;FR;f;Europe/Paris;t;FRCQZ;CDO;t;;f;8700855;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1435;Clermont-de-l’Oise;clermont-de-loise;8731330;87313304;49.385495;2.4179;;f;FR;f;Europe/Paris;t;FRCQZ;CDO;t;;f;8700855;f;;f;;f;;f;;;f;;f;8700877;f;;f;f;;;;;;;;;;;;;;;;;;
 1436;Moreuil;moreuil;8731332;87313320;49.7666670000;2.4833330000;;f;FR;f;Europe/Paris;t;FRCRA;;t;;f;8701582;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1437;Hargicourt-Pierrepont;hargicourt-pierrepont;8731333;87313338;49.71379;2.531856;;f;FR;f;Europe/Paris;t;FRCRB;;t;;f;8701257;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1438;Tricot;tricot;8731335;87313353;49.562000452943494;2.5815510749816895;;f;FR;f;Europe/Paris;t;FRCRC;;t;;f;8702123;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1439;St-Georges-les-Bains—Châteaurouge;st-georges-les-bains-chateaurouge;8733696;87336966;44.848585;4.826856;;f;FR;f;Europe/Paris;t;FRCRD;;t;;f;8705228;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1440;Crest;crest;8776178;87761783;44.7301461637429;5.016084909439087;;f;FR;f;Europe/Paris;t;FRCRE;CRE;t;;f;8702521;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1440;Crest;crest;8776178;87761783;44.7301461637429;5.016084909439087;;f;FR;f;Europe/Paris;t;FRCRE;CRE;t;;f;8702521;f;;f;;f;;f;;;f;;f;8700193;f;;f;f;;;;;;;;;;;;;;;;;;
 1441;Namps-Quevauvillers;namps-quevauvillers;8731337;87313379;49.808204;2.105282;;f;FR;f;Europe/Paris;t;FRCRF;;t;;f;8701680;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1442;Estrées-St-Denis;estrees-st-denis;8731338;87313387;49.4333330000;2.6500000000;;f;FR;f;Europe/Paris;t;FRCRG;;t;;f;8701080;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1443;Poix-de-Picardie;poix-de-picardie;8731339;87313395;49.7833330000;1.9833330000;;f;FR;f;Europe/Paris;t;FRCRH;;t;;f;8701746;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1120,12 +1120,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1457;Hermes-Berthecourt;hermes-berthecourt;8731358;87313585;49.354374;2.241622;;f;FR;f;Europe/Paris;t;FRCRW;;t;;f;8701239;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1458;Villers-St-Sépulcre;villers-st-sepulcre;8731359;87313593;49.368056;2.220515;;f;FR;f;Europe/Paris;t;FRCRX;;t;;f;8702211;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1459;Rochy-Condé;rochy-conde;8731360;87313601;49.4166670000;2.1833330000;;f;FR;f;Europe/Paris;t;FRCRY;;t;;f;8701912;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1460;Méru;meru;8731366;87313668;49.23237465738512;2.1322327852249146;;f;FR;f;Europe/Paris;t;FRCSA;;t;;f;8701594;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1460;Méru;meru;8731366;87313668;49.23237465738512;2.1322327852249146;;f;FR;f;Europe/Paris;t;FRCSA;;t;;f;8701594;f;;f;;f;;f;;;f;;f;8700883;f;;f;f;;;;;;;;;;;;;;;;;;
 1461;Laboissière-le-Déluge;laboissiere-le-deluge;8731367;87313676;49.288536640725056;2.136143445968628;;f;FR;f;Europe/Paris;t;FRCSB;;t;;f;8701360;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1462;St-Sulpice-Auteuil;st-sulpice-auteuil;8731368;87313684;49.347417;2.116321;;f;FR;f;Europe/Paris;t;FRCSC;;t;;f;8701939;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1463;Herchies;herchies;8731369;87313692;49.48796338341308;2.010927200317383;;f;FR;f;Europe/Paris;t;FRCSD;HEE;t;;f;8701262;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1464;Milly-sur-Thérain;milly-sur-therain;8731370;87313700;49.5000000000;2.0000000000;;f;FR;f;Europe/Paris;t;FRCSE;MYH;t;;f;8701644;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1465;Creil;creil;8727600;87276006;49.26384892519989;2.4687695503234863;;f;FR;f;Europe/Paris;t;FRCSF;CLH;t;;f;8700072;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;クレイユ;;;;Крей;;;克雷伊
+1465;Creil;creil;8727600;87276006;49.26384892519989;2.4687695503234863;;f;FR;f;Europe/Paris;t;FRCSF;CLH;t;;f;8700072;f;;f;;f;;f;;;f;;f;8700087;f;;f;t;;;;;;;;;;;クレイユ;;;;Крей;;;克雷伊
 1466;St-Omer-en-Chaussée;st-omer-en-chaussee;8731371;87313718;49.5333330000;2.0000000000;;f;FR;f;Europe/Paris;t;FRCSG;SHS;t;;f;8701938;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1467;Marseille-en-Beauvaisis;marseille-en-beauvaisis;8731372;87313726;49.570924;1.954605;;f;FR;f;Europe/Paris;t;FRCSH;MAI;t;;f;8701598;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1468;Grandvilliers;grandvilliers;8731373;87313734;49.6666670000;1.9333330000;;f;FR;f;Europe/Paris;t;FRCSI;GAR;t;;f;8701215;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1133,9 +1133,9 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1470;Aumale;aumale;8731376;87313767;49.7666670000;1.7500000000;;f;FR;f;Europe/Paris;t;FRCSK;;t;;f;8700559;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1471;Crasville-la-Mallet;crasville-la-mallet;8733789;87337899;49.8000000000;0.7166670000;;f;FR;f;Europe/Paris;t;FRCSM;;t;;f;8705229;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1472;Lachapelle-sous-Aubenas;lachapelle-sous-aubenas;8733706;87337063;44.58228;4.346167;;f;FR;f;Europe/Paris;t;FRCSN;;t;;f;8705230;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1473;Blangy-sur-Bresle;blangy-sur-bresle;8731380;87313809;49.93257033003996;1.6258049011230469;;f;FR;f;Europe/Paris;t;FRCSO;;t;;f;8700813;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1474;Longroy—Gamaches;longroy-gamaches;8731381;87313817;49.982487;1.551906;;f;FR;f;Europe/Paris;t;FRCSP;;t;;f;8701384;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1475;Chasse-sur-Rhône;chasse-sur-rhone;8772256;87722561;45.5666670000;4.8166670000;;f;FR;f;Europe/Paris;t;FRCSR;CSR;t;;f;8700963;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1473;Blangy-sur-Bresle;blangy-sur-bresle;8731380;87313809;49.93257033003996;1.6258049011230469;;f;FR;f;Europe/Paris;t;FRCSO;;t;;f;8700813;f;;f;;f;;f;;;f;;f;8700886;f;;f;f;;;;;;;;;;;;;;;;;;
+1474;Longroy—Gamaches;longroy-gamaches;8731381;87313817;49.982487;1.551906;;f;FR;f;Europe/Paris;t;FRCSP;;t;;f;8701384;f;;f;;f;;f;;;f;;f;8700887;f;;f;f;;;;;;;;;;;;;;;;;;
+1475;Chasse-sur-Rhône;chasse-sur-rhone;8772256;87722561;45.5666670000;4.8166670000;;f;FR;f;Europe/Paris;t;FRCSR;CSR;t;;f;8700963;f;;f;;f;;f;;;f;;f;8700429;f;;f;f;;;;;;;;;;;;;;;;;;
 1476;Formerie;formerie;8731383;87313833;49.6500000000;1.7333330000;;f;FR;f;Europe/Paris;t;FRCSS;;t;;f;8701153;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1477;Fouilloy;fouilloy;8731384;87313841;49.7333330000;1.8333330000;;f;FR;f;Europe/Paris;t;FRCST;;t;;f;8701106;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1478;Daours;daours;8731504;87315044;49.9000000000;2.4500000000;;f;FR;f;Europe/Paris;t;FRCSV;;t;;f;8701000;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1158,7 +1158,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1499;Le Castelet;le-castelet;8761154;87611541;42.740759;1.789734;;f;FR;f;Europe/Paris;t;FRCTT;;t;;f;8700947;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1503;Châteauroux;chateauroux;;;46.8166670000;1.7000000000;;t;FR;f;Europe/Paris;f;FRCTX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 1504;Châteauroux Gare Routière;chateauroux-gare-routiere;8720154;87201541;46.809088;1.688012;1503;f;FR;f;Europe/Paris;f;FRXGR;;t;;f;8705088;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1505;Castelnaudary;castelnaudary;8761503;87615039;43.312345035586986;1.9505023956298828;;f;FR;f;Europe/Paris;t;FRCTY;CTY;t;;f;8700549;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;カステルノーダリ;;;;Кастельнодари;;;卡斯泰尔诺达里
+1505;Castelnaudary;castelnaudary;8761503;87615039;43.312345035586986;1.9505023956298828;;f;FR;f;Europe/Paris;t;FRCTY;CTY;t;;f;8700549;f;;f;;f;;f;;;f;;f;8700170;f;;f;f;;;;;;;;;;;カステルノーダリ;;;;Кастельнодари;;;卡斯泰尔诺达里
 1506;Famechon;famechon;8731619;87316190;49.7500000000;2.0500000000;;f;FR;f;Europe/Paris;t;FRCTZ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1507;Wacquemoulin;wacquemoulin;8731620;87316208;49.503056;2.611734;;f;FR;f;Europe/Paris;t;FRCUA;;t;;f;8702257;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1508;Hyencourt-le-Grand;hyencourt-le-grand;8731621;87316216;49.8166670000;2.8333330000;;f;FR;f;Europe/Paris;t;FRCUB;;t;;f;8701295;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1178,19 +1178,19 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1524;Montreuil-sur-Thérain;montreuil-sur-therain;8731640;87316406;49.3833330000;2.2000000000;;f;FR;f;Europe/Paris;t;FRCUR;;t;;f;8701605;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1525;Villers-sur-Thère;villers-sur-there;8731642;87316422;49.414503;2.135459;;f;FR;f;Europe/Paris;t;FRCUS;;t;;f;8702248;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1529;Cluny;cluny;8772534;87725341;46.43362015175737;4.662505388259888;;f;FR;f;Europe/Paris;t;FRCUY;;t;;f;8703125;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Клюни;;;
-1530;Culoz;culoz;8774107;87741074;45.843195978835894;5.778712034225464;;f;FR;f;Europe/Paris;t;FRCUZ;CUZ;t;;f;8700039;f;;f;;f;8774107;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1530;Culoz;culoz;8774107;87741074;45.843195978835894;5.778712034225464;;f;FR;f;Europe/Paris;t;FRCUZ;CUZ;t;;f;8700039;f;;f;;f;8774107;f;;;f;;f;8700047;f;;f;f;;;;;;;;;;;;;;;;;;
 1531;Ste-Segrée;ste-segree;8731659;87316596;49.7500000000;1.9166670000;;f;FR;f;Europe/Paris;t;FRCVE;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1532;Aubin-St-Vaast;aubin-st-vaast;8731660;87316604;50.4000000000;1.9833330000;;f;FR;f;Europe/Paris;t;FRCVG;;t;;f;8700571;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1534;Marville;marville;8719323;87193235;49.4500000000;5.4500000000;;f;FR;f;Europe/Paris;t;FRCVI;;t;;f;8701484;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1535;Pihen;pihen;8731667;87316679;50.8666670000;1.7833330000;;f;FR;f;Europe/Paris;t;FRCVK;;t;;f;8701763;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1536;Le Haut-Banc;le-haut-banc;8731668;87316687;50.816362;1.772043;;f;FR;f;Europe/Paris;t;FRCVL;;t;;f;8703708;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1537;Feuquerolles;feuquerolles;8731675;87316752;50.064891;1.605464;;f;FR;f;Europe/Paris;t;FRCVQ;;t;;f;8701114;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1538;Boulogne-sur-Mer Tintelleries;boulogne-sur-mer-tintelleries;8731701;87317016;50.727382610467096;1.6091537475585935;5758;f;FR;f;Europe/Paris;t;FRCVS;;t;;f;8700451;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1539;Rang-du-Fliers—Verton;rang-du-fliers-verton;8731705;87317057;50.41578191155535;1.6482871770858765;;f;FR;f;Europe/Paris;t;FRCVU;RDF;t;;f;8701863;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1538;Boulogne-sur-Mer Tintelleries;boulogne-sur-mer-tintelleries;8731701;87317016;50.727382610467096;1.6091537475585935;5758;f;FR;f;Europe/Paris;t;FRCVS;;t;;f;8700451;f;;f;;f;;f;;;f;;f;8700100;f;;f;f;;;;;;;;;;;;;;;;;;
+1539;Rang-du-Fliers—Verton;rang-du-fliers-verton;8731705;87317057;50.41578191155535;1.6482871770858765;;f;FR;f;Europe/Paris;t;FRCVU;RDF;t;;f;8701863;f;;f;;f;;f;;;f;;f;8700845;f;;f;f;;;;;;;;;;;;;;;;;;
 1540;Dannes-Camiers;dannes-camiers;8731708;87317081;50.575927;1.614885;;f;FR;f;Europe/Paris;t;FRCVV;;t;;f;8700999;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1541;Neufchâtel-Hardelot;neufchatel-hardelot;8731709;87317099;50.6166670000;1.6333330000;;f;FR;f;Europe/Paris;t;FRCVW;;t;;f;8701658;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1542;Pont-de-Briques;pont-de-briques;8731711;87317115;50.6833330000;1.6333330000;;f;FR;f;Europe/Paris;t;FRCVX;;t;;f;8701747;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1543;Wimille—Wimereux;wimille-wimereux;8731712;87317123;50.763802;1.613797;;f;FR;f;Europe/Paris;t;FRCVY;;t;;f;8702273;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1543;Wimille—Wimereux;wimille-wimereux;8731712;87317123;50.763802;1.613797;;f;FR;f;Europe/Paris;t;FRCVY;;t;;f;8702273;f;;f;;f;;f;;;f;;f;8700843;f;;f;f;;;;;;;;;;;;;;;;;;
 1544;Irún;irun;8767791;;;;6657;f;ES;f;Europe/Madrid;f;FRCWA;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1545;Montreuil-sur-Mer;montreuil-sur-mer;8731716;87317164;50.466164323431634;1.7691850662231445;;f;FR;f;Europe/Paris;t;FRCWB;;t;;f;8700396;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;Montreuil;;Монтрей;;;
 1546;Brimeux;brimeux;8731718;87317180;50.44713757474187;1.8315088748931883;;f;FR;f;Europe/Paris;t;FRCWC;;t;;f;8700744;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1201,8 +1201,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1551;Blangy-sur-Ternoise;blangy-sur-ternoise;8731724;87317248;50.4166670000;2.1666670000;;f;FR;f;Europe/Paris;t;FRCWH;;t;;f;8700748;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1552;Anvin;anvin;8731725;87317255;50.44686087736178;2.2549653053283687;;f;FR;f;Europe/Paris;t;FRCWI;;t;;f;8700615;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1553;Caffiers;caffiers;8731732;87317321;50.8333330000;1.8000000000;;f;FR;f;Europe/Paris;t;FRCWK;;t;;f;8700825;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1554;Marquise-Rinxent;marquise-rinxent;8731733;87317339;50.805791;1.729983;;f;FR;f;Europe/Paris;t;FRCWL;;t;;f;8701591;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1555;Noyelles-sur-Mer;noyelles-sur-mer;8731739;87317396;50.187414;1.704759;;f;FR;f;Europe/Paris;t;FRCWN;NOE;t;;f;8701676;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1554;Marquise-Rinxent;marquise-rinxent;8731733;87317339;50.805791;1.729983;;f;FR;f;Europe/Paris;t;FRCWL;;t;;f;8701591;f;;f;;f;;f;;;f;;f;8700842;f;;f;f;;;;;;;;;;;;;;;;;;
+1555;Noyelles-sur-Mer;noyelles-sur-mer;8731739;87317396;50.187414;1.704759;;f;FR;f;Europe/Paris;t;FRCWN;NOE;t;;f;8701676;f;;f;;f;;f;;;f;;f;8700847;f;;f;f;;;;;;;;;;;;;;;;;;
 1557;Clermont-Ferrand;clermont-ferrand;;;45.7833330000;3.0833330000;;t;FR;f;Europe/Paris;f;FRCWP;;t;;f;;f;u04hqn;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 1558;Clermont-Ferrand La Pardieu;clermont-ferrand-la-pardieu;8778260;87782607;45.767004;3.134214;1557;f;FR;f;Europe/Paris;t;FRFDM;COP;t;;f;8703591;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1559;Clermont-Ferrand La Rotonde;clermont-ferrand-la-rotonde;8739689;87396895;45.768397;3.091668;1557;f;FR;f;Europe/Paris;t;FRHCL;RTD;t;;f;8705354;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1210,7 +1210,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1561;Chepy-Valines;chepy-valines;8731749;87317495;50.068235;1.635488;;f;FR;f;Europe/Paris;t;FRCWS;;t;;f;8700857;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1562;Feuquières-Fressenneville;feuquieres-fressenneville;8731750;87317503;50.063318;1.589068;;f;FR;f;Europe/Paris;t;FRCWT;;t;;f;8701116;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1563;Woincourt;woincourt;8731751;87317511;50.058724;1.53675;;f;FR;f;Europe/Paris;t;FRCWU;;t;;f;8702275;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1564;Le Tréport;le-treport;8731752;87317529;50.06285561083312;1.3763701915740967;;f;FR;f;Europe/Paris;t;FRCWV;LTM;t;;f;8700319;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1564;Le Tréport;le-treport;8731752;87317529;50.06285561083312;1.3763701915740967;;f;FR;f;Europe/Paris;t;FRCWV;LTM;t;;f;8700319;f;;f;;f;;f;;;f;;f;8700889;f;;f;f;;;;;;;;;;;;;;;;;;
 1565;Beau-Marais;beau-marais;8731761;87317610;50.945429;1.89827;;f;FR;f;Europe/Paris;t;FRCWY;;t;;f;8700740;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1567;Coux;coux;8733700;87337006;44.7666670000;4.6166670000;;f;FR;f;Europe/Paris;t;FRCXC;;t;;f;8705231;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1568;Miraumont;miraumont;8734203;87342030;50.1000000000;2.7333330000;;f;FR;f;Europe/Paris;t;FRCXE;;t;;f;8701552;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1218,18 +1218,18 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1570;Boisleux;boisleux;8734207;87342071;50.2000000000;2.7833330000;;f;FR;f;Europe/Paris;t;FRCXG;;t;;f;8700738;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1571;Rœux;roeux;8734208;87342089;50.2952610000;2.9007340000;;f;FR;f;Europe/Paris;t;FRCXH;;t;;f;8701890;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1572;Biache-St-Vaast;biache-st-vaast;8734209;87342097;50.3086930000;2.9477690000;;f;FR;f;Europe/Paris;t;FRCXI;;t;;f;8700716;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1573;Bully-Grenay;bully-grenay;8734210;87342105;50.448308;2.73317;;f;FR;f;Europe/Paris;t;FRCXJ;;t;;f;8700334;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1573;Bully-Grenay;bully-grenay;8734210;87342105;50.448308;2.73317;;f;FR;f;Europe/Paris;t;FRCXJ;;t;;f;8700334;f;;f;;f;;f;;;f;;f;8700601;f;;f;f;;;;;;;;;;;;;;;;;;
 1574;Vitry-en-Artois;vitry-en-artois;8734211;87342113;50.327699;2.982009;;f;FR;f;Europe/Paris;t;FRCXK;;t;;f;8702234;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1575;Mazingarbe;mazingarbe;8734212;87342121;50.4666670000;2.7000000000;;f;FR;f;Europe/Paris;t;FRCXL;;t;;f;8701649;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1576;Nœux-les-Mines;noeux-les-mines;8734213;87342139;50.48293;2.67429;;f;FR;f;Europe/Paris;t;FRCXM;;t;;f;8701698;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1576;Nœux-les-Mines;noeux-les-mines;8734213;87342139;50.48293;2.67429;;f;FR;f;Europe/Paris;t;FRCXM;;t;;f;8701698;f;;f;;f;;f;;;f;;f;8700602;f;;f;f;;;;;;;;;;;;;;;;;;
 1577;Marœuil;maroeuil;8734218;87342188;50.322369;2.698328;;f;FR;f;Europe/Paris;t;FRCXQ;;t;;f;8701565;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1579;Frévin-Capelle;frevin-capelle;8734221;87342212;50.3500000000;2.6333330000;;f;FR;f;Europe/Paris;t;FRCXS;;t;;f;8701168;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1580;Chocques;chocques;8734222;87342220;50.5333330000;2.5666670000;;f;FR;f;Europe/Paris;t;FRCXT;;t;;f;8700872;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1581;Lillers;lillers;8734223;87342238;50.5615513361181;2.4788331985473633;;f;FR;f;Europe/Paris;t;FRCXU;;t;;f;8701377;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1581;Lillers;lillers;8734223;87342238;50.5615513361181;2.4788331985473633;;f;FR;f;Europe/Paris;t;FRCXU;;t;;f;8701377;f;;f;;f;;f;;;f;;f;8700859;f;;f;f;;;;;;;;;;;;;;;;;;
 1582;Aubigny-en-Artois;aubigny-en-artois;8734224;87342246;50.3500000000;2.5833330000;;f;FR;f;Europe/Paris;t;FRCXV;;t;;f;8700565;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1583;Savy-Berlette;savy-berlette;8734225;87342253;50.3500000000;2.5500000000;;f;FR;f;Europe/Paris;t;FRCXW;;t;;f;8702079;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1584;Ham-en-Artois;ham-en-artois;8734226;87342261;50.5833330000;2.4666670000;;f;FR;f;Europe/Paris;t;FRCXX;;t;;f;8701275;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1585;Isbergues;isbergues;8734227;87342279;50.61420556430319;2.4627721309661865;;f;FR;f;Europe/Paris;t;FRCXY;;t;;f;8700704;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1585;Isbergues;isbergues;8734227;87342279;50.61420556430319;2.4627721309661865;;f;FR;f;Europe/Paris;t;FRCXY;;t;;f;8700704;f;;f;;f;;f;;;f;;f;8700861;f;;f;f;;;;;;;;;;;;;;;;;;
 1586;Thiennes;thiennes;8734228;87342287;50.653136;2.473687;;f;FR;f;Europe/Paris;t;FRCXZ;;t;;f;8702128;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1587;Steenbecque;steenbecque;8734229;87342295;50.680876;2.51003;;f;FR;f;Europe/Paris;t;FRCYA;;t;;f;8701925;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1588;Tincques;tincques;8734230;87342303;50.357103;2.497976;;f;FR;f;Europe/Paris;t;FRCYB;;t;;f;8702090;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1246,10 +1246,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1601;Vimy;vimy;8734257;87342576;50.373113;2.823116;;f;FR;f;Europe/Paris;t;FRCYS;;t;;f;8702179;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1602;Avion;avion;8734258;87342584;50.40718418218279;2.8338611125946045;;f;FR;f;Europe/Paris;t;FRCYT;;t;;f;8700648;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1603;Bailleul-Sir-Berthoult;bailleul-sir-berthoult;8734259;87342592;50.335142;2.84104;;f;FR;f;Europe/Paris;t;FRCYU;;t;;f;8700777;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1604;St-Amand-les-Eaux;st-amand-les-eaux;8734310;87343103;50.44285712432271;3.419365882873535;;f;FR;f;Europe/Paris;t;FRCYX;;t;;f;8700258;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1604;St-Amand-les-Eaux;st-amand-les-eaux;8734310;87343103;50.44285712432271;3.419365882873535;;f;FR;f;Europe/Paris;t;FRCYX;;t;;f;8700258;f;;f;;f;;f;;;f;;f;8700914;f;;f;f;;;;;;;;;;;;;;;;;;
 1605;Le Poirier Université;le-poirier-universite;8734321;87343210;50.329677;3.502727;;f;FR;f;Europe/Paris;t;FRCYZ;;t;;f;8701765;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1607;Wallers;wallers;8734330;87343301;50.384574;3.393337;;f;FR;f;Europe/Paris;t;FRCZB;;t;;f;8702270;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1608;Raismes;raismes;8734331;87343319;50.3833330000;3.4833330000;;f;FR;f;Europe/Paris;t;FRCZC;;t;;f;8701837;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1607;Wallers;wallers;8734330;87343301;50.384574;3.393337;;f;FR;f;Europe/Paris;t;FRCZB;;t;;f;8702270;f;;f;;f;;f;;;f;;f;8700878;f;;f;f;;;;;;;;;;;;;;;;;;
+1608;Raismes;raismes;8734331;87343319;50.3833330000;3.4833330000;;f;FR;f;Europe/Paris;t;FRCZC;;t;;f;8701837;f;;f;;f;;f;;;f;;f;8700879;f;;f;f;;;;;;;;;;;;;;;;;;
 1609;Trith-St-Léger;trith-st-leger;8734340;87343400;50.331601;3.489342;;f;FR;f;Europe/Paris;t;FRCZD;;t;;f;8702133;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1610;Prouvy-Thiant;prouvy-thiant;8734341;87343418;50.316822;3.461206;;f;FR;f;Europe/Paris;t;FRCZE;;t;;f;8701802;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1611;Denain;denain;8734345;87343459;50.3333330000;3.3833330000;;f;FR;f;Europe/Paris;t;FRCZG;;t;;f;8701009;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ドゥナン;;;;Денен;;;德南
@@ -1268,7 +1268,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1624;Pont-à-Vendin;pont-a-vendin;8734526;87345264;50.4666670000;2.8833330000;;f;FR;f;Europe/Paris;t;FRCZZ;;t;;f;8701739;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1625;Meurchin;meurchin;8734527;87345272;50.5000000000;2.8833330000;;f;FR;f;Europe/Paris;t;FRDAA;;t;;f;8701492;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1626;Bauvin-Provin;bauvin-provin;8734528;87345280;50.511538;2.90525;;f;FR;f;Europe/Paris;t;FRDAB;;t;;f;8700806;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1627;Montigny-en-Ostrevent;montigny-en-ostrevent;8734530;87345306;50.361369435420066;3.188180923461914;;f;FR;f;Europe/Paris;t;FRDAC;;t;;f;8701519;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1627;Montigny-en-Ostrevent;montigny-en-ostrevent;8734530;87345306;50.361369435420066;3.188180923461914;;f;FR;f;Europe/Paris;t;FRDAC;;t;;f;8701519;f;;f;;f;;f;;;f;;f;8700862;f;;f;f;;;;;;;;;;;;;;;;;;
 1628;Francheville;francheville;8772270;87722702;45.73446325857705;4.769032001495361;;f;FR;f;Europe/Paris;t;FRDAD;FRW;t;;f;8703348;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1629;Sain-Bel;sain-bel;8772160;87721605;45.810973845759726;4.601426124572754;;f;FR;f;Europe/Paris;t;FRDAG;SBL;t;;f;8704404;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1630;Bouchain;bouchain;8734538;87345389;50.2833330000;3.3166670000;;f;FR;f;Europe/Paris;t;FRDAI;;t;;f;8700798;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1283,7 +1283,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1641;Escaudœuvres;escaudoeuvres;8734549;87345496;50.19184354630194;3.2754921913146973;;f;FR;f;Europe/Paris;t;FRDAU;;t;;f;8701079;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1642;Maurois;maurois;8734554;87345546;50.0666670000;3.4500000000;;f;FR;f;Europe/Paris;t;FRDAX;;t;;f;8701567;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1643;Bertry;bertry;8734555;87345553;50.091236836081485;3.449106216430664;;f;FR;f;Europe/Paris;t;FRDAY;;t;;f;8700794;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1644;Caudry;caudry;8734556;87345561;50.12806879875748;3.4155678749084473;;f;FR;f;Europe/Paris;t;FRDAZ;CAU;t;;f;8700552;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1644;Caudry;caudry;8734556;87345561;50.12806879875748;3.4155678749084473;;f;FR;f;Europe/Paris;t;FRDAZ;CAU;t;;f;8700552;f;;f;;f;;f;;;f;;f;8700869;f;;f;f;;;;;;;;;;;;;;;;;;
 1645;Montauban-de-Bretagne;montauban-de-bretagne;;;48.2000000000;-2.0500000000;;t;FR;f;Europe/Paris;f;FRDBA;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1647;Cattenières;cattenieres;8734558;87345587;50.1333330000;3.3333330000;;f;FR;f;Europe/Paris;t;FRDBB;;t;;f;8700970;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1648;Wambaix;wambaix;8734559;87345595;50.133874;3.31141;;f;FR;f;Europe/Paris;t;FRDBC;;t;;f;8702274;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1299,11 +1299,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1660;Guécélard;guecelard;8736550;87365502;47.8833330000;0.1333330000;;f;FR;f;Europe/Paris;t;FRDBP;;t;;f;8703446;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1661;Parigné-le-Pôlin La Chenaie;parigne-le-polin-la-chenaie;8736566;87365668;47.854416;0.100679;;f;FR;f;Europe/Paris;t;FRDBQ;;t;;f;8704182;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1678;Liancourt-St-Pierre;liancourt-st-pierre;8738121;;49.2333330000;1.9166670000;;f;FR;f;Europe/Paris;t;FRDCM;;t;;f;8703798;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1681;Gisors;gisors;8738124;87381244;49.285202;1.785275;;f;FR;f;Europe/Paris;t;FRDCP;GIS;t;;f;8703408;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Жизор;;;吉索尔
+1681;Gisors;gisors;8738124;87381244;49.285202;1.785275;;f;FR;f;Europe/Paris;t;FRDCP;GIS;t;;f;8703408;f;;f;;f;;f;;;f;;f;8700829;f;;f;f;;;;;;;;;;;;;;;Жизор;;;吉索尔
 1682;Sérifontaine;serifontaine;8738126;87381269;49.3500000000;1.7666670000;;f;FR;f;Europe/Paris;t;FRDCR;;t;;f;8704483;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1683;Amécourt-Talmontier;amecourt-talmontier;8738127;87381277;49.386547;1.73952;;f;FR;f;Europe/Paris;t;FRDCS;;t;;f;8702651;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1684;Neuf-Marché;neuf-marche;8738128;87381285;49.417847;1.723304;;f;FR;f;Europe/Paris;t;FRDCT;;t;;f;8704099;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1685;Gournay—Ferrières;gournay-ferrieres;8738129;87381293;49.481390670400856;1.738157272338867;;f;FR;f;Europe/Paris;t;FRDCU;;t;;f;8703419;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1685;Gournay—Ferrières;gournay-ferrieres;8738129;87381293;49.481390670400856;1.738157272338867;;f;FR;f;Europe/Paris;t;FRDCU;;t;;f;8703419;f;;f;;f;;f;;;f;;f;8700828;f;;f;f;;;;;;;;;;;;;;;;;;
 1691;Conflans-Fin-d’Oise;conflans-fin-doise;8738145;;48.991965;2.074683;;f;FR;f;Europe/Paris;f;FRDDC;;f;;f;8703147;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1701;Bréval;breval;8738162;87381624;48.9500000000;1.5333330000;;f;FR;f;Europe/Paris;t;FRDDM;BVA;t;;f;8702918;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1702;Dourdan;dourdan;8754552;87545525;48.533430486724825;2.0096397399902344;1965;f;FR;t;Europe/Paris;t;FRDDN;;t;;f;8701028;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Дурдан;;;杜尔当
@@ -1318,19 +1318,19 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1764;Raze;raze;8718543;87185439;47.5833330000;6.0166670000;;f;FR;f;Europe/Paris;t;FRDHI;;t;;f;8701839;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1765;Mauléon Brossardière;mauleon-brossardiere;8738989;87389890;46.923394;-0.744792;;f;FR;f;Europe/Paris;t;FRDHL;;t;;f;8703946;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1767;Paris-Gare-Montparnasse-2-Pasteur;paris-gare-montparnasse-2-pasteur;8739101;;;;4916;f;FR;f;Europe/Paris;f;FRDHP;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1778;Die;die;8776184;87761841;44.75822289694286;5.3632378578186035;;f;FR;f;Europe/Paris;t;FRDIE;DIE;t;;f;8702522;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1778;Die;die;8776184;87761841;44.75822289694286;5.3632378578186035;;f;FR;f;Europe/Paris;t;FRDIE;DIE;t;;f;8702522;f;;f;;f;;f;;;f;;f;8700194;f;;f;f;;;;;;;;;;;;;;;;;;
 1782;Dijon;dijon;;;47.32337785274246;5.027124881744385;;t;FR;f;Europe/Paris;t;FRDIJ;;t;;f;;f;u07t4j;t;;f;;f;;;f;;f;;f;;f;f;;;;;;Digione;;;;;ディジョン;디종;;;Дижон;;;第戎
 1783;Dijon Porte Neuve;dijon-porte-neuve;8771300;87713008;47.322785;5.055182;1782;f;FR;f;Europe/Paris;t;FRGVW;DJP;t;;f;8700429;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Digione;;;;;ディジョン;디종;;;Дижон;;;第戎
-1787;Dinan;dinan;8747816;87478164;48.45680079327452;-2.053542137145996;;f;FR;f;Europe/Paris;t;FRDIN;;t;;f;8703215;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ディナン;;;;Динан;;;
+1787;Dinan;dinan;8747816;87478164;48.45680079327452;-2.053542137145996;;f;FR;f;Europe/Paris;t;FRDIN;;t;;f;8703215;f;;f;;f;;f;;;f;;f;8700779;f;;f;t;;;;;;;;;;;ディナン;;;;Динан;;;
 1804;St-Germain—St-Rémy;st-germain-st-remy;8739352;87393520;48.758479;1.257375;;f;FR;f;Europe/Paris;t;FRDJG;;t;;f;8704573;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1807;Nonancourt;nonancourt;8739355;87393553;48.7666670000;1.2000000000;;f;FR;f;Europe/Paris;t;FRDJJ;;t;;f;8704129;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1809;Tillières;tillieres;8739358;87393587;48.760852;1.054668;;f;FR;f;Europe/Paris;t;FRDJL;;t;;f;8704722;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1810;Verneuil-sur-Avre;verneuil-sur-avre;8739359;87393595;48.74274799571551;0.9292566776275634;;f;FR;f;Europe/Paris;t;FRDJM;VEA;t;;f;8704808;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1810;Verneuil-sur-Avre;verneuil-sur-avre;8739359;87393595;48.74274799571551;0.9292566776275634;;f;FR;f;Europe/Paris;t;FRDJM;VEA;t;;f;8704808;f;;f;;f;;f;;;f;;f;8700748;f;;f;f;;;;;;;;;;;;;;;;;;
 1811;Bourth;bourth;8739360;87393603;48.7666670000;0.8166670000;;f;FR;f;Europe/Paris;t;FRDJN;;t;;f;8702897;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1812;Longjumeau;longjumeau;8739361;;48.70219169958698;2.2945332527160645;;f;FR;f;Europe/Paris;t;FRDJO;;t;;f;8703822;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ロンジュモー;;;;Лонжюмо;;;隆格瑞莫
 1816;Petit-Vaux;petit-vaux;8739365;;48.6763;2.333491;;f;FR;f;Europe/Paris;t;FRDJS;;t;;f;8704209;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1818;Massy TGV;massy-tgv;8739370;87393702;48.725864129391965;2.2614026069641113;2000;f;FR;t;Europe/Paris;t;FRDJU;MPW;t;;f;8701607;f;;f;DJU;t;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-1822;Épernon;epernon;8739411;87394114;48.60514170812404;1.6815948486328125;;f;FR;f;Europe/Paris;t;FRDKA;;t;;f;8701073;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1818;Massy TGV;massy-tgv;8739370;87393702;48.725864129391965;2.2614026069641113;2000;f;FR;t;Europe/Paris;t;FRDJU;MPW;t;;f;8701607;f;;f;DJU;t;;f;;;f;;f;8700703;f;;f;t;;;;;;;;;;;;;;;;;;
+1822;Épernon;epernon;8739411;87394114;48.60514170812404;1.6815948486328125;;f;FR;f;Europe/Paris;t;FRDKA;;t;;f;8701073;f;;f;;f;;f;;;f;;f;8700480;f;;f;f;;;;;;;;;;;;;;;;;;
 1823;Maintenon;maintenon;8739413;87394130;48.58529481682537;1.5925240516662598;;f;FR;f;Europe/Paris;t;FRDKB;;t;;f;8701561;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;曼特农
 1824;St-Piat;st-piat;8739414;87394148;48.5500000000;1.5833330000;;f;FR;f;Europe/Paris;t;FRDKC;;t;;f;8702023;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1825;Jouy;jouy;8739415;87394155;48.5166670000;1.5500000000;;f;FR;f;Europe/Paris;t;FRDKD;;t;;f;8701324;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1339,10 +1339,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1828;St-Aubin—St-Luperce;st-aubin-st-luperce;8739421;87394213;48.44765;1.332533;;f;FR;f;Europe/Paris;t;FRDKG;;t;;f;8700568;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1829;Courville-sur-Eure;courville-sur-eure;8739422;87394221;48.45147123002932;1.2348353862762451;;f;FR;f;Europe/Paris;t;FRDKH;;t;;f;8700984;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1830;Pontgouin;pontgouin;8739424;87394247;48.4833330000;1.1666670000;;f;FR;f;Europe/Paris;t;FRDKI;;t;;f;8701811;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1831;La Loupe;la-loupe;8739425;87394254;48.474023766011065;1.0107958316802979;;f;FR;f;Europe/Paris;t;FRDKJ;;t;;f;8701435;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1831;La Loupe;la-loupe;8739425;87394254;48.474023766011065;1.0107958316802979;;f;FR;f;Europe/Paris;t;FRDKJ;;t;;f;8701435;f;;f;;f;;f;;;f;;f;8700717;f;;f;f;;;;;;;;;;;;;;;;;;
 1832;Bretoncelles;bretoncelles;8739427;87394270;48.4333330000;0.8833330000;;f;FR;f;Europe/Paris;t;FRDKK;;t;;f;8700718;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1833;Condé-sur-Huisne;conde-sur-huisne;8739428;87394288;48.3833330000;0.8666670000;;f;FR;f;Europe/Paris;t;FRDKL;;t;;f;8700848;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1834;Nogent-le-Rotrou;nogent-le-rotrou;8739429;87394296;48.32584784455557;0.8100700378417969;;f;FR;f;Europe/Paris;t;FRDKM;;t;;f;8701673;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Ножан-ле-Ротру;;;诺让莱罗特鲁
+1833;Condé-sur-Huisne;conde-sur-huisne;8739428;87394288;48.3833330000;0.8666670000;;f;FR;f;Europe/Paris;t;FRDKL;;t;;f;8700848;f;;f;;f;;f;;;f;;f;8700718;f;;f;f;;;;;;;;;;;;;;;;;;
+1834;Nogent-le-Rotrou;nogent-le-rotrou;8739429;87394296;48.32584784455557;0.8100700378417969;;f;FR;f;Europe/Paris;t;FRDKM;;t;;f;8701673;f;;f;;f;;f;;;f;;f;8700719;f;;f;f;;;;;;;;;;;;;;;Ножан-ле-Ротру;;;诺让莱罗特鲁
 1835;La Taye;la-taye;8739440;87394403;48.40776764984665;1.373441219329834;;f;FR;f;Europe/Paris;t;FRDKN;;t;;f;8702343;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1836;Bailleau-le-Pin;bailleau-le-pin;8739441;87394411;48.3666670000;1.3333330000;;f;FR;f;Europe/Paris;t;FRDKO;;t;;f;8702333;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1837;Magny-Blandainville;magny-blandainville;8739442;87394429;48.334278;1.28098;;f;FR;f;Europe/Paris;t;FRDKP;;t;;f;8702352;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1361,16 +1361,16 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1853;Domfront;domfront;8739620;87396200;48.1000000000;0.0166670000;;f;FR;f;Europe/Paris;t;FRDLN;;t;;f;8703229;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1854;Conlie;conlie;8739621;87396218;48.12731468876769;-0.01132965087890625;;f;FR;f;Europe/Paris;t;FRDLO;;t;;f;8700912;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1855;Crissé;crisse;8739622;87396226;48.16813910701335;-0.06591260433197021;;f;FR;f;Europe/Paris;t;FRDLP;;t;;f;8700945;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1856;Sillé-le-Guillaume;sille-le-guillaume;8739623;87396234;48.18168280099414;-0.1288318634033203;;f;FR;f;Europe/Paris;t;FRDLQ;;t;;f;8701961;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1856;Sillé-le-Guillaume;sille-le-guillaume;8739623;87396234;48.18168280099414;-0.1288318634033203;;f;FR;f;Europe/Paris;t;FRDLQ;;t;;f;8701961;f;;f;;f;;f;;;f;;f;8700818;f;;f;f;;;;;;;;;;;;;;;;;;
 1857;Rouessé-Vassé;rouesse-vasse;8739625;87396259;48.1666670000;-0.2000000000;;f;FR;f;Europe/Paris;t;FRDLR;;t;;f;8701886;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1858;Deols;deols;8730462;87304626;46.8333330000;1.7000000000;;f;FR;f;Europe/Paris;t;FRDLS;;t;;f;8700447;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1859;Champagné;champagne;8739627;87396275;48.01971887995994;0.33524394035339355;;f;FR;f;Europe/Paris;t;FRDLT;;t;;f;8700906;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1859;Champagné;champagne;8739627;87396275;48.01971887995994;0.33524394035339355;;f;FR;f;Europe/Paris;t;FRDLT;;t;;f;8700906;f;;f;;f;;f;;;f;;f;8700725;f;;f;f;;;;;;;;;;;;;;;;;;
 1860;St-Mars-la-Brière;st-mars-la-briere;8739628;87396283;48.0304610000;0.3731920000;;f;FR;f;Europe/Paris;t;FRDLU;;t;;f;8702109;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1861;Montfort-le-Gesnois;montfort-le-gesnois;8739629;87396291;48.0500000000;0.4166670000;;f;FR;f;Europe/Paris;t;FRDLV;;t;;f;8701498;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1862;Connerre—Beillé;connerre-beille;8739630;87396309;48.073807;0.48655;;f;FR;f;Europe/Paris;t;FRDLW;;t;;f;8700922;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1863;Sceaux—Boëssé;sceaux-boesse;8739631;87396317;48.122142;0.572424;;f;FR;f;Europe/Paris;t;FRDLX;;t;;f;8701931;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1864;La Ferté-Bernard;la-ferte-bernard;8739632;87396325;48.18651845664379;0.6390738487243652;;f;FR;f;Europe/Paris;t;FRDLY;;t;;f;8701113;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1865;Le Theil—La Rouge;le-theil-la-rouge;8739633;87396333;48.267291;0.694452;;f;FR;f;Europe/Paris;t;FRDLZ;;t;;f;8702099;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1862;Connerre—Beillé;connerre-beille;8739630;87396309;48.073807;0.48655;;f;FR;f;Europe/Paris;t;FRDLW;;t;;f;8700922;f;;f;;f;;f;;;f;;f;8700724;f;;f;f;;;;;;;;;;;;;;;;;;
+1863;Sceaux—Boëssé;sceaux-boesse;8739631;87396317;48.122142;0.572424;;f;FR;f;Europe/Paris;t;FRDLX;;t;;f;8701931;f;;f;;f;;f;;;f;;f;8700723;f;;f;f;;;;;;;;;;;;;;;;;;
+1864;La Ferté-Bernard;la-ferte-bernard;8739632;87396325;48.18651845664379;0.6390738487243652;;f;FR;f;Europe/Paris;t;FRDLY;;t;;f;8701113;f;;f;;f;;f;;;f;;f;8700722;f;;f;f;;;;;;;;;;;;;;;;;;
+1865;Le Theil—La Rouge;le-theil-la-rouge;8739633;87396333;48.267291;0.694452;;f;FR;f;Europe/Paris;t;FRDLZ;;t;;f;8702099;f;;f;;f;;f;;;f;;f;8700721;f;;f;f;;;;;;;;;;;;;;;;;;
 1866;Voivres;voivres;8739635;87396358;47.93042;0.085352;;f;FR;f;Europe/Paris;t;FRDMB;;t;;f;8702247;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1867;La Suze;la-suze;8739636;87396366;47.892183088167755;0.025534629821777344;;f;FR;f;Europe/Paris;t;FRDMC;;t;;f;8702068;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1868;Noyen;noyen;8739637;87396374;47.8666670000;-0.1000000000;;f;FR;f;Europe/Paris;t;FRDMD;;t;;f;8701699;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1378,21 +1378,21 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1871;Buzy-Darmont;buzy-darmont;8745881;87458810;49.1666670000;5.7000000000;;f;FR;f;Europe/Paris;t;FRDMH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1872;La Flèche;la-fleche;8735863;87358630;47.696808529186065;-0.06939411163330077;;f;FR;f;Europe/Paris;t;FRDMI;;t;;f;8702946;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1874;Laigné—St-Gervais;laigne-st-gervais;8739655;87396556;47.874076;0.216918;;f;FR;f;Europe/Paris;t;FRDML;;t;;f;8702360;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1875;Écommoy;ecommoy;8739656;87396564;47.82446506504089;0.26888608932495117;;f;FR;f;Europe/Paris;t;FRDMM;ECO;t;;f;8702340;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1875;Écommoy;ecommoy;8739656;87396564;47.82446506504089;0.26888608932495117;;f;FR;f;Europe/Paris;t;FRDMM;ECO;t;;f;8702340;f;;f;;f;;f;;;f;;f;8700278;f;;f;f;;;;;;;;;;;;;;;;;;
 1876;Aubigné-Racan;aubigne-racan;8739657;87396572;47.6833330000;0.2666670000;;f;FR;f;Europe/Paris;t;FRDMN;;t;;f;8702354;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1877;Mayet;mayet;8739658;87396580;47.7666670000;0.2833330000;;f;FR;f;Europe/Paris;t;FRDMO;;t;;f;8702351;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1878;Vaas;vaas;8739659;87396598;47.670767;0.316492;;f;FR;f;Europe/Paris;t;FRDMP;;t;;f;8702375;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1879;Château-la-Vallière;chateau-la-valliere;8739663;;47.5500000000;0.3166670000;;f;FR;f;Europe/Paris;t;FRDMQ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1881;Mondoubleau;mondoubleau;8739674;;47.98396;0.898777;4776;f;FR;t;Europe/Paris;t;FRDMU;;t;;f;8704007;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1882;Étain Centre;etain-centre;8745882;87458828;49.2135989092445;5.636265277862549;;f;FR;f;Europe/Paris;t;FRDMV;;t;;f;8706286;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;Etain;;;;;
-1886;Elbeuf—St-Aubin;elbeuf-st-aubin;8741117;87411173;49.302839;1.010333;26829;f;FR;f;Europe/Paris;t;FRDND;;t;;f;8703261;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1886;Elbeuf—St-Aubin;elbeuf-st-aubin;8741117;87411173;49.302839;1.010333;26829;f;FR;f;Europe/Paris;t;FRDND;;t;;f;8703261;f;;f;;f;;f;;;f;;f;8700700;f;;f;f;;;;;;;;;;;;;;;;;;
 1887;Tourville;tourville;8741118;87411181;49.324809;1.09885;;f;FR;f;Europe/Paris;t;FRDNE;;t;;f;8704736;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1888;St-Étienne-du-Rouvray;st-etienne-du-rouvray;8741121;87411215;49.3833330000;1.1000000000;;f;FR;f;Europe/Paris;t;FRDNF;;t;;f;8704556;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1889;Sotteville;sotteville;8741122;87411223;49.412507;1.10232;;f;FR;f;Europe/Paris;t;FRDNG;;t;;f;8704510;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1891;Maromme;maromme;8741124;87411249;49.4666670000;1.0333330000;;f;FR;f;Europe/Paris;t;FRDNI;;t;;f;8703920;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1892;Barentin;barentin;8741126;87411264;49.549233;0.953854;;f;FR;f;Europe/Paris;t;FRDNJ;;t;;f;8700764;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1893;Pavilly;pavilly;8741127;87411272;49.564165;0.950447;;f;FR;f;Europe/Paris;t;FRDNK;;t;;f;8704193;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1895;Forges-les-Eaux;forges-les-eaux;8741138;87411389;49.61393558012603;1.5534281730651855;;f;FR;f;Europe/Paris;t;FRDNO;;t;;f;8703337;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1895;Forges-les-Eaux;forges-les-eaux;8741138;87411389;49.61393558012603;1.5534281730651855;;f;FR;f;Europe/Paris;t;FRDNO;;t;;f;8703337;f;;f;;f;;f;;;f;;f;8700827;f;;f;f;;;;;;;;;;;;;;;;;;
 1896;St-Martin-du-Vivier;st-martin-du-vivier;8741141;87411413;49.4666670000;1.1666670000;;f;FR;f;Europe/Paris;t;FRDNP;;t;;f;8701503;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1897;Morgny;morgny;8741143;87411439;49.5166670000;1.2500000000;;f;FR;f;Europe/Paris;t;FRDNQ;;t;;f;8701573;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1899;Longuerue—Vieux-Manoir;longuerue-vieux-manoir;8741144;87411447;49.556757;1.276459;;f;FR;f;Europe/Paris;t;FRDNS;;t;;f;8701389;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1407,12 +1407,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1908;Dolus-d’Oléron;dolus-doleron;8734698;87346981;45.90923036786113;-1.2632828950881958;;f;FR;f;Europe/Paris;t;FRDOB;;t;;f;8734698;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1909;Montville;montville;8741180;87411801;49.55107361722291;1.0697454214096067;;f;FR;f;Europe/Paris;t;FRDOC;;t;;f;8704057;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1910;Clères;cleres;8741181;87411819;49.599383741493654;1.1066579818725586;;f;FR;f;Europe/Paris;t;FRDOD;;t;;f;8703120;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1911;St-Laurent—Gainneville;st-laurent-gainneville;8741331;87413310;49.528621;0.252201;;f;FR;f;Europe/Paris;t;FRDOF;;t;;f;8704598;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1911;St-Laurent—Gainneville;st-laurent-gainneville;8741331;87413310;49.528621;0.252201;;f;FR;f;Europe/Paris;t;FRDOF;;t;;f;8704598;f;;f;;f;;f;;;f;;f;8700609;f;;f;f;;;;;;;;;;;;;;;;;;
 1912;Etainhus—St-Romain;etainhus-st-romain;8741332;87413328;49.561198;0.330946;;f;FR;f;Europe/Paris;t;FRDOG;;t;;f;8701088;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1913;Virville—Manneville;virville-manneville;8741333;87413336;49.583626;0.35413;;f;FR;f;Europe/Paris;t;FRDOH;;t;;f;8704894;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1914;Bolbec—Nointot;bolbec-nointot;8741335;87413351;49.59177;0.483529;;f;FR;f;Europe/Paris;t;FRDOI;;t;;f;8702862;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1915;Foucart—Alvimare;foucart-alvimare;8741337;87413377;49.608113;0.596461;;f;FR;f;Europe/Paris;t;FRDOK;;t;;f;8703340;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1916;Dol-de-Bretagne;dol-de-bretagne;8747807;87478073;48.5441215583482;-1.7501091957092285;;f;FR;f;Europe/Paris;t;FRDOL;DOL;t;;f;8703223;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ドル＝ド＝ブルターニュ;;;;Доль-де-Бретань;;;多德布雷塔尼
+1916;Dol-de-Bretagne;dol-de-bretagne;8747807;87478073;48.5441215583482;-1.7501091957092285;;f;FR;f;Europe/Paris;t;FRDOL;DOL;t;;f;8703223;f;;f;;f;;f;;;f;;f;8700080;f;;f;t;;;;;;;;;;;ドル＝ド＝ブルターニュ;;;;Доль-де-Бретань;;;多德布雷塔尼
 1917;Don-Sainghin;don-sainghin;8728643;87286435;50.551486;2.913098;;f;FR;f;Europe/Paris;t;FRDON;DON;t;;f;8700305;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1918;Dommerville;dommerville;8733296;;;;;f;FR;f;Europe/Paris;f;FRDOO;;t;;f;8705232;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1920;Fécamp;fecamp;8741354;87413542;49.75950276582805;0.37525177001953125;;f;FR;f;Europe/Paris;t;FRDOQ;;t;;f;8703306;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;フェカン;페캉;;;Фекан;;;费康
@@ -1425,7 +1425,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1928;Agen Magnolias;agen-magnolias;8746555;87465559;44.2000000000;0.6333330000;17433;f;FR;f;Europe/Paris;t;FRDPG;;t;;f;8706301;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1929;Arques-la-Bataille;arques-la-bataille;8741504;87415042;49.8833330000;1.1333330000;;f;FR;f;Europe/Paris;t;FRDPH;;t;;f;8702689;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Арк-ла-Батай;;;
 1930;St-Vaast-d’Équiqueville;st-vaast-dequiqueville;8741506;87415067;49.816123;1.265887;;f;FR;f;Europe/Paris;t;FRDPJ;;t;;f;8704761;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1931;Neufchâtel-en-Bray;neufchatel-en-bray;8741509;87415091;49.7333330000;1.4500000000;;f;FR;f;Europe/Paris;t;FRDPM;;t;;f;8704926;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1931;Neufchâtel-en-Bray;neufchatel-en-bray;8741509;87415091;49.7333330000;1.4500000000;;f;FR;f;Europe/Paris;t;FRDPM;;t;;f;8704926;f;;f;;f;;f;;;f;;f;8700825;f;;f;f;;;;;;;;;;;;;;;;;;
 1932;Nesle—St-Saire;nesle-st-saire;8741510;87415109;49.692863;1.497764;;f;FR;f;Europe/Paris;t;FRDPN;;t;;f;8704096;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1934;St-Aubin-sur-Scie;st-aubin-sur-scie;8741512;87415125;49.8666670000;1.0666670000;;f;FR;f;Europe/Paris;t;FRDPP;;t;;f;8700421;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1936;Longueville-sur-Scie;longueville-sur-scie;8741514;87415141;49.8000000000;1.1000000000;;f;FR;f;Europe/Paris;t;FRDPR;;t;;f;8703824;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1434,11 +1434,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1939;Osmoy Carrefour;osmoy-carrefour;8741529;87415299;49.8000000000;1.3166670000;;f;FR;f;Europe/Paris;t;FRDPU;;t;;f;8704159;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1940;Bourgtheroulde-Thuit-Hébert;bourgtheroulde-thuit-hebert;8741532;87415323;49.317536;0.838271;;f;FR;f;Europe/Paris;t;FRDPV;;t;;f;8702891;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1941;Glos-Montfort;glos-montfort;8741534;87415349;49.271521;0.682838;;f;FR;f;Europe/Paris;t;FRDPX;;t;;f;8703412;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1942;Brionne;brionne;8741536;87415364;49.196435582351896;0.7116597890853882;;f;FR;f;Europe/Paris;t;FRDPZ;;t;;f;8702927;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1943;Vernon—Giverny;vernon-giverny;8741560;87415604;49.091647;1.477961;;f;FR;f;Europe/Paris;t;FRDQC;VNO;t;;f;8700230;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-1944;Gaillon—Aubevoye;gaillon-aubevoye;8741562;87415620;49.174644;1.352741;;f;FR;f;Europe/Paris;t;FRDQE;GAA;t;;f;8703364;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1945;St-Pierre-du-Vauvray;st-pierre-du-vauvray;8741564;87415646;49.2333330000;1.2166670000;;f;FR;f;Europe/Paris;t;FRDQG;;t;;f;8704639;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1946;Pont-de-l’Arche;pont-de-larche;8741566;87415661;49.3000000000;1.1666670000;;f;FR;f;Europe/Paris;t;FRDQH;;t;;f;8704264;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;蓬德拉尔克
+1942;Brionne;brionne;8741536;87415364;49.196435582351896;0.7116597890853882;;f;FR;f;Europe/Paris;t;FRDPZ;;t;;f;8702927;f;;f;;f;;f;;;f;;f;8700300;f;;f;f;;;;;;;;;;;;;;;;;;
+1943;Vernon—Giverny;vernon-giverny;8741560;87415604;49.091647;1.477961;;f;FR;f;Europe/Paris;t;FRDQC;VNO;t;;f;8700230;f;;f;;f;;f;;;f;;f;8700797;f;;f;t;;;;;;;;;;;;;;;;;;
+1944;Gaillon—Aubevoye;gaillon-aubevoye;8741562;87415620;49.174644;1.352741;;f;FR;f;Europe/Paris;t;FRDQE;GAA;t;;f;8703364;f;;f;;f;;f;;;f;;f;8700796;f;;f;f;;;;;;;;;;;;;;;;;;
+1945;St-Pierre-du-Vauvray;st-pierre-du-vauvray;8741564;87415646;49.2333330000;1.2166670000;;f;FR;f;Europe/Paris;t;FRDQG;;t;;f;8704639;f;;f;;f;;f;;;f;;f;8700795;f;;f;f;;;;;;;;;;;;;;;;;;
+1946;Pont-de-l’Arche;pont-de-larche;8741566;87415661;49.3000000000;1.1666670000;;f;FR;f;Europe/Paris;t;FRDQH;;t;;f;8704264;f;;f;;f;;f;;;f;;f;8700794;f;;f;f;;;;;;;;;;;;;;;;;;蓬德拉尔克
 1948;Louviers;louviers;8741585;87415851;49.21591516908271;1.1773449182510376;;f;FR;t;Europe/Paris;f;FRDQK;;t;;f;8703843;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1949;Rosny-sur-Seine;rosny-sur-seine;8741588;87415885;48.99739539415905;1.6302037239074707;;f;FR;f;Europe/Paris;t;FRDQL;RSS;t;;f;8704388;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1950;Bonnières;bonnieres;8741589;87415893;49.0166670000;1.4833330000;;f;FR;f;Europe/Paris;t;FRDQM;BNR;t;;f;8702867;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1454,29 +1454,29 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1965;Dourdan;dourdan;;;48.5333330000;2.0166670000;;t;FR;f;Europe/Paris;f;FRDRN;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1967;Frénouville—Cagny;frenouville-cagny;8744418;87444182;49.14097;-0.259707;;f;FR;f;Europe/Paris;t;FRDRO;;t;;f;8702357;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1968;Moult—Argences;moult-argences;8744419;87444190;49.111099;-0.186517;;f;FR;f;Europe/Paris;t;FRDRP;;t;;f;8702365;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1969;St-Pierre-sur-Dives;st-pierre-sur-dives;8744421;87444216;49.0166670000;-0.0333330000;;f;FR;f;Europe/Paris;t;FRDRQ;SPD;t;;f;8702373;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1970;Coulibœuf;couliboeuf;8744423;87444232;48.9333330000;-0.0666670000;;f;FR;f;Europe/Paris;t;FRDRS;;t;;f;8702356;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1969;St-Pierre-sur-Dives;st-pierre-sur-dives;8744421;87444216;49.0166670000;-0.0333330000;;f;FR;f;Europe/Paris;t;FRDRQ;SPD;t;;f;8702373;f;;f;;f;;f;;;f;;f;8700298;f;;f;f;;;;;;;;;;;;;;;;;;
+1970;Coulibœuf;couliboeuf;8744423;87444232;48.9333330000;-0.0666670000;;f;FR;f;Europe/Paris;t;FRDRS;;t;;f;8702356;f;;f;;f;;f;;;f;;f;8700381;f;;f;f;;;;;;;;;;;;;;;;;;
 1971;St-Martin-Valmeroux;st-martin-valmeroux;8700365;;45.1166670000;2.4166670000;;f;FR;f;Europe/Paris;t;FRDRU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1972;Le Grand-Jardin;le-grand-jardin;8744432;87444323;49.150598;0.227076;;f;FR;f;Europe/Paris;t;FRDRX;;t;;f;8703706;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1973;Blonville-sur-Mer—Benerville;blonville-sur-mer-benerville;8744438;87444380;49.331452;0.035687;5656;f;FR;t;Europe/Paris;t;FRDSB;;t;;f;8702847;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1974;Villers-sur-Mer;villers-sur-mer;8744439;87444398;49.315981;0.009924;5661;f;FR;t;Europe/Paris;t;FRDSC;;t;;f;8704876;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1975;Houlgate;houlgate;8744440;87444406;49.30007480119012;-0.07722079753875731;4893;f;FR;t;Europe/Paris;t;FRDSD;;t;;f;8703475;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1973;Blonville-sur-Mer—Benerville;blonville-sur-mer-benerville;8744438;87444380;49.331452;0.035687;5656;f;FR;t;Europe/Paris;t;FRDSB;;t;;f;8702847;f;;f;;f;;f;;;f;;f;8700789;f;;f;f;;;;;;;;;;;;;;;;;;
+1974;Villers-sur-Mer;villers-sur-mer;8744439;87444398;49.315981;0.009924;5661;f;FR;t;Europe/Paris;t;FRDSC;;t;;f;8704876;f;;f;;f;;f;;;f;;f;8700791;f;;f;f;;;;;;;;;;;;;;;;;;
+1975;Houlgate;houlgate;8744440;87444406;49.30007480119012;-0.07722079753875731;4893;f;FR;t;Europe/Paris;t;FRDSD;;t;;f;8703475;f;;f;;f;;f;;;f;;f;8700817;f;;f;f;;;;;;;;;;;;;;;;;;
 1976;Écouché;ecouche;8744454;87444547;48.7166670000;-0.1333330000;10160;f;FR;t;Europe/Paris;t;FRDSJ;;t;;f;8703257;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1977;Nonant-le-Pin;nonant-le-pin;8744457;87444570;48.7000000000;0.2166670000;;f;FR;f;Europe/Paris;t;FRDSL;;t;;f;8704130;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1978;Le Merlerault;le-merlerault;8744458;87444588;48.7000000000;0.3000000000;10155;f;FR;t;Europe/Paris;t;FRDSM;;t;;f;8703716;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1979;Ste-Gauburge;ste-gauburge;8744460;87444604;48.7000000000;0.4333330000;;f;FR;f;Europe/Paris;t;FRDSO;;t;;f;8704672;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1978;Le Merlerault;le-merlerault;8744458;87444588;48.7000000000;0.3000000000;10155;f;FR;t;Europe/Paris;t;FRDSM;;t;;f;8703716;f;;f;;f;;f;;;f;;f;8700782;f;;f;f;;;;;;;;;;;;;;;;;;
+1979;Ste-Gauburge;ste-gauburge;8744460;87444604;48.7000000000;0.4333330000;;f;FR;f;Europe/Paris;t;FRDSO;;t;;f;8704672;f;;f;;f;;f;;;f;;f;8700749;f;;f;f;;;;;;;;;;;;;;;;;;
 1980;Rai—Aube;rai-aube;8744462;87444620;48.750083;0.578473;;f;FR;f;Europe/Paris;t;FRDSP;;t;;f;8704342;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1981;L’Aigle;laigle;8744463;87444638;48.76635183940031;0.6200945377349854;;f;FR;f;Europe/Paris;t;FRDSQ;LAE;t;;f;8700315;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;レーグル;;;;Л’Эгль;;;莱格尔
-1982;Sées;sees;8744469;87444695;48.59990223352594;0.16617357730865479;;f;FR;f;Europe/Paris;t;FRDST;SKS;t;;f;8702370;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1983;Coutances;coutances;8744711;87447110;49.042791079324125;-1.4414405822753906;;f;FR;f;Europe/Paris;t;FRDTC;CCS;t;;f;8700232;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1984;Carantilly—Marigny;carantilly-marigny;8744714;87447144;49.068104;-1.245527;;f;FR;f;Europe/Paris;t;FRDTE;;t;;f;8702973;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1986;Pont-Hébert;pont-hebert;8744718;87447185;49.16254006512167;-1.126645803451538;;f;FR;f;Europe/Paris;t;FRDTI;;t;;f;8704271;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1987;Carentan;carentan;8744724;87447243;49.30239050429058;-1.2449312210083008;;f;FR;f;Europe/Paris;t;FRDTK;CAR;t;;f;8700225;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1989;Valognes;valognes;8744728;87447284;49.505294;-1.480001;;f;FR;f;Europe/Paris;t;FRDTO;VAS;t;;f;8700226;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Валонь;;;瓦洛盖
+1982;Sées;sees;8744469;87444695;48.59990223352594;0.16617357730865479;;f;FR;f;Europe/Paris;t;FRDST;SKS;t;;f;8702370;f;;f;;f;;f;;;f;;f;8700281;f;;f;f;;;;;;;;;;;;;;;;;;
+1983;Coutances;coutances;8744711;87447110;49.042791079324125;-1.4414405822753906;;f;FR;f;Europe/Paris;t;FRDTC;CCS;t;;f;8700232;f;;f;;f;;f;;;f;;f;8700799;f;;f;f;;;;;;;;;;;;;;;;;;
+1984;Carantilly—Marigny;carantilly-marigny;8744714;87447144;49.068104;-1.245527;;f;FR;f;Europe/Paris;t;FRDTE;;t;;f;8702973;f;;f;;f;;f;;;f;;f;8700450;f;;f;f;;;;;;;;;;;;;;;;;;
+1986;Pont-Hébert;pont-hebert;8744718;87447185;49.16254006512167;-1.126645803451538;;f;FR;f;Europe/Paris;t;FRDTI;;t;;f;8704271;f;;f;;f;;f;;;f;;f;8700440;f;;f;f;;;;;;;;;;;;;;;;;;
+1987;Carentan;carentan;8744724;87447243;49.30239050429058;-1.2449312210083008;;f;FR;f;Europe/Paris;t;FRDTK;CAR;t;;f;8700225;f;;f;;f;;f;;;f;;f;8700773;f;;f;f;;;;;;;;;;;;;;;;;;
+1989;Valognes;valognes;8744728;87447284;49.505294;-1.480001;;f;FR;f;Europe/Paris;t;FRDTO;VAS;t;;f;8700226;f;;f;;f;;f;;;f;;f;8700774;f;;f;f;;;;;;;;;;;;;;;Валонь;;;瓦洛盖
 1990;Orval—Hyenville;orval-hyenville;8744750;87447508;49.0166670000;-1.4666670000;;f;FR;f;Europe/Paris;t;FRDUJ;;t;;f;8704158;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1991;Quettreville-sur-Sienne;quettreville-sur-sienne;8744761;87447615;48.9666670000;-1.4666670000;;f;FR;f;Europe/Paris;t;FRDUK;;t;;f;8704334;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1992;St-Planchers;st-planchers;8744767;87447672;48.8166670000;-1.5166670000;;f;FR;f;Europe/Paris;t;FRDUN;;t;;f;8704230;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1993;Villedieu-les-Poêles;villedieu-les-poeles;8744769;87447698;48.834204;-1.225427;5658;f;FR;t;Europe/Paris;t;FRDUO;VDS;t;;f;8704852;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+1993;Villedieu-les-Poêles;villedieu-les-poeles;8744769;87447698;48.834204;-1.225427;5658;f;FR;t;Europe/Paris;t;FRDUO;VDS;t;;f;8704852;f;;f;;f;;f;;;f;;f;8700757;f;;f;f;;;;;;;;;;;;;;;;;;
 1994;St-Aubin-des-Bois;st-aubin-des-bois;8744770;;48.8333330000;-1.1333330000;;f;FR;f;Europe/Paris;t;FRDUP;;t;;f;8704952;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1995;Mesnil-Clinchamps;mesnil-clinchamps;8744772;87447722;48.8500000000;-0.9833330000;;f;FR;f;Europe/Paris;t;FRDUR;;t;;f;8703978;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1996;Fromentel;fromentel;8744807;87448076;48.71;-0.270521;;f;FR;f;Europe/Paris;t;FRDUS;;t;;f;8703353;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1484,8 +1484,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1998;Messei Centre;messei-centre;8744810;87448100;48.7115660000;-0.5373860000;;f;FR;f;Europe/Paris;t;FRDUU;;t;;f;8703979;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2000;Massy;massy;9903004;;48.7333330000;2.2833330000;;t;FR;f;Europe/Paris;f;FRDVC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2002;Massy—Palaiseau;massy-palaiseau;8739357;;48.725426;2.259636;2000;f;FR;f;Europe/Paris;t;FRMPU;;t;;f;8703937;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2004;La Ferté-Macé;la-ferte-mace;8744846;87448464;48.5899930000;-0.3580000000;2008;f;FR;t;Europe/Paris;t;FRDVE;;t;;f;8703570;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2006;Avranches;avranches;8744851;87448514;48.69025215381758;-1.369943618774414;;f;FR;f;Europe/Paris;t;FRDVG;;t;;f;8702743;f;gbxj1b;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;アヴランシュ;;;;Авранш;;;阿夫朗什
+2004;La Ferté-Macé;la-ferte-mace;8744846;87448464;48.5899930000;-0.3580000000;2008;f;FR;t;Europe/Paris;t;FRDVE;;t;;f;8703570;f;;f;;f;;f;;;f;;f;8700761;f;;f;f;;;;;;;;;;;;;;;;;;
+2006;Avranches;avranches;8744851;87448514;48.69025215381758;-1.369943618774414;;f;FR;f;Europe/Paris;t;FRDVG;;t;;f;8702743;f;gbxj1b;t;;f;;f;;;f;;f;8700834;f;;f;f;;;;;;;;;;;アヴランシュ;;;;Авранш;;;阿夫朗什
 2008;La Ferté-Macé;la-ferte-mace;;;48.5899930000;-0.3580000000;;t;FR;f;Europe/Paris;f;FRDVL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2009;La Ferté-Macé Place Neustadt;la-ferte-mace-place-neustadt;8739168;;48.584205;-0.366759;2008;f;FR;f;Europe/Paris;t;FRDVP;;t;;f;8705319;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2010;Incarville;incarville;8744985;87449850;49.2333330000;1.1833330000;;f;FR;f;Europe/Paris;t;FRDVN;;t;;f;8703481;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1503,7 +1503,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2022;Guichen—Bourg-des-Comptes;guichen-bourg-des-comptes;8747115;87471151;47.935094;-1.760177;;f;FR;f;Europe/Paris;t;FRDWN;;t;;f;8701194;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2023;St-Senoux—Pléchâtel;st-senoux-plechatel;8747116;87471169;47.897852;-1.76602;;f;FR;f;Europe/Paris;t;FRDWO;;t;;f;8702058;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2024;Pléchâtel;plechatel;8747117;87471177;47.9000000000;-1.7500000000;;f;FR;f;Europe/Paris;t;FRDWP;;t;;f;8701772;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2025;Messac—Guipry;messac-guipry;8747118;87471185;47.822343;-1.818589;;f;FR;f;Europe/Paris;t;FRDWQ;;t;;f;8701489;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2025;Messac—Guipry;messac-guipry;8747118;87471185;47.822343;-1.818589;;f;FR;f;Europe/Paris;t;FRDWQ;;t;;f;8701489;f;;f;;f;;f;;;f;;f;8700747;f;;f;f;;;;;;;;;;;;;;;;;;
 2026;Fougeray—Langon;fougeray-langon;8747120;87471201;47.72988;-1.85113;;f;FR;f;Europe/Paris;t;FRDWR;;t;;f;8701129;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2027;Beslé;besle;8747121;87471219;47.699029;-1.870268;;f;FR;f;Europe/Paris;t;FRDWS;;t;;f;8700697;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2028;Massérac;masserac;8747122;87471227;47.6666670000;-1.9166670000;;f;FR;f;Europe/Paris;t;FRDWT;;t;;f;8701624;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1567,10 +1567,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2094;Lorraine TGV;lorraine-tgv;8714210;87142109;48.947406;6.169692;;f;FR;f;Europe/Paris;t;FREAM;TGL;t;;f;8700729;f;;f;;f;;f;;;f;;f;;f;;f;t;;30 km von Metz und Nancy entfernt;30km from Metz and Nancy;a 30 km de Metz y Nancy;à 30 km de Metz et Nancy;30km da Metz a Nancy;;;;;;;;;;;;
 2096;Le Juch;le-juch;8747413;;48.0666670000;-4.2500000000;;f;FR;f;Europe/Paris;t;FREAP;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2097;Bannalec;bannalec;8747418;87474189;47.9333330000;-3.7000000000;;f;FR;f;Europe/Paris;t;FREAQ;;t;;f;8700745;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Банналек;;;巴纳莱克
-2099;Kerhuon;kerhuon;8747421;87474213;48.4000000000;-4.4000000000;;f;FR;f;Europe/Paris;t;FREAS;;t;;f;8701336;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2100;La Forest;la-forest;8747422;87474221;48.4333330000;-4.3166670000;;f;FR;f;Europe/Paris;t;FREAT;;t;;f;8701149;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2099;Kerhuon;kerhuon;8747421;87474213;48.4000000000;-4.4000000000;;f;FR;f;Europe/Paris;t;FREAS;;t;;f;8701336;f;;f;;f;;f;;;f;;f;8700592;f;;f;f;;;;;;;;;;;;;;;;;;
+2100;La Forest;la-forest;8747422;87474221;48.4333330000;-4.3166670000;;f;FR;f;Europe/Paris;t;FREAT;;t;;f;8701149;f;;f;;f;;f;;;f;;f;8700591;f;;f;f;;;;;;;;;;;;;;;;;;
 2101;La Roche-Maurice;la-roche-maurice;8747426;87474262;48.4666670000;-4.2000000000;;f;FR;f;Europe/Paris;t;FREAU;;t;;f;8701441;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ラ・ロッシュ＝モーリス;;;;;;;拉罗克莫里克
-2102;Landivisiau;landivisiau;8747427;87474270;48.5156378130935;-4.052925109863281;;f;FR;f;Europe/Paris;t;FREAV;;t;;f;8701468;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ランディヴィジオ;;;;;;;朗迪维西奥
+2102;Landivisiau;landivisiau;8747427;87474270;48.5156378130935;-4.052925109863281;;f;FR;f;Europe/Paris;t;FREAV;;t;;f;8701468;f;;f;;f;;f;;;f;;f;8700744;f;;f;f;;;;;;;;;;;ランディヴィジオ;;;;;;;朗迪维西奥
 2103;Guimiliau;guimiliau;8747429;87474296;48.4833330000;-4.0000000000;;f;FR;f;Europe/Paris;t;FREAW;;t;;f;8701225;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ギミリオー;;;;;;;吉米利奥
 2104;St-Thégonnec;st-thegonnec;8747431;87474312;48.5166670000;-3.9500000000;;f;FR;f;Europe/Paris;t;FREAX;;t;;f;8702096;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;圣泰戈内克
 2105;Pleyber-Christ;pleyber-christ;8747432;87474320;48.5000000000;-3.8666670000;;f;FR;f;Europe/Paris;t;FREAY;;t;;f;8701777;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;普莱贝克里斯
@@ -1579,16 +1579,16 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2111;Roscoff Port de Bloscon;roscoff-port-de-bloscon;8741433;87414334;48.719122444072696;-3.967941999435425;2126;f;FR;f;Europe/Paris;t;FREBN;;t;;f;8705619;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2112;Henvic;henvic;8747454;87474544;48.6333330000;-3.9333330000;;f;FR;f;Europe/Paris;t;FREBO;;t;;f;8703463;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Анвик;;;昂维克
 2113;Plouenan—Kerlaudy;plouenan-kerlaudy;8747455;87474551;48.643876;-3.971703;;f;FR;f;Europe/Paris;t;FREBP;;t;;f;8704242;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2114;St-Pol-de-Léon;st-pol-de-leon;8747456;87474569;48.676836261845814;-3.9873504638671875;;f;FR;f;Europe/Paris;t;FREBQ;;t;;f;8700372;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝ポル＝ド＝レオン;;;;;;;圣波德莱翁
-2115;Roscoff;roscoff;8747463;87474635;48.72075397941156;-3.9833593368530273;2126;f;FR;t;Europe/Paris;t;FREBR;;t;;f;8704384;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Роскоф;;;罗斯科
+2114;St-Pol-de-Léon;st-pol-de-leon;8747456;87474569;48.676836261845814;-3.9873504638671875;;f;FR;f;Europe/Paris;t;FREBQ;;t;;f;8700372;f;;f;;f;;f;;;f;;f;8700735;f;;f;f;;;;;;;;;;;サン＝ポル＝ド＝レオン;;;;;;;圣波德莱翁
+2115;Roscoff;roscoff;8747463;87474635;48.72075397941156;-3.9833593368530273;2126;f;FR;t;Europe/Paris;t;FREBR;;t;;f;8704384;f;;f;;f;;f;;;f;;f;8700736;f;;f;f;;;;;;;;;;;;;;;Роскоф;;;罗斯科
 2116;Kernevel;kernevel;8747466;87474668;47.9500000000;-3.7833330000;;f;FR;f;Europe/Paris;t;FREBS;;t;;f;8703524;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2117;Scaër;scaer;8747467;87474676;48.0333330000;-3.7000000000;;f;FR;f;Europe/Paris;t;FREBT;;t;;f;8704470;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;斯卡厄
 2118;St-Étienne;st-etienne;;;45.44348229750384;4.399509429931641;;t;FR;f;Europe/Paris;t;FREBU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝テティエンヌ;생테티엔;;;Сент-Этьен;;;圣艾蒂安
 2119;St-Étienne Bellevue;st-etienne-bellevue;8772619;87726190;45.41713371236035;4.392707347869873;2118;f;FR;f;Europe/Paris;t;FRHHI;SEB;t;;f;8704554;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝テティエンヌ;생테티엔;;;Сент-Этьен;;;圣艾蒂安
 2120;St-Étienne Le Clapier;st-etienne-le-clapier;8772617;87726174;45.437118;4.378232;2118;f;FR;f;Europe/Paris;t;FRHHH;SEC;t;;f;8704558;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝テティエンヌ;생테티엔;;;Сент-Этьен;;;圣艾蒂安
 2121;St-Étienne La Terrasse;st-etienne-la-terrasse;8772615;87726158;45.464715;4.379562;2118;f;FR;f;Europe/Paris;t;FRHHG;SET;t;;f;8704557;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝テティエンヌ;생테티엔;;;Сент-Этьен;;;圣艾蒂安
-2122;St-Étienne Châteaucreux;st-etienne-chateaucreux;8772600;87726000;45.44339949510415;4.399477243423462;2118;f;FR;t;Europe/Paris;t;FRHHD;SEN;t;;f;8700046;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;サン＝テティエンヌ;생테티엔;;;Сент-Этьен;;;圣艾蒂安
-2123;St-Étienne Carnot;st-etienne-carnot;8772690;87726901;45.44688;4.385306;2118;f;FR;f;Europe/Paris;t;FRHJD;SEO;t;;f;8704555;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝テティエンヌ;생테티엔;;;Сент-Этьен;;;圣艾蒂安
+2122;St-Étienne Châteaucreux;st-etienne-chateaucreux;8772600;87726000;45.44339949510415;4.399477243423462;2118;f;FR;t;Europe/Paris;t;FRHHD;SEN;t;;f;8700046;f;;f;;f;;f;;;f;;f;8700056;f;;f;t;;;;;;;;;;;サン＝テティエンヌ;생테티엔;;;Сент-Этьен;;;圣艾蒂安
+2123;St-Étienne Carnot;st-etienne-carnot;8772690;87726901;45.44688;4.385306;2118;f;FR;f;Europe/Paris;t;FRHJD;SEO;t;;f;8704555;f;;f;;f;;f;;;f;;f;8700350;f;;f;f;;;;;;;;;;;サン＝テティエンヌ;생테티엔;;;Сент-Этьен;;;圣艾蒂安
 2125;Guiscriff;guiscriff;8747469;87474692;48.0500000000;-3.6500000000;;f;FR;f;Europe/Paris;t;FREBW;;t;;f;8703450;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;吉斯克里
 2126;Roscoff;roscoff;;;48.7238120000;-3.9870930000;;t;FR;f;Europe/Paris;f;FREBX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2127;Argol;argol;8747473;87474734;48.24601115085295;-4.316833019256592;;f;FR;f;Europe/Paris;t;FREBZ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1600,29 +1600,29 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2133;Landaul—Mendon;landaul-mendon;8747622;87476226;47.736271;-3.086563;;f;FR;f;Europe/Paris;t;FRECH;;t;;f;8701352;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2134;Landevant;landevant;8747623;87476234;47.7666670000;-3.1166670000;;f;FR;f;Europe/Paris;t;FRECI;;t;;f;8701471;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2135;Brandérion;branderion;8747624;87476242;47.7833330000;-3.2000000000;;f;FR;f;Europe/Paris;t;FRECJ;;t;;f;8700661;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2136;Hennebont;hennebont;8747625;87476259;47.79899485071827;-3.2857543230056763;;f;FR;f;Europe/Paris;t;FRECK;HEN;t;;f;8701251;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;エンヌボン;;;;;;;埃内邦
+2136;Hennebont;hennebont;8747625;87476259;47.79899485071827;-3.2857543230056763;;f;FR;f;Europe/Paris;t;FRECK;HEN;t;;f;8701251;f;;f;;f;;f;;;f;;f;8700677;f;;f;f;;;;;;;;;;;エンヌボン;;;;;;;埃内邦
 2137;Gestel;gestel;8747630;87476309;47.8000000000;-3.4500000000;;f;FR;f;Europe/Paris;t;FRECN;;t;;f;8701196;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2138;Quimperlé;quimperle;8747631;87476317;47.86953867386069;-3.552982807159424;;f;FR;f;Europe/Paris;t;FRECO;QPL;t;ECO;t;8700543;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;カンペルレ;;;;Кемперле;;;坎佩尔莱
+2138;Quimperlé;quimperle;8747631;87476317;47.86953867386069;-3.552982807159424;;f;FR;f;Europe/Paris;t;FRECO;QPL;t;ECO;t;8700543;f;;f;;f;;f;;;f;;f;8700679;f;;f;t;;;;;;;;;;;カンペルレ;;;;Кемперле;;;坎佩尔莱
 2139;Belz—Ploemel;belz-ploemel;8747640;87476408;47.652465;-3.072189;;f;FR;f;Europe/Paris;t;FRECQ;;t;;f;8704938;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2140;Penthièvre;penthievre;8747642;87476424;47.558024;-3.133073;;f;FR;f;Europe/Paris;t;FRECS;;t;;f;8704198;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2141;Kerhostin;kerhostin;8747643;87476432;47.536962;-3.136363;;f;FR;f;Europe/Paris;t;FRECT;;t;;f;8703523;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2142;Quiberon;quiberon;8747645;87476457;47.485290830718775;-3.1181752681732173;;f;FR;f;Europe/Paris;t;FRECV;;t;;f;8704336;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;キブロン;;;;;;;屈伊伯龙
+2140;Penthièvre;penthievre;8747642;87476424;47.558024;-3.133073;;f;FR;f;Europe/Paris;t;FRECS;;t;;f;8704198;f;;f;;f;;f;;;f;;f;8700738;f;;f;f;;;;;;;;;;;;;;;;;;
+2141;Kerhostin;kerhostin;8747643;87476432;47.536962;-3.136363;;f;FR;f;Europe/Paris;t;FRECT;;t;;f;8703523;f;;f;;f;;f;;;f;;f;8700739;f;;f;f;;;;;;;;;;;;;;;;;;
+2142;Quiberon;quiberon;8747645;87476457;47.485290830718775;-3.1181752681732173;;f;FR;f;Europe/Paris;t;FRECV;;t;;f;8704336;f;;f;;f;;f;;;f;;f;8700742;f;;f;f;;;;;;;;;;;キブロン;;;;;;;屈伊伯龙
 2143;Pontivy;pontivy;8747655;87476556;48.06192304752991;-2.965782880783081;9399;f;FR;t;Europe/Paris;t;FREDA;;t;;f;8704283;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ポンティヴィ;;;;Понтиви;;;蓬蒂维
 2144;St-Gérand;st-gerand;8747656;87476564;48.1000000000;-2.8833330000;;f;FR;f;Europe/Paris;t;FREDB;;t;;f;8704411;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2145;Ste-Anne-d’Auray;ste-anne-dauray;8747664;87476648;47.67857571853804;-2.9605525732040405;;f;FR;f;Europe/Paris;t;FREDC;;t;;f;8701947;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2146;Questembert;questembert;8747667;87476671;47.68315889627395;-2.4495863914489746;;f;FR;f;Europe/Paris;t;FREDF;QUE;t;;f;8701827;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;屈埃斯唐贝尔
+2146;Questembert;questembert;8747667;87476671;47.68315889627395;-2.4495863914489746;;f;FR;f;Europe/Paris;t;FREDF;QUE;t;;f;8701827;f;;f;;f;;f;;;f;;f;8700674;f;;f;f;;;;;;;;;;;;;;;;;;屈埃斯唐贝尔
 2147;Malansac;malansac;8747668;87476689;47.6833330000;-2.3000000000;;f;FR;f;Europe/Paris;t;FREDG;;t;;f;8701493;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2148;Séverac;severac;8747675;87476754;47.54931927800045;-2.0722424983978267;;f;FR;f;Europe/Paris;t;FREDH;;t;;f;8704491;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2149;St-Gildas-des-Bois;st-gildas-des-bois;8747676;87476762;47.516490592721055;-2.043934464454651;;f;FR;f;Europe/Paris;t;FREDI;;t;;f;8704578;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2150;Dréfféac;dreffeac;8747677;87476770;47.4666670000;-2.0666670000;;f;FR;f;Europe/Paris;t;FREDJ;;t;;f;8703246;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2151;St-Germain-sur-Ille;st-germain-sur-ille;8747801;87478016;48.24889395301306;-1.6593700647354126;;f;FR;f;Europe/Paris;t;FREDK;;t;;f;8704574;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2152;St-Médard-sur-Ille;st-medard-sur-ille;8747802;87478024;48.2666670000;-1.6666670000;;f;FR;f;Europe/Paris;t;FREDL;;t;;f;8703962;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2153;Montreuil-sur-Ille;montreuil-sur-ille;8747803;87478032;48.30701897687044;-1.6743206977844236;;f;FR;f;Europe/Paris;t;FREDM;;t;;f;8704051;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2153;Montreuil-sur-Ille;montreuil-sur-ille;8747803;87478032;48.30701897687044;-1.6743206977844236;;f;FR;f;Europe/Paris;t;FREDM;;t;;f;8704051;f;;f;;f;;f;;;f;;f;8700630;f;;f;f;;;;;;;;;;;;;;;;;;
 2154;Dingé;dinge;8747804;87478040;48.3500000000;-1.7166670000;;f;FR;f;Europe/Paris;t;FREDN;;t;;f;8703217;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2155;Combourg;combourg;8747805;87478057;48.416188797615135;-1.727723479270935;;f;FR;f;Europe/Paris;t;FREDO;;t;;f;8703136;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2155;Combourg;combourg;8747805;87478057;48.416188797615135;-1.727723479270935;;f;FR;f;Europe/Paris;t;FREDO;;t;;f;8703136;f;;f;;f;;f;;;f;;f;8700833;f;;f;f;;;;;;;;;;;;;;;;;;
 2156;Bonnemain;bonnemain;8747806;87478065;48.4666670000;-1.7666670000;;f;FR;f;Europe/Paris;t;FREDP;;t;;f;8702866;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2157;La Fresnais;la-fresnais;8747808;87478081;48.6000000000;-1.8500000000;;f;FR;f;Europe/Paris;t;FREDQ;;t;;f;8703575;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2158;La Gouesnière—Cancale;la-gouesniere-cancale;8747809;87478099;48.614418;-1.905803;;f;FR;f;Europe/Paris;t;FREDR;;t;;f;8703580;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2158;La Gouesnière—Cancale;la-gouesniere-cancale;8747809;87478099;48.614418;-1.905803;;f;FR;f;Europe/Paris;t;FREDR;;t;;f;8703580;f;;f;;f;;f;;;f;;f;8700832;f;;f;f;;;;;;;;;;;;;;;;;;
 2159;Plerguer;plerguer;8747812;87478123;48.5333330000;-1.8500000000;;f;FR;f;Europe/Paris;t;FREDS;;t;;f;8704233;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;普莱尔盖
 2160;Miniac;miniac;8747813;87478131;48.5166670000;-1.9000000000;;f;FR;f;Europe/Paris;t;FREDT;;t;;f;8703995;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2161;Pleudihen;pleudihen;8747814;87478149;48.5166670000;-1.9666670000;;f;FR;f;Europe/Paris;t;FREDU;;t;;f;8704235;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1631,7 +1631,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2164;Laval Centre;laval-centre;8747839;87478396;48.07048017444796;-0.7713925838470459;4714;f;FR;f;Europe/Paris;t;FREDZ;;t;;f;8704979;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2165;Montsurs;montsurs;8747853;87478537;48.1333330000;-0.5500000000;;f;FR;f;Europe/Paris;t;FREEC;;t;;f;8701563;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2166;Neau;neau;8747854;87478545;48.1500000000;-0.4666670000;;f;FR;f;Europe/Paris;t;FREED;;t;;f;8701661;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2167;Évron;evron;8747855;87478552;48.15563681307041;-0.3969240188598633;;f;FR;f;Europe/Paris;t;FREEE;;t;;f;8701096;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2167;Évron;evron;8747855;87478552;48.15563681307041;-0.3969240188598633;;f;FR;f;Europe/Paris;t;FREEE;;t;;f;8701096;f;;f;;f;;f;;;f;;f;8700819;f;;f;f;;;;;;;;;;;;;;;;;;
 2168;Voutré;voutre;8747856;87478560;48.134044;-0.292185;;f;FR;f;Europe/Paris;t;FREEF;;t;;f;8702208;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2169;Martigné-sur-mayenne Centre;martigne-sur-mayenne-centre;8747857;;48.2000000000;-0.6666670000;;f;FR;f;Europe/Paris;t;FREEG;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2170;Commer Centre;commer-centre;8747858;;48.2333330000;-0.6166670000;;f;FR;f;Europe/Paris;t;FREEH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1648,11 +1648,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2183;Le Cellier;le-cellier;8748116;87481168;47.3166670000;-1.3500000000;;f;FR;f;Europe/Paris;t;FREFK;;t;;f;8700884;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;勒瑟利耶
 2184;Boussay-la-Bruffière;boussay-la-bruffiere;8748117;87481176;47.050574;-1.182809;;f;FR;f;Europe/Paris;t;FREFL;;t;;f;8702898;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2185;Oudon;oudon;8748118;87481184;47.3500000000;-1.2833330000;;f;FR;f;Europe/Paris;t;FREFM;;t;;f;8701707;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2186;Ancenis;ancenis;8748119;87481192;47.36942271048285;-1.177886724472046;;f;FR;f;Europe/Paris;t;FREFN;ANC;t;;f;8700618;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アンスニ;;;;;;;昂瑟尼
+2186;Ancenis;ancenis;8748119;87481192;47.36942271048285;-1.177886724472046;;f;FR;f;Europe/Paris;t;FREFN;ANC;t;;f;8700618;f;;f;;f;;f;;;f;;f;8700714;f;;f;t;;;;;;;;;;;アンスニ;;;;;;;昂瑟尼
 2187;Bouaye;bouaye;8748120;87481200;47.1500000000;-1.7000000000;;f;FR;f;Europe/Paris;t;FREFO;;t;;f;8702877;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;布艾埃
 2188;Port-St-Père St-Mars;port-st-pere-st-mars;8748121;87481218;47.116429;-1.739547;9210;f;FR;f;Europe/Paris;t;FREFP;;t;;f;8704295;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2189;Bourgneuf-en-Retz;bourgneuf-en-retz;8748124;87481242;47.0500000000;-1.9500000000;2193;f;FR;t;Europe/Paris;t;FREFQ;;t;;f;8702890;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;雷特地区布尔盖于
-2192;Pornic;pornic;8748128;87481283;47.11457635000373;-2.097541093826294;;f;FR;f;Europe/Paris;t;FREFT;;t;;f;8704290;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;波尔尼克
+2189;Bourgneuf-en-Retz;bourgneuf-en-retz;8748124;87481242;47.0500000000;-1.9500000000;2193;f;FR;t;Europe/Paris;t;FREFQ;;t;;f;8702890;f;;f;;f;;f;;;f;;f;8700823;f;;f;f;;;;;;;;;;;;;;;;;;雷特地区布尔盖于
+2192;Pornic;pornic;8748128;87481283;47.11457635000373;-2.097541093826294;;f;FR;f;Europe/Paris;t;FREFT;;t;;f;8704290;f;;f;;f;;f;;;f;;f;8700821;f;;f;f;;;;;;;;;;;;;;;;;;波尔尼克
 2193;Bourgneuf-en-Retz;bourgneuf-en-retz;;;47.0500000000;-1.9500000000;;t;FR;f;Europe/Paris;f;FREFU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2194;Machecoul;machecoul;8748136;87481366;46.99048439006509;-1.8227326869964597;;f;FR;f;Europe/Paris;t;FREFW;;t;;f;8703874;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;马谢库
 2195;Vertou;vertou;8748140;87481408;47.18605;-1.477907;;f;FR;f;Europe/Paris;t;FREFY;VTU;t;;f;8702238;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ヴェルトゥ;;;;;;;韦尔图
@@ -1663,11 +1663,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2200;Cugand;cugand;8748145;87481457;47.0666670000;-1.2500000000;;f;FR;f;Europe/Paris;t;FREGD;;t;;f;8703193;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;屈冈
 2201;Montaigu;montaigu;8748146;87481465;46.983707166807655;-1.316288709640503;;f;FR;f;Europe/Paris;t;FREGE;;t;;f;8701566;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2202;La Croix-de-Méan;la-croix-de-mean;8748168;87481689;47.300456;-2.193305;;f;FR;f;Europe/Paris;t;FREGO;;t;;f;8700987;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2203;Donges;donges;8748172;87481721;47.3182390000;-2.0753760000;;f;FR;f;Europe/Paris;t;FREGP;;t;;f;8701018;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;东热
-2204;Pornichet;pornichet;8748174;87481747;47.270537494911174;-2.3445886373519897;;f;FR;f;Europe/Paris;t;FREGR;PNI;t;;f;8701799;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;波尔尼谢
-2205;Le Pouliguen;le-pouliguen;8748176;87481762;47.282547995628576;-2.4331283569335938;;f;FR;f;Europe/Paris;t;FREGS;LIG;t;;f;8701820;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;勒普利盖恩
-2206;Batz-sur-Mer;batz-sur-mer;8748177;87481770;47.28096858849457;-2.4789083003997803;;f;FR;f;Europe/Paris;t;FREGT;;t;;f;8700795;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;滨海巴特
-2207;Le Croisic;le-croisic;8748178;87481788;47.290044077686;-2.5069212913513184;;f;FR;f;Europe/Paris;t;FREGU;LCC;t;;f;8700199;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;勒克鲁瓦西克
+2203;Donges;donges;8748172;87481721;47.3182390000;-2.0753760000;;f;FR;f;Europe/Paris;t;FREGP;;t;;f;8701018;f;;f;;f;;f;;;f;;f;8700763;f;;f;f;;;;;;;;;;;;;;;;;;东热
+2204;Pornichet;pornichet;8748174;87481747;47.270537494911174;-2.3445886373519897;;f;FR;f;Europe/Paris;t;FREGR;PNI;t;;f;8701799;f;;f;;f;;f;;;f;;f;8700618;f;;f;t;;;;;;;;;;;;;;;;;;波尔尼谢
+2205;Le Pouliguen;le-pouliguen;8748176;87481762;47.282547995628576;-2.4331283569335938;;f;FR;f;Europe/Paris;t;FREGS;LIG;t;;f;8701820;f;;f;;f;;f;;;f;;f;8700619;f;;f;f;;;;;;;;;;;;;;;;;;勒普利盖恩
+2206;Batz-sur-Mer;batz-sur-mer;8748177;87481770;47.28096858849457;-2.4789083003997803;;f;FR;f;Europe/Paris;t;FREGT;;t;;f;8700795;f;;f;;f;;f;;;f;;f;8700622;f;;f;f;;;;;;;;;;;;;;;;;;滨海巴特
+2207;Le Croisic;le-croisic;8748178;87481788;47.290044077686;-2.5069212913513184;;f;FR;f;Europe/Paris;t;FREGU;LCC;t;;f;8700199;f;;f;;f;;f;;;f;;f;8700623;f;;f;f;;;;;;;;;;;;;;;;;;勒克鲁瓦西克
 2208;Couëron;coueron;8748180;87481804;47.2166670000;-1.7333330000;;f;FR;f;Europe/Paris;t;FREGV;;t;;f;8700976;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;库厄龙
 2209;St-Étienne-de-Montluc;st-etienne-de-montluc;8748181;87481812;47.2666670000;-1.7833330000;;f;FR;f;Europe/Paris;t;FREGW;;t;;f;8702061;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;圣埃蒂安德蒙特吕克
 2210;Cordemais;cordemais;8748182;87481820;47.2833330000;-1.8833330000;;f;FR;f;Europe/Paris;t;FREGX;;t;;f;8700850;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;科尔代迈
@@ -1686,10 +1686,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2228;Château-Gontier;chateau-gontier;8748465;;47.8500000000;-0.9500000000;5274;f;FR;t;Europe/Paris;f;FREHV;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2229;Segré;segre;8748470;;47.7000000000;-0.4500000000;5185;f;FR;t;Europe/Paris;t;FREHZ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2231;L’Île-d’Elle;lile-delle;8748507;87485078;46.323275;-0.941512;;f;FR;f;Europe/Paris;t;FREIJ;;t;;f;8702437;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2232;Châtelaillon;chatelaillon;8748511;87485110;46.07833629106095;-1.0908865928649902;;f;FR;f;Europe/Paris;t;FREIL;CTL;t;;f;8702303;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2233;Tonnay;tonnay;8748515;87485151;45.943301;-0.897896;;f;FR;f;Europe/Paris;t;FREIO;;t;;f;8702425;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2234;Surgères;surgeres;8748522;87485227;46.11336359497748;-0.7620584964752196;;f;FR;f;Europe/Paris;t;FREIP;SGE;t;;f;8702063;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-2235;Mauzé;mauze;8748525;87485250;46.199594401792936;-0.673760175704956;;f;FR;f;Europe/Paris;t;FREIQ;;t;;f;8701646;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2232;Châtelaillon;chatelaillon;8748511;87485110;46.07833629106095;-1.0908865928649902;;f;FR;f;Europe/Paris;t;FREIL;CTL;t;;f;8702303;f;;f;;f;;f;;;f;;f;8700632;f;;f;f;;;;;;;;;;;;;;;;;;
+2233;Tonnay;tonnay;8748515;87485151;45.943301;-0.897896;;f;FR;f;Europe/Paris;t;FREIO;;t;;f;8702425;f;;f;;f;;f;;;f;;f;8700634;f;;f;f;;;;;;;;;;;;;;;;;;
+2234;Surgères;surgeres;8748522;87485227;46.11336359497748;-0.7620584964752196;;f;FR;f;Europe/Paris;t;FREIP;SGE;t;;f;8702063;f;;f;;f;;f;;;f;;f;8700629;f;;f;t;;;;;;;;;;;;;;;;;;
+2235;Mauzé;mauze;8748525;87485250;46.199594401792936;-0.673760175704956;;f;FR;f;Europe/Paris;t;FREIQ;;t;;f;8701646;f;;f;;f;;f;;;f;;f;8700628;f;;f;f;;;;;;;;;;;;;;;;;;
 2236;Prin-Deyrançon;prin-deyrancon;8748526;87485268;46.2166670000;-0.6333330000;;f;FR;f;Europe/Paris;t;FREIR;;t;;f;8701440;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2237;Épannes;epannes;8748527;;46.2333330000;-0.5833330000;;f;FR;f;Europe/Paris;f;FREIS;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2238;Fors;fors;8748532;87485326;46.2333330000;-0.4000000000;;f;FR;f;Europe/Paris;t;FREIV;;t;;f;8703339;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1697,7 +1697,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2240;Beauvoir-sur-Niort;beauvoir-sur-niort;8748534;87485342;46.1666670000;-0.4666670000;;f;FR;f;Europe/Paris;t;FREIX;;t;;f;8702792;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2241;Prissé-la-Charrière;prisse-la-charriere;8748535;87485359;46.1500000000;-0.5000000000;;f;FR;f;Europe/Paris;t;FREIY;;t;;f;8704323;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2242;La Crèche;la-creche;8748547;87485474;46.3666670000;-0.3000000000;;f;FR;f;Europe/Paris;t;FREJA;;t;;f;8700944;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2243;St-Maixent;st-maixent;8748549;87485490;46.40640989896774;-0.20123004913330078;;f;FR;f;Europe/Paris;t;FREJC;SMX;t;;f;8702007;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+2243;St-Maixent;st-maixent;8748549;87485490;46.40640989896774;-0.20123004913330078;;f;FR;f;Europe/Paris;t;FREJC;SMX;t;;f;8702007;f;;f;;f;;f;;;f;;f;8700625;f;;f;t;;;;;;;;;;;;;;;;;;
 2244;La Mothe-St-Héray;la-mothe-st-heray;8748550;87485508;46.36067143443812;-0.1126420497894287;;f;FR;f;Europe/Paris;t;FREJD;;t;;f;8701549;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2245;Pamproux;pamproux;8748552;87485524;46.3833330000;-0.0500000000;;f;FR;f;Europe/Paris;t;FREJE;;t;;f;8701735;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2246;Rouillé;rouille;8748553;87485532;46.4166670000;0.0500000000;;f;FR;f;Europe/Paris;t;FREJF;;t;;f;8701869;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1712,19 +1712,19 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2260;La Chaize-le-Vicomte;la-chaize-le-vicomte;8748630;87486308;46.6666670000;-1.3000000000;;f;FR;f;Europe/Paris;t;FREKC;;t;;f;8703551;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2261;Fougeré;fougere;8748631;87486316;46.6500000000;-1.2333330000;;f;FR;f;Europe/Paris;t;FREKD;;t;;f;8703341;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2262;Bournezeau;bournezeau;8748632;87486324;46.6333330000;-1.1666670000;;f;FR;f;Europe/Paris;t;FREKE;;t;;f;8702893;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2263;Chantonnay;chantonnay;8748633;87486332;46.6833330000;-1.0500000000;;f;FR;f;Europe/Paris;t;FREKF;;t;;f;8703040;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2263;Chantonnay;chantonnay;8748633;87486332;46.6833330000;-1.0500000000;;f;FR;f;Europe/Paris;t;FREKF;;t;;f;8703040;f;;f;;f;;f;;;f;;f;8700616;f;;f;f;;;;;;;;;;;;;;;;;;
 2264;Les Clouzeaux;les-clouzeaux;8748640;;46.6166670000;-1.5166670000;;f;FR;f;Europe/Paris;t;FREKG;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2265;La Mothe-Achard;la-mothe-achard;8748642;87486423;46.60686491187382;-1.6596221923828125;;f;FR;f;Europe/Paris;t;FREKI;;t;;f;8701410;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2265;La Mothe-Achard;la-mothe-achard;8748642;87486423;46.60686491187382;-1.6596221923828125;;f;FR;f;Europe/Paris;t;FREKI;;t;;f;8701410;f;;f;;f;;f;;;f;;f;8700728;f;;f;f;;;;;;;;;;;;;;;;;;
 2266;Olonne-sur-Mer;olonne-sur-mer;8748643;87486431;46.5333330000;-1.7833330000;;f;FR;f;Europe/Paris;t;FREKJ;;t;;f;8701711;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2267;Soullans Centre;soullans-centre;8748658;87486589;;;;f;FR;f;Europe/Paris;f;FREKP;;t;;f;8704518;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2268;Torfou;torfou;8748689;87486894;47.032497;-1.091802;5285;f;FR;t;Europe/Paris;t;FREKQ;;t;;f;8704726;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2270;Noirterre;noirterre;8748723;87487231;46.8666670000;-0.4000000000;;f;FR;f;Europe/Paris;t;FREKV;;t;;f;8704124;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2271;Cerizay;cerizay;8748728;87487280;46.8166670000;-0.6666670000;5125;f;FR;t;Europe/Paris;t;FREKX;;t;;f;8703003;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2271;Cerizay;cerizay;8748728;87487280;46.8166670000;-0.6666670000;5125;f;FR;t;Europe/Paris;t;FREKX;;t;;f;8703003;f;;f;;f;;f;;;f;;f;8700614;f;;f;f;;;;;;;;;;;;;;;;;;
 2272;St-Mesmin-le-Vieux;st-mesmin-le-vieux;8748729;;;;;f;FR;f;Europe/Paris;f;FREKY;;t;;f;8704621;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2273;Pouzauges;pouzauges;8748731;87487314;46.7833330000;-0.8333330000;5018;f;FR;t;Europe/Paris;t;FREKZ;;t;;f;8704307;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2273;Pouzauges;pouzauges;8748731;87487314;46.7833330000;-0.8333330000;5018;f;FR;t;Europe/Paris;t;FREKZ;;t;;f;8704307;f;;f;;f;;f;;;f;;f;8700615;f;;f;f;;;;;;;;;;;;;;;;;;
 2275;Chavagnes-les-Redoux;chavagnes-les-redoux;8748734;;46.7166670000;-0.9000000000;;f;FR;f;Europe/Paris;t;FRELB;;t;;f;8703077;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2278;Brion-près-Thouet;brion-pres-thouet;8748761;87487611;47.0500000000;-0.1833330000;;f;FR;f;Europe/Paris;t;FRELI;;t;;f;8702926;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2279;Montreuil-Bellay;montreuil-bellay;8748763;87487637;47.1333330000;-0.1500000000;4941;f;FR;t;Europe/Paris;t;FRELJ;;t;;f;8704050;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2279;Montreuil-Bellay;montreuil-bellay;8748763;87487637;47.1333330000;-0.1500000000;4941;f;FR;t;Europe/Paris;t;FRELJ;;t;;f;8704050;f;;f;;f;;f;;;f;;f;8700611;f;;f;f;;;;;;;;;;;;;;;;;;
 2280;Eurville Mairie;eurville-mairie;8710746;;48.5833330000;5.0333330000;5606;f;FR;f;Europe/Paris;t;FRELM;;t;;f;8705021;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2282;Vivy Centre;vivy-centre;8748771;87487710;47.324763;-0.059086;;f;FR;f;Europe/Paris;t;FRELO;;t;;f;8704900;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2283;Vernantes Centre;vernantes-centre;8748773;87487736;47.39358127232468;0.052533745765686035;;f;FR;f;Europe/Paris;t;FRELP;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1732,36 +1732,36 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2287;Bauge;bauge;8748783;87487835;47.5500000000;-0.1000000000;;f;FR;f;Europe/Paris;t;FRELU;;t;;f;8702783;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2288;La Bohalle;la-bohalle;8748784;87487843;47.4166670000;-0.4000000000;;f;FR;f;Europe/Paris;t;FRELV;;t;;f;8702851;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2289;Les Rosiers-sur-Loire;les-rosiers-sur-loire;8748787;87487876;47.36257740705761;-0.22047758102416992;;f;FR;f;Europe/Paris;t;FRELW;;t;;f;8704385;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2290;La Ménitré;la-menitre;8748788;87487884;47.39744866512633;-0.27618706226348877;;f;FR;f;Europe/Paris;t;FRELX;;t;;f;8703586;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2290;La Ménitré;la-menitre;8748788;87487884;47.39744866512633;-0.27618706226348877;;f;FR;f;Europe/Paris;t;FRELX;;t;;f;8703586;f;;f;;f;;f;;;f;;f;8700713;f;;f;f;;;;;;;;;;;;;;;;;;
 2291;St-Mathurin;st-mathurin;8748789;87487892;47.4166670000;-0.3166670000;;f;FR;f;Europe/Paris;t;FRELY;;t;;f;8704421;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2292;Chiche;chiche;8748908;87489088;46.8000000000;-0.3666670000;;f;FR;f;Europe/Paris;t;FREMB;;t;;f;8703096;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2293;Mouzeuil-St-Martin;mouzeuil-st-martin;8748914;87489146;46.4666670000;-0.9666670000;;f;FR;f;Europe/Paris;t;FREMC;;t;;f;8702445;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2296;Bords;bords;8749101;87491019;45.9000000000;-0.8000000000;;f;FR;f;Europe/Paris;t;FREMJ;;t;;f;8702391;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2297;St-Savinien-sur-Charente;st-savinien-sur-charente;8749103;87491035;45.875953;-0.677687;;f;FR;f;Europe/Paris;t;FREML;;t;;f;8702423;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2298;Taillebourg;taillebourg;8749104;87491043;45.830576;-0.64511;;f;FR;f;Europe/Paris;t;FREMM;;t;;f;8702447;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2299;Pons;pons;8749110;87491100;45.5833330000;-0.5500000000;;f;FR;f;Europe/Paris;t;FREMO;;t;;f;8702413;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2299;Pons;pons;8749110;87491100;45.5833330000;-0.5500000000;;f;FR;f;Europe/Paris;t;FREMO;;t;;f;8702413;f;;f;;f;;f;;;f;;f;8700638;f;;f;f;;;;;;;;;;;;;;;;;;
 2300;Clion-sur-Seugne;clion-sur-seugne;8749113;87491134;45.478558;-0.50211;;f;FR;f;Europe/Paris;t;FREMQ;;t;;f;8702398;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2301;Jonzac;jonzac;8749114;87491142;45.43873225428931;-0.4416525363922119;;f;FR;f;Europe/Paris;t;FREMR;JOH;t;;f;8702405;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2301;Jonzac;jonzac;8749114;87491142;45.43873225428931;-0.4416525363922119;;f;FR;f;Europe/Paris;t;FREMR;JOH;t;;f;8702405;f;;f;;f;;f;;;f;;f;8700639;f;;f;f;;;;;;;;;;;;;;;;;;
 2302;Fontaines-d’Ozillac;fontaines-dozillac;8749115;87491159;45.387178748844136;-0.38359880447387695;;f;FR;f;Europe/Paris;t;FREMS;;t;;f;8702432;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2303;Montendre;montendre;8749118;87491183;45.28052596820598;-0.39617300033569336;;f;FR;f;Europe/Paris;t;FREMT;;t;;f;8702443;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2303;Montendre;montendre;8749118;87491183;45.28052596820598;-0.39617300033569336;;f;FR;f;Europe/Paris;t;FREMT;;t;;f;8702443;f;;f;;f;;f;;;f;;f;8700641;f;;f;f;;;;;;;;;;;;;;;;;;
 2304;Bussac-Forêt;bussac-foret;8749119;87491191;45.2119;-0.3682;;f;FR;f;Europe/Paris;t;FREMU;;t;;f;8702392;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2305;St-Mariens—St-Yzan;st-mariens-st-yzan;8749120;87491209;45.139476;-0.391489;;f;FR;f;Europe/Paris;t;FREMV;SMS;t;;f;8702421;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2305;St-Mariens—St-Yzan;st-mariens-st-yzan;8749120;87491209;45.139476;-0.391489;;f;FR;f;Europe/Paris;t;FREMV;SMS;t;;f;8702421;f;;f;;f;;f;;;f;;f;8700642;f;;f;f;;;;;;;;;;;;;;;;;;
 2306;Cavignac;cavignac;8749121;87491217;45.1000000000;-0.3833330000;;f;FR;f;Europe/Paris;t;FREMW;;t;;f;8702393;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2307;Gauriaguet;gauriaguet;8749122;87491225;45.0333330000;-0.4000000000;;f;FR;f;Europe/Paris;t;FREMX;;t;;f;8702435;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2308;Aubie—St-Antoine;aubie-st-antoine;8749123;87491233;45.015083;-0.419823;;f;FR;f;Europe/Paris;t;FREMY;;t;;f;8702390;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2309;St-André-de-Cubzac;st-andre-de-cubzac;8749124;87491241;44.99107985991532;-0.4403972625732422;;f;FR;f;Europe/Paris;t;FREMZ;SAC;t;;f;8702417;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2309;St-André-de-Cubzac;st-andre-de-cubzac;8749124;87491241;44.99107985991532;-0.4403972625732422;;f;FR;f;Europe/Paris;t;FREMZ;SAC;t;;f;8702417;f;;f;;f;;f;;;f;;f;8700644;f;;f;f;;;;;;;;;;;;;;;;;;
 2310;Villeneuve-la-Comtesse;villeneuve-la-comtesse;8749125;87491258;46.09867;-0.513032;;f;FR;f;Europe/Paris;t;FRENA;;t;;f;8704864;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2311;Cubzac-les-Ponts;cubzac-les-ponts;8749126;87491266;44.9666670000;-0.4500000000;;f;FR;f;Europe/Paris;t;FRENB;;t;;f;8702400;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2312;Nancy;nancy;8714100;87141002;48.68918269690642;6.174434423446655;;f;FR;f;Europe/Paris;t;FRENC;NCY;t;;f;8700018;f;u0skvn;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ナンシー;;;;Нанси;;;南希
+2312;Nancy;nancy;8714100;87141002;48.68918269690642;6.174434423446655;;f;FR;f;Europe/Paris;t;FRENC;NCY;t;;f;8700018;f;u0skvn;t;;f;;f;;;f;;f;8700022;f;;f;t;;;;;;;;;;;ナンシー;;;;Нанси;;;南希
 2313;La Grave-d’Ambarès;la-grave-dambares;8749127;87491274;44.93579;-0.477048;;f;FR;f;Europe/Paris;t;FREND;;t;;f;8702438;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2314;Ste-Eulalie—Carbon-Blanc;ste-eulalie-carbon-blanc;8749128;87491282;44.897864;-0.493741;;f;FR;f;Europe/Paris;t;FRENE;;t;;f;8702424;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2315;Loulay;loulay;8749129;87491290;46.0500000000;-0.5000000000;;f;FR;f;Europe/Paris;t;FRENF;;t;;f;8703836;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2316;St-Hilaire—Brizambourg;st-hilaire-brizambourg;8749132;87491324;45.850082;-0.534633;;f;FR;f;Europe/Paris;t;FRENH;;t;;f;8704412;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2317;St-Jean-d’Angély;st-jean-dangely;8749135;87491357;45.94255573048781;-0.5103707313537598;;f;FR;f;Europe/Paris;t;FRENJ;;t;;f;8704590;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝ジャン＝ダンジェリ;;;;Сен-Жан-д’Анжели;;;圣让当热利
-2318;Jarnac-Charente;jarnac-charente;8749147;87491472;45.67117154038404;-0.1777660846710205;;f;FR;f;Europe/Paris;t;FRENP;;t;;f;8702350;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2319;Châteauneuf-sur-Charente;chateauneuf-sur-charente;8749150;87491506;45.6000000000;-0.0500000000;;f;FR;f;Europe/Paris;t;FRENR;;t;;f;8702336;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2318;Jarnac-Charente;jarnac-charente;8749147;87491472;45.67117154038404;-0.1777660846710205;;f;FR;f;Europe/Paris;t;FRENP;;t;;f;8702350;f;;f;;f;;f;;;f;;f;8700258;f;;f;f;;;;;;;;;;;;;;;;;;
+2319;Châteauneuf-sur-Charente;chateauneuf-sur-charente;8749150;87491506;45.6000000000;-0.0500000000;;f;FR;f;Europe/Paris;t;FRENR;;t;;f;8702336;f;;f;;f;;f;;;f;;f;8700248;f;;f;f;;;;;;;;;;;;;;;;;;
 2320;Barbézieux;barbezieux;8749177;87491779;45.4500000000;-0.1333330000;;f;FR;f;Europe/Paris;t;FRENW;;t;;f;8702769;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2321;Saujon;saujon;8749181;87491811;45.66651193258001;-0.9300130605697631;;f;FR;f;Europe/Paris;t;FRENX;SJW;t;;f;8702346;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2321;Saujon;saujon;8749181;87491811;45.66651193258001;-0.9300130605697631;;f;FR;f;Europe/Paris;t;FRENX;SJW;t;;f;8702346;f;;f;;f;;f;;;f;;f;8700579;f;;f;f;;;;;;;;;;;;;;;;;;
 2324;L’Habitarelle;lhabitarelle;8750352;87503524;44.573228;3.769473;;f;FR;f;Europe/Paris;t;FREOF;;t;;f;8703532;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2325;Larroque;larroque;8751774;87517748;44.5166670000;1.9500000000;;f;FR;f;Europe/Paris;t;FREOK;;t;;f;8703665;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2326;Asasp;asasp;8751789;87517896;43.1166670000;-0.6166670000;;f;FR;f;Europe/Paris;t;FREOL;;t;;f;8702696;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1775,13 +1775,13 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2340;Chevilly;chevilly;8754304;87543041;48.0333330000;1.8833330000;;f;FR;f;Europe/Paris;t;FREPI;;t;;f;8700882;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Шевильи-Ларю;;;谢维利拉吕厄
 2341;Artenay;artenay;8754305;;48.080860099164866;1.883329153060913;;f;FR;f;Europe/Paris;t;FREPJ;;t;;f;8700629;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;阿尔特奈
 2342;Château-Gaillard;chateau-gaillard;8754306;;48.141442;1.912697;;f;FR;f;Europe/Paris;t;FREPK;;t;;f;8700876;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2343;Épinal;epinal;8714400;87144006;48.17800568058464;6.441614627838135;;f;FR;f;Europe/Paris;t;FREPL;ELP;t;;f;8700255;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;エピナル;;;;Эпиналь;;;埃皮纳勒
+2343;Épinal;epinal;8714400;87144006;48.17800568058464;6.441614627838135;;f;FR;f;Europe/Paris;t;FREPL;ELP;t;;f;8700255;f;;f;;f;;f;;;f;;f;8700897;f;;f;t;;;;;;;;;;;エピナル;;;;Эпиналь;;;埃皮纳勒
 2344;Toury;toury;8754307;87543074;48.193507;1.939701;;f;FR;f;Europe/Paris;t;FREPM;;t;;f;8702138;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2345;Boisseaux;boisseaux;8754308;87543082;48.25644133812459;1.9858646392822266;;f;FR;f;Europe/Paris;t;FREPN;;t;;f;8700757;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2346;Angerville;angerville;8754309;;48.3166670000;2.0000000000;2335;f;FR;t;Europe/Paris;t;FREPO;;t;;f;8700619;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2347;La Ferté-St-Aubin;la-ferte-st-aubin;8754312;87543124;47.720943021405056;1.9322848320007324;;f;FR;f;Europe/Paris;t;FREPP;;t;;f;8702317;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2348;Lamotte-Beuvron;lamotte-beuvron;8754314;87543140;47.60190588084909;2.022932767868042;;f;FR;f;Europe/Paris;t;FREPQ;;t;;f;8702313;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2349;Nouan-le-Fuzelier;nouan-le-fuzelier;8754315;87543157;47.53378036911572;2.0331037044525146;;f;FR;f;Europe/Paris;t;FREPR;;t;;f;8702321;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2347;La Ferté-St-Aubin;la-ferte-st-aubin;8754312;87543124;47.720943021405056;1.9322848320007324;;f;FR;f;Europe/Paris;t;FREPP;;t;;f;8702317;f;;f;;f;;f;;;f;;f;8700686;f;;f;f;;;;;;;;;;;;;;;;;;
+2348;Lamotte-Beuvron;lamotte-beuvron;8754314;87543140;47.60190588084909;2.022932767868042;;f;FR;f;Europe/Paris;t;FREPQ;;t;;f;8702313;f;;f;;f;;f;;;f;;f;8700687;f;;f;f;;;;;;;;;;;;;;;;;;
+2349;Nouan-le-Fuzelier;nouan-le-fuzelier;8754315;87543157;47.53378036911572;2.0331037044525146;;f;FR;f;Europe/Paris;t;FREPR;;t;;f;8702321;f;;f;;f;;f;;;f;;f;8700688;f;;f;f;;;;;;;;;;;;;;;;;;
 2351;Theillay;theillay;8754319;87543199;47.313958;2.044173;;f;FR;f;Europe/Paris;t;FREPT;;t;;f;8702328;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2354;Epuisay;epuisay;8733139;87331397;47.9000000000;0.9333330000;;f;FR;f;Europe/Paris;t;FREPY;;t;;f;8704098;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2355;Monnerville;monnerville;;;48.3500000000;2.0500000000;;t;FR;f;Europe/Paris;f;FREQA;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1803,38 +1803,38 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2413;Loches;loches;8757147;87571471;47.13046170053461;1.0007214546203613;;f;FR;f;Europe/Paris;t;FRESV;;t;;f;8703816;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ロシュ;;;;Лош;;;洛什
 2414;Perrusson;perrusson;8757148;87571489;47.1000000000;1.0000000000;;f;FR;f;Europe/Paris;t;FRESW;;t;;f;8705199;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2415;St-Jean-en-Touraine;st-jean-en-touraine;8757149;87571497;47.080912;1.021651;;f;FR;f;Europe/Paris;t;FRESX;;t;;f;8705198;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2416;Etaples—Le Touquet;etaples-le-touquet;8731706;87317065;50.516886;1.642347;26830;f;FR;f;Europe/Paris;t;FRETA;ETA;t;;f;8700237;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+2416;Etaples—Le Touquet;etaples-le-touquet;8731706;87317065;50.516886;1.642347;26830;f;FR;f;Europe/Paris;t;FRETA;ETA;t;;f;8700237;f;;f;;f;;f;;;f;;f;8700844;f;;f;t;;;;;;;;;;;;;;;;;;
 2417;St-Antoine-du-Rocher;st-antoine-du-rocher;8757153;87571539;47.5000000000;0.6333330000;;f;FR;f;Europe/Paris;t;FRETB;;t;;f;8702372;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2418;Neuillé-Pont-Pierre;neuille-pont-pierre;8757154;87571547;47.5500000000;0.5500000000;5281;f;FR;t;Europe/Paris;t;FRETC;;t;;f;8702367;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2419;St-Paterne;st-paterne;8757155;87571554;47.60277036254522;0.4840850830078125;;f;FR;f;Europe/Paris;t;FRETD;;t;;f;8702353;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2420;Ballan;ballan;8757160;87571604;47.3333330000;0.6166670000;;f;FR;f;Europe/Paris;t;FRETF;;t;;f;8702762;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2421;Étang;etang;8769414;87694141;46.86790811545109;4.183902740478516;;f;FR;f;Europe/Paris;t;FRETG;;t;;f;8700168;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2421;Étang;etang;8769414;87694141;46.86790811545109;4.183902740478516;;f;FR;f;Europe/Paris;t;FRETG;;t;;f;8700168;f;;f;;f;;f;;;f;;f;8700391;f;;f;f;;;;;;;;;;;;;;;;;;
 2422;Druye;druye;8757161;87571612;47.3166670000;0.5166670000;;f;FR;f;Europe/Paris;t;FRETH;;t;;f;8703250;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2423;Azay-le-Rideau;azay-le-rideau;8757163;87571638;47.26635137684019;0.4475051164627075;5083;f;FR;t;Europe/Paris;t;FRETJ;;t;;f;8702747;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Castillo de Azay-le-Rideau;;;;;;;アゼ＝ル＝リドー城;아제르리도;;;Азе-лё-Ридо;;;阿泽莱里多
 2424;Rivarennes;rivarennes;8757165;87571653;47.2666670000;0.3500000000;;f;FR;f;Europe/Paris;t;FRETL;;t;;f;8704369;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2425;Chinon;chinon;8757168;87571687;47.16297682646879;0.2518272399902344;;f;FR;f;Europe/Paris;t;FRETN;;t;;f;8703098;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;シノン;;;;Шинон;;;希农
 2426;La Roche-Clermault;la-roche-clermault;8757170;87571703;47.1500000000;0.2000000000;;f;FR;f;Europe/Paris;t;FRETO;;t;;f;8703602;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2427;Étampes;etampes;8754513;;48.436746204897666;2.159585952758789;;f;FR;f;Europe/Paris;t;FRETP;;t;;f;8700548;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;エタンプ;;;;Этамп;;;埃唐普
+2427;Étampes;etampes;8754513;;48.436746204897666;2.159585952758789;;f;FR;f;Europe/Paris;t;FRETP;;t;;f;8700548;f;;f;;f;;f;;;f;;f;8700683;f;;f;f;;;;;;;;;;;エタンプ;;;;Этамп;;;埃唐普
 2428;Beuxes;beuxes;8757171;87571711;47.0833330000;0.1833330000;;f;FR;f;Europe/Paris;t;FRETQ;;t;;f;8702830;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2429;Basses—Sammarçolles;basses-sammarcolles;8757172;87571729;47.04147627238398;0.13337016105651855;;f;FR;f;Europe/Paris;t;FRETR;;t;;f;8702781;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2430;Port-Boulet;port-boulet;8757179;87571794;47.24866;0.155612;;f;FR;f;Europe/Paris;t;FRETT;;t;;f;8704291;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2430;Port-Boulet;port-boulet;8757179;87571794;47.24866;0.155612;;f;FR;f;Europe/Paris;t;FRETT;;t;;f;8704291;f;;f;;f;;f;;;f;;f;8700599;f;;f;f;;;;;;;;;;;;;;;;;;
 2431;La Chapelle-sur-Loire;la-chapelle-sur-loire;8757180;87571802;47.2506300000;0.2188680000;;f;FR;f;Europe/Paris;t;FRETU;;t;;f;8703554;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2432;St-Patrice;st-patrice;8757181;87571810;47.2833330000;0.3166670000;;f;FR;f;Europe/Paris;t;FRETV;;t;;f;8704632;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2433;Langeais;langeais;8757182;87571828;47.3241051123528;0.41098952293395996;;f;FR;f;Europe/Paris;t;FRETW;;t;;f;8703644;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Ланже;;;朗热
+2433;Langeais;langeais;8757182;87571828;47.3241051123528;0.41098952293395996;;f;FR;f;Europe/Paris;t;FRETW;;t;;f;8703644;f;;f;;f;;f;;;f;;f;8700598;f;;f;f;;;;;;;;;;;;;;;Ланже;;;朗热
 2434;Cinq-Mars;cinq-mars;8757183;87571836;47.3500000000;0.4666670000;;f;FR;f;Europe/Paris;t;FRETX;;t;;f;8703106;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2435;Savonnières;savonnieres;8757184;87571844;47.3500000000;0.5500000000;;f;FR;f;Europe/Paris;t;FRETY;;t;;f;8704469;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2436;St-Genouph;st-genouph;8757185;87571851;47.3833330000;0.6000000000;;f;FR;f;Europe/Paris;t;FRETZ;;t;;f;8703384;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2437;Chaingy-Fourneaux-Plage;chaingy-fourneaux-plage;8757411;87574111;47.87715;1.782444;;f;FR;f;Europe/Paris;t;FREUA;;t;;f;8700878;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2438;St-Ay;st-ay;8757412;87574129;47.8500000000;1.7500000000;;f;FR;f;Europe/Paris;t;FREUB;;t;;f;8702059;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2439;Meung-sur-Loire;meung-sur-loire;8757413;87574137;47.82989613368746;1.6919159889221191;;f;FR;f;Europe/Paris;t;FREUC;MGL;t;;f;8701599;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;卢瓦尔河畔默恩
+2439;Meung-sur-Loire;meung-sur-loire;8757413;87574137;47.82989613368746;1.6919159889221191;;f;FR;f;Europe/Paris;t;FREUC;MGL;t;;f;8701599;f;;f;;f;;f;;;f;;f;8700647;f;;f;f;;;;;;;;;;;;;;;;;;卢瓦尔河畔默恩
 2440;Baule;baule;8757415;87574152;47.8166670000;1.6666670000;;f;FR;f;Europe/Paris;t;FREUD;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2441;Beaugency;beaugency;8757416;87574160;47.778472699221226;1.6257941722869873;;f;FR;f;Europe/Paris;t;FREUE;BGY;t;;f;8700690;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Божанси;;;博让西
-2442;Mer (Loir-et-Cher);mer-loir-et-cher;8757419;87574194;47.70596405838555;1.5064144134521484;;f;FR;f;Europe/Paris;t;FREUG;;t;;f;8701511;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2441;Beaugency;beaugency;8757416;87574160;47.778472699221226;1.6257941722869873;;f;FR;f;Europe/Paris;t;FREUE;BGY;t;;f;8700690;f;;f;;f;;f;;;f;;f;8700648;f;;f;f;;;;;;;;;;;;;;;Божанси;;;博让西
+2442;Mer (Loir-et-Cher);mer-loir-et-cher;8757419;87574194;47.70596405838555;1.5064144134521484;;f;FR;f;Europe/Paris;t;FREUG;;t;;f;8701511;f;;f;;f;;f;;;f;;f;8700649;f;;f;f;;;;;;;;;;;;;;;;;;
 2443;Suèvres;suevres;8757423;87574236;47.680403;1.454256;;f;FR;f;Europe/Paris;t;FREUH;;t;;f;8702067;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2444;Menars;menars;8757424;87574244;47.6333330000;1.4000000000;;f;FR;f;Europe/Paris;t;FREUI;;t;;f;8701592;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2445;La Chaussée-St-Victor;la-chaussee-st-victor;8757425;87574251;47.612774161573846;1.3538718223571777;;f;FR;f;Europe/Paris;t;FREUJ;;t;;f;8701250;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2446;Chouzy;chouzy;8757430;87574301;47.52030186061943;1.2478280067443848;;f;FR;f;Europe/Paris;t;FREUK;;t;;f;8700931;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2447;Onzain – Chaumont-sur-Loire;onzain-chaumont-sur-loire;8757431;87574319;47.49184834218662;1.186051368713379;;f;FR;f;Europe/Paris;t;FREUL;OZA;t;;f;8701717;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2447;Onzain – Chaumont-sur-Loire;onzain-chaumont-sur-loire;8757431;87574319;47.49184834218662;1.186051368713379;;f;FR;f;Europe/Paris;t;FREUL;OZA;t;;f;8701717;f;;f;;f;;f;;;f;;f;8700651;f;;f;f;;;;;;;;;;;;;;;;;;
 2448;Veuves—Monteaux;veuves-monteaux;8757432;87574327;47.475692;1.123813;;f;FR;f;Europe/Paris;t;FREUM;;t;;f;8702167;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2449;Limeray;limeray;8757433;87574335;47.4666670000;1.0333330000;;f;FR;f;Europe/Paris;t;FREUN;;t;;f;8701402;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2450;Noizay;noizay;8757436;87574368;47.4166670000;0.9000000000;;f;FR;f;Europe/Paris;t;FREUO;;t;;f;8701702;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1855,18 +1855,18 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2465;St-Aignan—Noyers;st-aignan-noyers;8757489;87574897;47.286891;1.383925;;f;FR;f;Europe/Paris;t;FREVM;;t;;f;8704524;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2466;Monts;monts;8757503;87575035;47.281893;0.65472;;f;FR;f;Europe/Paris;t;FREVO;;t;;f;8701617;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2467;Villeperdue;villeperdue;8757504;87575043;47.202042;0.63364;;f;FR;f;Europe/Paris;t;FREVP;;t;;f;8702189;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2468;Ste-Maure—Noyant;ste-maure-noyant;8757505;87575050;47.111233;0.57699;;f;FR;f;Europe/Paris;t;FREVQ;;t;;f;8702119;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2468;Ste-Maure—Noyant;ste-maure-noyant;8757505;87575050;47.111233;0.57699;;f;FR;f;Europe/Paris;t;FREVQ;;t;;f;8702119;f;;f;;f;;f;;;f;;f;8700663;f;;f;f;;;;;;;;;;;;;;;;;;
 2469;Maillé;maille;8757506;87575068;47.05345825641032;0.5829191207885742;;f;FR;f;Europe/Paris;t;FREVR;;t;;f;8701527;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2470;Port-de-Piles;port-de-piles;8757507;87575076;47.010225655683485;0.5989265441894531;;f;FR;f;Europe/Paris;t;FREVS;;t;;f;8701787;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2470;Port-de-Piles;port-de-piles;8757507;87575076;47.010225655683485;0.5989265441894531;;f;FR;f;Europe/Paris;t;FREVS;;t;;f;8701787;f;;f;;f;;f;;;f;;f;8700664;f;;f;f;;;;;;;;;;;;;;;;;;
 2471;Loudun;loudun;8757508;87575084;47.01596813069852;0.08369028568267822;;f;FR;f;Europe/Paris;t;FREVT;;t;;f;8703833;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;卢丹
 2472;Arçay;arcay;8757510;87575100;46.9666670000;0.0166670000;;f;FR;f;Europe/Paris;t;FREVU;;t;;f;8702676;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2473;Les Ormes-sur-Vienne;les-ormes-sur-vienne;8757511;87575118;46.971828;0.608003;;f;FR;f;Europe/Paris;t;FREVV;;t;;f;8701715;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2474;Dangé-St-Romain;dange-st-romain;8757512;87575126;46.9333330000;0.6000000000;;f;FR;f;Europe/Paris;t;FREVW;;t;;f;8700998;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2475;Évreux;evreux;8738700;87387001;49.018483645040696;1.1496752500534058;;f;FR;f;Europe/Paris;t;FREVX;EVX;t;;f;8700219;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;エヴルー;에브뢰;;;Эврё;;;埃夫勒
+2475;Évreux;evreux;8738700;87387001;49.018483645040696;1.1496752500534058;;f;FR;f;Europe/Paris;t;FREVX;EVX;t;;f;8700219;f;;f;;f;;f;;;f;;f;8700765;f;;f;t;;;;;;;;;;;エヴルー;에브뢰;;;Эврё;;;埃夫勒
 2476;Ingrandes-sur-Vienne;ingrandes-sur-vienne;8757513;87575134;46.874718;0.569295;;f;FR;f;Europe/Paris;t;FREVY;;t;;f;8701308;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2477;Nerpuy;nerpuy;8757516;87575167;46.783396;0.525734;;f;FR;f;Europe/Paris;t;FREVZ;;t;;f;8701685;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2478;Naintré—Les Barres;naintre-les-barres;8757517;87575175;46.75953;0.496339;;f;FR;f;Europe/Paris;t;FREWA;;t;;f;8701692;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2479;La Tricherie;la-tricherie;8757518;87575183;46.7333330000;0.4500000000;;f;FR;f;Europe/Paris;t;FREWB;;t;;f;8702125;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2479;La Tricherie;la-tricherie;8757518;87575183;46.7333330000;0.4500000000;;f;FR;f;Europe/Paris;t;FREWB;;t;;f;8702125;f;;f;;f;;f;;;f;;f;8700692;f;;f;f;;;;;;;;;;;;;;;;;;
 2480;Dissay;dissay;8757519;87575191;46.7000000000;0.4333330000;;f;FR;f;Europe/Paris;t;FREWC;;t;;f;8701024;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2481;Pas-de-Jeu;pas-de-jeu;8757520;87575209;46.9833330000;-0.0333330000;;f;FR;f;Europe/Paris;t;FREWD;;t;;f;8704190;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2482;Jaunay-Clan;jaunay-clan;8757521;87575217;46.6833330000;0.3666670000;;f;FR;f;Europe/Paris;t;FREWE;;t;;f;8701315;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1888,7 +1888,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2504;La Ferté-Imbault;la-ferte-imbault;8757608;87576082;47.3833330000;1.9666670000;;f;FR;f;Europe/Paris;t;FREXL;;t;;f;8703569;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2505;Vierzon Forges;vierzon-forges;8757609;87576090;47.209944;2.099853;5673;f;FR;f;Europe/Paris;t;FREXM;;t;;f;8700005;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2506;Foëcy;foecy;8757610;87576108;47.1666670000;2.1666670000;;f;FR;f;Europe/Paris;t;FREXN;;t;;f;8703325;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2507;Mehun-sur-Yèvre;mehun-sur-yevre;8757611;87576116;47.1500000000;2.2166670000;;f;FR;f;Europe/Paris;t;FREXO;;t;;f;8703963;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2507;Mehun-sur-Yèvre;mehun-sur-yevre;8757611;87576116;47.1500000000;2.2166670000;;f;FR;f;Europe/Paris;t;FREXO;;t;;f;8703963;f;;f;;f;;f;;;f;;f;8700111;f;;f;f;;;;;;;;;;;;;;;;;;
 2508;Marmagne;marmagne;8757613;87576132;47.1000000000;2.2833330000;;f;FR;f;Europe/Paris;t;FREXP;;t;;f;8703916;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2509;Selles-St-Denis;selles-st-denis;8757614;87576140;47.3833330000;1.9166670000;;f;FR;f;Europe/Paris;t;FREXQ;;t;;f;8704474;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2510;Loreux;loreux;8757615;87576157;47.4000000000;1.8333330000;;f;FR;f;Europe/Paris;t;FREXR;;t;;f;8703828;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1899,21 +1899,21 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2515;Valençay;valencay;8757621;87576215;47.16317013565614;1.5584439039230347;;f;FR;f;Europe/Paris;t;FREXW;;t;;f;8704767;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2516;Chabris;chabris;8757622;87576223;47.254883357981896;1.645975112915039;;f;FR;f;Europe/Paris;t;FREXX;;t;;f;8703011;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2517;Varennes-sur-Fouzon;varennes-sur-fouzon;8757623;87576231;47.214915;1.614777;;f;FR;f;Europe/Paris;t;FREXY;;t;;f;8704778;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2518;St-Florent-sur-Cher;st-florent-sur-cher;8757627;87576272;46.99205781250841;2.25244402885437;10731;f;FR;f;Europe/Paris;t;FREYA;SFT;t;;f;8704561;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2518;St-Florent-sur-Cher;st-florent-sur-cher;8757627;87576272;46.99205781250841;2.25244402885437;10731;f;FR;f;Europe/Paris;t;FREYA;SFT;t;;f;8704561;f;;f;;f;;f;;;f;;f;8700158;f;;f;f;;;;;;;;;;;;;;;;;;
 2519;Lunery;lunery;8757628;87576280;46.9333330000;2.2666670000;;f;FR;f;Europe/Paris;t;FREYB;;t;;f;8703860;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2520;Châteauneuf-sur-Cher;chateauneuf-sur-cher;8757629;87576298;46.85678692329182;2.310476303100586;;f;FR;f;Europe/Paris;t;FREYC;CHC;t;;f;8703063;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2520;Châteauneuf-sur-Cher;chateauneuf-sur-cher;8757629;87576298;46.85678692329182;2.310476303100586;;f;FR;f;Europe/Paris;t;FREYC;CHC;t;;f;8703063;f;;f;;f;;f;;;f;;f;8700691;f;;f;f;;;;;;;;;;;;;;;;;;
 2521;Bigny;bigny;8757630;87576306;46.8000000000;2.3833330000;;f;FR;f;Europe/Paris;t;FREYD;;t;;f;8702838;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2522;St-Florent-sur-Cher Mairie;st-florent-sur-cher-mairie;8731081;87310813;46.9833330000;2.2500000000;10731;f;FR;f;Europe/Paris;t;FREYE;;t;;f;8700411;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2523;St-Amand-Montrond—Orval;st-amand-montrond-orval;8757632;87576322;46.7264772093162;2.485957145690918;;f;FR;f;Europe/Paris;t;FREYF;SAD;t;;f;8704525;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2524;Eygurande—Merlines;eygurande-merlines;8764124;87641241;45.645074;2.46112;;f;FR;f;Europe/Paris;t;FREYG;EYG;t;;f;8700052;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2523;St-Amand-Montrond—Orval;st-amand-montrond-orval;8757632;87576322;46.7264772093162;2.485957145690918;;f;FR;f;Europe/Paris;t;FREYF;SAD;t;;f;8704525;f;;f;;f;;f;;;f;;f;8700159;f;;f;f;;;;;;;;;;;;;;;;;;
+2524;Eygurande—Merlines;eygurande-merlines;8764124;87641241;45.645074;2.46112;;f;FR;f;Europe/Paris;t;FREYG;EYG;t;;f;8700052;f;;f;;f;;f;;;f;;f;8700063;f;;f;f;;;;;;;;;;;;;;;;;;
 2525;Urçay;urcay;8757634;87576348;46.629447;2.586511;;f;FR;f;Europe/Paris;t;FREYH;;t;;f;8704754;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2526;La Gauterie;la-gauterie;8757635;87576355;47.139774;1.486195;;f;FR;f;Europe/Paris;t;FREYI;;t;;f;8703378;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2527;Luçay-le-Mâle;lucay-le-male;8757636;87576363;47.1166670000;1.4333330000;;f;FR;f;Europe/Paris;t;FREYJ;;t;;f;8703851;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2528;St-Germain-du-Puy;st-germain-du-puy;8757640;87576405;47.1000000000;2.4833330000;;f;FR;f;Europe/Paris;t;FREYK;;t;;f;8704572;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2530;Avord;avord;8757643;87576439;47.034902948947796;2.6523667573928833;;f;FR;f;Europe/Paris;t;FREYN;;t;;f;8700646;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2530;Avord;avord;8757643;87576439;47.034902948947796;2.6523667573928833;;f;FR;f;Europe/Paris;t;FREYN;;t;;f;8700646;f;;f;;f;;f;;;f;;f;8700112;f;;f;f;;;;;;;;;;;;;;;;;;
 2531;Bengy;bengy;8757644;87576447;47.0000000000;2.7500000000;;f;FR;f;Europe/Paris;t;FREYO;;t;;f;8702814;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2532;Nérondes;nerondes;8757645;87576454;46.9975830000;2.8183360000;;f;FR;f;Europe/Paris;t;FREYP;;t;;f;8704094;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2533;La Guerche-sur-l’Aubois;la-guerche-sur-laubois;8757647;87576470;46.947735451756174;2.9485470056533813;;f;FR;f;Europe/Paris;t;FREYR;;t;;f;8703582;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2533;La Guerche-sur-l’Aubois;la-guerche-sur-laubois;8757647;87576470;46.947735451756174;2.9485470056533813;;f;FR;f;Europe/Paris;t;FREYR;;t;;f;8703582;f;;f;;f;;f;;;f;;f;8700113;f;;f;f;;;;;;;;;;;;;;;;;;
 2534;Aubigny-sur-Nère;aubigny-sur-nere;8731451;87314518;47.4833330000;2.4333330000;;f;FR;f;Europe/Paris;t;FREYS;;t;;f;8700479;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;オービニー＝シュル＝ネール;;;;Обиньи-сюр-Нер;;;内尔河畔奥比尼
 2535;Thenioux;thenioux;8757670;87576702;47.252561;1.936438;;f;FR;f;Europe/Paris;t;FREYT;;t;;f;8704708;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2536;Châtres-sur-Cher;chatres-sur-cher;8757671;87576710;47.2666670000;1.9166670000;;f;FR;f;Europe/Paris;t;FREYU;;t;;f;8703073;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1921,7 +1921,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2538;Langon (Loir-et-Cher);langon-loir-et-cher;8757673;87576736;47.2833330000;1.8333330000;;f;FR;f;Europe/Paris;t;FREYW;;t;;f;8703646;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ランゴーニュ;;;;;;;朗戈尼
 2539;Selles-sur-Cher;selles-sur-cher;8757686;87576868;47.281812885731476;1.5461862087249756;;f;FR;f;Europe/Paris;t;FREYX;;t;;f;8704475;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2540;Villefranche-sur-Cher;villefranche-sur-cher;8757688;87576884;47.294982;1.767962;;f;FR;f;Europe/Paris;t;FREYY;;t;;f;8704923;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2542;Èze;eze;8775638;87756387;43.722176161008335;7.356795072555542;;f;FR;f;Europe/Paris;t;FREZE;;t;;f;8701100;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Eza;;;;;;;;;;;;
+2542;Èze;eze;8775638;87756387;43.722176161008335;7.356795072555542;;f;FR;f;Europe/Paris;t;FREZE;;t;;f;8701100;f;;f;;f;;f;;;f;;f;8700425;f;;f;f;;;;;;Eza;;;;;;;;;;;;
 2543;Vouille;vouille;8757739;87577395;46.645888;0.168152;;f;FR;f;Europe/Paris;t;FREZG;;t;;f;8704904;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2544;Iteuil;iteuil;8757740;87577403;46.48419554823519;0.31695127487182617;;f;FR;f;Europe/Paris;t;FREZH;;t;;f;8701300;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2546;Ludon;ludon;8758118;87581181;44.9833330000;-0.6000000000;4708;f;FR;t;Europe/Paris;t;FREZR;;t;;f;8703855;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1929,14 +1929,14 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2548;Margaux;margaux;8758121;87581215;45.035831;-0.685409;4746;f;FR;t;Europe/Paris;t;FREZU;;t;;f;8703909;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2550;Moulis—Listrac;moulis-listrac;8758123;87581231;45.084049;-0.744414;4796;f;FR;t;Europe/Paris;t;FREZW;;t;;f;8704066;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2551;Pauillac;pauillac;8758125;87581256;45.20372513703703;-0.7549828290939331;;f;FR;f;Europe/Paris;t;FREZY;;t;;f;8704191;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ポーイヤック;;;;;;;波亚克
-2553;Facture—Biganos;facture-biganos;8758247;87582478;44.637833;-0.965765;;f;FR;f;Europe/Paris;t;FRFAC;FAT;t;;f;8700195;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+2553;Facture—Biganos;facture-biganos;8758247;87582478;44.637833;-0.965765;;f;FR;f;Europe/Paris;t;FRFAC;FAT;t;;f;8700195;f;;f;;f;;f;;;f;;f;8700568;f;;f;t;;;;;;;;;;;;;;;;;;
 2554;Lesparre;lesparre;8758131;87581314;45.3035237117361;-0.9453606605529784;;f;FR;f;Europe/Paris;t;FRFAD;;t;;f;8703793;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2555;Gaillan;gaillan;8758132;;45.3166670000;-0.9500000000;;f;FR;f;Europe/Paris;t;FRFAE;;t;;f;8703363;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2556;Queyrac;queyrac;8758133;;45.3666670000;-0.9833330000;;f;FR;f;Europe/Paris;t;FRFAF;;t;;f;8704335;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2557;Soulac-sur-Mer;soulac-sur-mer;8758137;87581371;45.508178;-1.117583;2935;f;FR;t;Europe/Paris;t;FRFAI;;t;;f;8704517;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;滨海苏拉克
+2557;Soulac-sur-Mer;soulac-sur-mer;8758137;87581371;45.508178;-1.117583;2935;f;FR;t;Europe/Paris;t;FRFAI;;t;;f;8704517;f;;f;;f;;f;;;f;;f;8700582;f;;f;f;;;;;;;;;;;;;;;;;;滨海苏拉克
 2558;Le Verdon;le-verdon;8758138;87581389;45.5500000000;-1.0666670000;5621;f;FR;t;Europe/Paris;t;FRFAJ;;t;;f;8703744;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2559;Pointe-de-Grave;pointe-de-grave;8758139;87581397;45.567066;-1.06585;;f;FR;f;Europe/Paris;t;FRFAK;;t;;f;8704247;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2560;Caudéran—Mérignac;cauderan-merignac;8758153;87581538;44.842967;-0.627339;;f;FR;f;Europe/Paris;t;FRFAM;;t;;f;8702985;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+2560;Caudéran—Mérignac;cauderan-merignac;8758153;87581538;44.842967;-0.627339;;f;FR;f;Europe/Paris;t;FRFAM;;t;;f;8702985;f;;f;;f;;f;;;f;;f;8700501;f;;f;t;;;;;;;;;;;;;;;;;;
 2562;Parempuyre;parempuyre;8758171;87581710;44.9500000000;-0.5833330000;5015;f;FR;t;Europe/Paris;t;FRFAO;;t;;f;8704180;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2563;Blanquefort;blanquefort;8758172;87581728;44.9166670000;-0.6333330000;;f;FR;f;Europe/Paris;t;FRFAP;;t;;f;8702842;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2564;Bruges;bruges;8758173;87581736;44.88707329080843;-0.609440803527832;;f;FR;f;Europe/Paris;t;FRFAQ;;t;;f;8702931;f;;f;;f;;f;;;f;;f;;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;;;;;;;;
@@ -1951,12 +1951,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2596;Gazinet—Cestas;gazinet-cestas;8758240;87582403;44.772015;-0.699468;;f;FR;f;Europe/Paris;t;FRFBW;;t;;f;8701172;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2598;Croix-d’Hins;croix-dhins;8758243;87582437;44.71010043360508;-0.814812183380127;;f;FR;f;Europe/Paris;t;FRFBZ;;t;;f;8700986;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2599;Marcheprime;marcheprime;8758244;87582445;44.69050539829347;-0.85368812084198;;f;FR;f;Europe/Paris;t;FRFCA;;t;;f;8701577;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2601;Ychoux;ychoux;8758253;87582536;44.32926;-0.946033;;f;FR;f;Europe/Paris;t;FRFCD;;t;;f;8702291;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2602;Labouheyre;labouheyre;8758255;87582551;44.21062620859284;-0.920952558517456;;f;FR;f;Europe/Paris;t;FRFCE;;t;;f;8701392;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2601;Ychoux;ychoux;8758253;87582536;44.32926;-0.946033;;f;FR;f;Europe/Paris;t;FRFCD;;t;;f;8702291;f;;f;;f;;f;;;f;;f;8700571;f;;f;f;;;;;;;;;;;;;;;;;;
+2602;Labouheyre;labouheyre;8758255;87582551;44.21062620859284;-0.920952558517456;;f;FR;f;Europe/Paris;t;FRFCE;;t;;f;8701392;f;;f;;f;;f;;;f;;f;8700572;f;;f;f;;;;;;;;;;;;;;;;;;
 2604;Le Teich;le-teich;8758260;87582601;44.632321842567855;-1.0256123542785645;;f;FR;f;Europe/Paris;t;FRFCG;;t;;f;8702093;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2605;Gujan-Mestras;gujan-mestras;8758261;87582619;44.64055174562602;-1.0691285133361814;;f;FR;f;Europe/Paris;t;FRFCH;;t;;f;8701224;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2606;La Hume;la-hume;8758263;87582635;44.639955;-1.115983;;f;FR;f;Europe/Paris;t;FRFCI;;t;;f;8701292;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2607;La Teste;la-teste;8758264;87582643;44.637116399261735;-1.1428356170654295;;f;FR;f;Europe/Paris;t;FRFCJ;TTE;t;;f;8702130;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2605;Gujan-Mestras;gujan-mestras;8758261;87582619;44.64055174562602;-1.0691285133361814;;f;FR;f;Europe/Paris;t;FRFCH;;t;;f;8701224;f;;f;;f;;f;;;f;;f;8700589;f;;f;f;;;;;;;;;;;;;;;;;;
+2606;La Hume;la-hume;8758263;87582635;44.639955;-1.115983;;f;FR;f;Europe/Paris;t;FRFCI;;t;;f;8701292;f;;f;;f;;f;;;f;;f;8700583;f;;f;f;;;;;;;;;;;;;;;;;;
+2607;La Teste;la-teste;8758264;87582643;44.637116399261735;-1.1428356170654295;;f;FR;f;Europe/Paris;t;FRFCJ;TTE;t;;f;8702130;f;;f;;f;;f;;;f;;f;8700585;f;;f;f;;;;;;;;;;;;;;;;;;
 2608;Cadaujac;cadaujac;8758268;87582684;44.7500000000;-0.5333330000;;f;FR;f;Europe/Paris;t;FRFCK;;t;;f;8702947;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2609;St-Médard-d’Eyrans;st-medard-deyrans;8758269;87582692;44.7166670000;-0.5166670000;;f;FR;f;Europe/Paris;t;FRFCL;;t;;f;8704422;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2610;Beautiran;beautiran;8758270;87582700;44.70115213242409;-0.4501068592071533;;f;FR;f;Europe/Paris;t;FRFCM;;t;;f;8702791;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1966,22 +1966,22 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2614;Cérons;cerons;8758274;87582742;44.632192048106006;-0.3407478332519531;;f;FR;f;Europe/Paris;t;FRFCQ;;t;;f;8703006;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2615;Barsac;barsac;8758275;87582759;44.604065616036486;-0.3205454349517822;;f;FR;f;Europe/Paris;t;FRFCR;;t;;f;8702776;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2616;Preignac;preignac;8758276;87582767;44.5833330000;-0.3000000000;;f;FR;f;Europe/Paris;t;FRFCS;;t;;f;8704316;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2617;Langon (Gironde);langon-gironde;8758277;87582775;44.55558564279705;-0.25573253631591797;;f;FR;f;Europe/Paris;t;FRFCT;;t;;f;8700209;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ランゴーニュ;;;;;;;朗戈尼
+2617;Langon (Gironde);langon-gironde;8758277;87582775;44.55558564279705;-0.25573253631591797;;f;FR;f;Europe/Paris;t;FRFCT;;t;;f;8700209;f;;f;;f;;f;;;f;;f;8700712;f;;f;f;;;;;;;;;;;ランゴーニュ;;;;;;;朗戈尼
 2618;St-Macaire;st-macaire;8758282;87582825;44.5666670000;-0.2166670000;;f;FR;f;Europe/Paris;t;FRFCU;;t;;f;8704607;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2619;St-Pierre-d’Aurillac;st-pierre-daurillac;8758283;87582833;44.5666670000;-0.1833330000;;f;FR;f;Europe/Paris;t;FRFCV;;t;;f;8704635;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2620;Caudrot;caudrot;8758284;87582841;44.5666670000;-0.1500000000;;f;FR;f;Europe/Paris;t;FRFCW;;t;;f;8702986;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2621;Gironde-sur-Dropt;gironde-sur-dropt;8758285;87582858;44.58326;-0.09201;;f;FR;f;Europe/Paris;t;FRFCX;;t;;f;8703406;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2622;La Réole;la-reole;8758286;87582866;44.57983832419595;-0.030705928802490234;;f;FR;f;Europe/Paris;t;FRFCY;;t;;f;8703597;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2622;La Réole;la-reole;8758286;87582866;44.57983832419595;-0.030705928802490234;;f;FR;f;Europe/Paris;t;FRFCY;;t;;f;8703597;f;;f;;f;;f;;;f;;f;8700711;f;;f;f;;;;;;;;;;;;;;;;;;
 2623;Lamothe-Landerron;lamothe-landerron;8758288;87582882;44.5500000000;0.0666670000;;f;FR;f;Europe/Paris;t;FRFCZ;;t;;f;8703636;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2624;Ruelle;ruelle;8758320;87583203;45.6833330000;0.2333330000;;f;FR;f;Europe/Paris;t;FRFDB;;t;;f;8704397;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2625;La Rochefoucauld;la-rochefoucauld;8758342;87583427;45.74024413006693;0.38962841033935547;;f;FR;f;Europe/Paris;t;FRFDD;;t;;f;8703604;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2626;Chasseneuil-sur-Bonnieure;chasseneuil-sur-bonnieure;8758344;87583443;45.82455277703318;0.45344352722167974;;f;FR;f;Europe/Paris;t;FRFDE;;t;;f;8703054;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2627;Roumazières-Loubert;roumazieres-loubert;8758346;87583468;45.8955000000;0.5759000000;;f;FR;f;Europe/Paris;t;FRFDF;;t;;f;8704393;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2625;La Rochefoucauld;la-rochefoucauld;8758342;87583427;45.74024413006693;0.38962841033935547;;f;FR;f;Europe/Paris;t;FRFDD;;t;;f;8703604;f;;f;;f;;f;;;f;;f;8700270;f;;f;f;;;;;;;;;;;;;;;;;;
+2626;Chasseneuil-sur-Bonnieure;chasseneuil-sur-bonnieure;8758344;87583443;45.82455277703318;0.45344352722167974;;f;FR;f;Europe/Paris;t;FRFDE;;t;;f;8703054;f;;f;;f;;f;;;f;;f;8700999;f;;f;f;;;;;;;;;;;;;;;;;;
+2627;Roumazières-Loubert;roumazieres-loubert;8758346;87583468;45.8955000000;0.5759000000;;f;FR;f;Europe/Paris;t;FRFDF;;t;;f;8704393;f;;f;;f;;f;;;f;;f;8700998;f;;f;f;;;;;;;;;;;;;;;;;;
 2628;Vellexon;vellexon;8718548;87185488;47.56375;5.803004;;f;FR;f;Europe/Paris;t;FRFDI;;t;;f;8702168;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2629;Montmoreau;montmoreau;8758367;87583674;45.4000000000;0.1333330000;;f;FR;f;Europe/Paris;t;FRFDK;;t;;f;8701555;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2630;Chalais;chalais;8758369;87583690;45.270748914540015;0.04349470138549804;;f;FR;f;Europe/Paris;t;FRFDL;;t;;f;8700868;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2632;Luxé;luxe;8758382;87583823;45.8833330000;0.1166670000;;f;FR;f;Europe/Paris;t;FRFDQ;;t;;f;8701464;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2633;Ruffec (Charente);ruffec-charente;8758384;87583849;46.03050613404603;0.1902008056640625;;f;FR;f;Europe/Paris;t;FRFDS;RUG;t;;f;8701902;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+2633;Ruffec (Charente);ruffec-charente;8758384;87583849;46.03050613404603;0.1902008056640625;;f;FR;f;Europe/Paris;t;FRFDS;RUG;t;;f;8701902;f;;f;;f;;f;;;f;;f;8700567;f;;f;t;;;;;;;;;;;;;;;;;;
 2634;St-Émilion;st-emilion;8758410;87584102;44.88126555065233;-0.15921592712402344;;f;FR;f;Europe/Paris;t;FRFDT;;t;;f;8704553;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2635;Assier Ville;assier-ville;8716547;87165472;44.6666670000;1.8833330000;2715;f;FR;f;Europe/Paris;t;FRFDV;;t;;f;8705771;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2636;Castillon;castillon;8758413;87584136;44.8570552520214;-0.04079103469848633;;f;FR;f;Europe/Paris;t;FRFDW;;t;;f;8702983;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -1992,7 +1992,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2642;Gardonne;gardonne;8758423;87584235;44.83471024320718;0.33196628093719477;;f;FR;f;Europe/Paris;t;FRFEC;;t;;f;8703373;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2643;Lamonzie-St-Martin;lamonzie-st-martin;8758424;87584243;44.8500000000;0.3833330000;;f;FR;f;Europe/Paris;t;FRFED;;t;;f;8703635;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2647;Couze;couze;8758442;87584425;44.8333330000;0.7000000000;;f;FR;f;Europe/Paris;t;FRFEH;;t;;f;8703179;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2648;Lalinde;lalinde;8758444;87584441;44.83673401197435;0.7021111249923706;;f;FR;f;Europe/Paris;t;FRFEI;;t;;f;8703631;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2648;Lalinde;lalinde;8758444;87584441;44.83673401197435;0.7021111249923706;;f;FR;f;Europe/Paris;t;FRFEI;;t;;f;8703631;f;;f;;f;;f;;;f;;f;8700594;f;;f;f;;;;;;;;;;;;;;;;;;
 2650;Mauzac;mauzac;8758446;87584466;44.8666670000;0.7833330000;;f;FR;f;Europe/Paris;t;FRFEK;;t;;f;8703954;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2651;Trémolat;tremolat;8758447;87584474;44.862545;0.830369;;f;FR;f;Europe/Paris;t;FRFEL;;t;;f;8704742;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2652;St-Denis-de-Pile;st-denis-de-pile;8758450;87584508;45.0000000000;-0.2000000000;;f;FR;f;Europe/Paris;t;FRFEM;;t;;f;8702053;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2018,14 +2018,14 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2672;Rambert—Preignan;rambert-preignan;8758637;87586370;43.717203;0.62546;;f;FR;f;Europe/Paris;t;FRFFK;;t;;f;8704343;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2673;Pont-du-Casse;pont-du-casse;8758640;87586404;44.2333330000;0.6833330000;;f;FR;f;Europe/Paris;t;FRFFL;;t;;f;8704269;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2674;Laroque;laroque;8758641;87586412;44.2833330000;0.7666670000;;f;FR;f;Europe/Paris;t;FRFFM;;t;;f;8703660;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2675;Penne;penne;8758643;87586438;44.3833330000;0.8333330000;;f;FR;f;Europe/Paris;t;FRFFO;PNE;t;;f;8704197;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2675;Penne;penne;8758643;87586438;44.3833330000;0.8333330000;;f;FR;f;Europe/Paris;t;FRFFO;PNE;t;;f;8704197;f;;f;;f;;f;;;f;;f;8700659;f;;f;f;;;;;;;;;;;;;;;;;;
 2676;Trentels—Ladignac;trentels-ladignac;8758644;87586446;44.442965;0.884835;;f;FR;f;Europe/Paris;t;FRFFP;;t;;f;8704743;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2677;Ste-Bazeille;ste-bazeille;8758647;87586479;44.5333330000;0.1000000000;;f;FR;f;Europe/Paris;t;FRFFR;;t;;f;8704668;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2678;Sauveterre-la-Lémance;sauveterre-la-lemance;8758649;87586495;44.5833330000;1.0166670000;;f;FR;f;Europe/Paris;t;FRFFT;;t;;f;8704463;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2679;Fumel;fumel;8758658;87586586;44.49675787313771;0.9683632850646972;;f;FR;f;Europe/Paris;t;FRFFV;;t;;f;8703358;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;菲梅勒
 2680;Condat Bonaguil;condat-bonaguil;8758659;87586594;44.497179;0.988813;;f;FR;f;Europe/Paris;t;FRFFW;;t;;f;8703145;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2681;Villeneuve-sur-Lot;villeneuve-sur-lot;8758660;87586602;44.40714019487177;0.709143877029419;;f;FR;f;Europe/Paris;t;FRFFX;;t;;f;8704870;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ヴィルヌーヴ＝シュル＝ロット;;;;Вильнёв-сюр-Ло;;;洛特河畔新城
-2682;Tonneins;tonneins;8758665;87586651;44.392904;0.314343;;f;FR;f;Europe/Paris;t;FRFFZ;;t;;f;8704723;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2682;Tonneins;tonneins;8758665;87586651;44.392904;0.314343;;f;FR;f;Europe/Paris;t;FRFFZ;;t;;f;8704723;f;;f;;f;;f;;;f;;f;8700699;f;;f;f;;;;;;;;;;;;;;;;;;
 2683;Ste-Christie—Casteljaloux;ste-christie-casteljaloux;8758677;87586776;44.3166670000;0.1000000000;;f;FR;f;Europe/Paris;t;FRFGC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2684;Ragegat;ragegat;8758920;87589200;43.975301;0.674137;;f;FR;f;Europe/Paris;t;FRFGE;;t;;f;8705043;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2685;Limoges Montjovis;limoges-montjovis;8759202;87592022;45.838486;1.25146;4651;f;FR;f;Europe/Paris;t;FRFGH;;t;;f;8703808;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2055,31 +2055,31 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2709;Nantiat;nantiat;8759244;87592444;46.0166670000;1.1833330000;;f;FR;f;Europe/Paris;t;FRFHL;;t;;f;8704084;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2710;Vaulry;vaulry;8759245;87592451;46.025003;1.10872;;f;FR;f;Europe/Paris;t;FRFHM;;t;;f;8704786;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2711;Bellac;bellac;8759248;87592485;46.12522527623879;1.046125888824463;;f;FR;f;Europe/Paris;t;FRFHO;;t;;f;8702800;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ベラック;;;;;;;贝拉克
-2712;St-Sébastien;st-sebastien;8759249;;46.391582400989996;1.5294277667999268;;f;FR;f;Europe/Paris;t;FRFHP;;t;;f;8702324;f;;f;;f;;f;;;f;;f;;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;;;;;;;;
-2713;La Coquille;la-coquille;8759250;87592501;45.54083392855251;0.9745270013809204;;f;FR;f;Europe/Paris;t;FRFHQ;;t;;f;8703561;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2712;St-Sébastien;st-sebastien;8759249;;46.391582400989996;1.5294277667999268;;f;FR;f;Europe/Paris;t;FRFHP;;t;;f;8702324;f;;f;;f;;f;;;f;;f;8700693;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;;;;;;;;
+2713;La Coquille;la-coquille;8759250;87592501;45.54083392855251;0.9745270013809204;;f;FR;f;Europe/Paris;t;FRFHQ;;t;;f;8703561;f;;f;;f;;f;;;f;;f;8700566;f;;f;f;;;;;;;;;;;;;;;;;;
 2714;Le Dorat;le-dorat;8759254;87592543;46.21110341165666;1.0793423652648926;;f;FR;f;Europe/Paris;t;FRFHS;;t;;f;8703704;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;勒多拉
 2715;Assier;assier;;;44.6666670000;1.8833330000;;t;FR;f;Europe/Paris;f;FRFHT;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2716;Assier;assier;8761307;87613075;44.674482035666315;1.8693280220031738;2715;f;FR;t;Europe/Paris;t;FRFSD;AER;t;;f;8702699;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2716;Assier;assier;8761307;87613075;44.674482035666315;1.8693280220031738;2715;f;FR;t;Europe/Paris;t;FRFSD;AER;t;;f;8702699;f;;f;;f;;f;;;f;;f;8700518;f;;f;f;;;;;;;;;;;;;;;;;;
 2717;L’Aiguille;laiguille;8759263;87592634;45.7500000000;1.2000000000;;f;FR;f;Europe/Paris;t;FRFHU;;t;;f;8703526;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2718;Figeac;figeac;;;44.6000000000;2.0333330000;;t;FR;f;Europe/Paris;f;FRFHV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2719;Figeac;figeac;8761309;87613091;44.603494;2.037306;2718;f;FR;t;Europe/Paris;t;FRFIG;FIG;t;;f;8703314;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;フィジャック;;;;Фижак;;;菲雅克
+2719;Figeac;figeac;8761309;87613091;44.603494;2.037306;2718;f;FR;t;Europe/Paris;t;FRFIG;FIG;t;;f;8703314;f;;f;;f;;f;;;f;;f;8700519;f;;f;f;;;;;;;;;;;フィジャック;;;;Фижак;;;菲雅克
 2720;Verneuil-sur-Vienne;verneuil-sur-vienne;8759267;87592675;45.838307;1.112136;;f;FR;f;Europe/Paris;t;FRFHW;;t;;f;8704810;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2721;St-Victurnien;st-victurnien;8759268;87592683;45.8833330000;1.0000000000;;f;FR;f;Europe/Paris;t;FRFHX;;t;;f;8704665;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2722;St-Brice-sur-Vienne;st-brice-sur-vienne;8759269;87592691;45.8833330000;0.9500000000;;f;FR;f;Europe/Paris;t;FRFHY;;t;;f;8702921;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2723;St-Junien;st-junien;8759270;87592709;45.88139725876443;0.9004926681518555;;f;FR;f;Europe/Paris;t;FRFHZ;;t;;f;8704596;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2724;Saillat—Chassenon;saillat-chassenon;8759271;87592717;45.869625;0.811743;;f;FR;f;Europe/Paris;t;FRFIA;;t;;f;8704403;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2723;St-Junien;st-junien;8759270;87592709;45.88139725876443;0.9004926681518555;;f;FR;f;Europe/Paris;t;FRFHZ;;t;;f;8704596;f;;f;;f;;f;;;f;;f;8700995;f;;f;f;;;;;;;;;;;;;;;;;;
+2724;Saillat—Chassenon;saillat-chassenon;8759271;87592717;45.869625;0.811743;;f;FR;f;Europe/Paris;t;FRFIA;;t;;f;8704403;f;;f;;f;;f;;;f;;f;8700996;f;;f;f;;;;;;;;;;;;;;;;;;
 2725;Lafarge;lafarge;8759273;87592733;45.633775;1.130807;;f;FR;f;Europe/Paris;t;FRFIB;;t;;f;8703626;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2726;Bussière-Galant;bussiere-galant;8759274;87592741;45.62664763326196;1.036410927772522;;f;FR;f;Europe/Paris;t;FRFIC;;t;;f;8702941;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2726;Bussière-Galant;bussiere-galant;8759274;87592741;45.62664763326196;1.036410927772522;;f;FR;f;Europe/Paris;t;FRFIC;;t;;f;8702941;f;;f;;f;;f;;;f;;f;8700563;f;;f;f;;;;;;;;;;;;;;;;;;
 2727;La Meyze;la-meyze;8759280;87592808;45.62128647816979;1.212294101715088;;f;FR;f;Europe/Paris;t;FRFIE;;t;;f;8703587;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2728;St-Yrieix;st-yrieix;8759282;87592824;45.519424843606615;1.2054812908172607;;f;FR;f;Europe/Paris;t;FRFIH;;t;;f;8704667;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2729;Coussac-Bonneval;coussac-bonneval;8759284;87592840;45.5000000000;1.3166670000;;f;FR;f;Europe/Paris;t;FRFII;;t;;f;8703178;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2730;Chabanais;chabanais;8759287;87592873;45.87263562403657;0.7168149948120117;;f;FR;f;Europe/Paris;t;FRFIK;;t;;f;8703009;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2730;Chabanais;chabanais;8759287;87592873;45.87263562403657;0.7168149948120117;;f;FR;f;Europe/Paris;t;FRFIK;;t;;f;8703009;f;;f;;f;;f;;;f;;f;8700997;f;;f;f;;;;;;;;;;;;;;;;;;
 2731;Exideuil-sur-Vienne;exideuil-sur-vienne;8759288;87592881;45.8863;0.666684;;f;FR;f;Europe/Paris;t;FRFIL;;t;;f;8703299;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2732;Uzerche Ville;uzerche-ville;8759403;87594036;45.426951;1.563062;5607;f;FR;f;Europe/Paris;t;FRFIM;;t;;f;8704760;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2733;Jassonneix;jassonneix;8759408;87594085;45.543604;2.139864;;f;FR;f;Europe/Paris;t;FRFIN;;t;;f;8703496;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2734;Corrèze;correze;8759411;87594119;45.4166670000;1.9500000000;;f;FR;f;Europe/Paris;t;FRFIP;CZE;t;;f;8700954;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2734;Corrèze;correze;8759411;87594119;45.4166670000;1.9500000000;;f;FR;f;Europe/Paris;t;FRFIP;CZE;t;;f;8700954;f;;f;;f;;f;;;f;;f;8700988;f;;f;f;;;;;;;;;;;;;;;;;;
 2735;Montaignac-St-Hippolyte;montaignac-st-hippolyte;8759413;87594135;45.355343;1.980602;;f;FR;f;Europe/Paris;t;FRFIR;;t;;f;8704017;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2737;Égletons;egletons;8759416;87594168;45.4000000000;2.0500000000;10329;f;FR;t;Europe/Paris;t;FRFIU;EGL;t;;f;8701061;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2737;Égletons;egletons;8759416;87594168;45.4000000000;2.0500000000;10329;f;FR;t;Europe/Paris;t;FRFIU;EGL;t;;f;8701061;f;;f;;f;;f;;;f;;f;8700987;f;;f;f;;;;;;;;;;;;;;;;;;
 2738;Naves Bourg;naves-bourg;8759417;87594176;45.31266889256478;1.768798828125;4870;f;FR;t;Europe/Paris;t;FRFIV;;t;;f;8704090;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2739;Vigeois;vigeois;8759421;87594218;45.382814;1.51523;;f;FR;f;Europe/Paris;t;FRFIY;VGE;t;;f;8702178;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2740;Séveux;seveux;8718551;87185512;47.5500000000;5.7500000000;;f;FR;f;Europe/Paris;t;FRFJA;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2088,13 +2088,13 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2743;Dampierre-sur-Salon;dampierre-sur-salon;8714342;87143420;47.556267022283876;5.679883360862732;;f;FR;f;Europe/Paris;t;FRFJD;;t;;f;8701026;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2744;Vereux;vereux;8718555;87185553;47.521276;5.645926;;f;FR;f;Europe/Paris;t;FRFJE;;t;;f;8702221;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2745;Gignac—Cressensac;gignac-cressensac;8759432;87594325;45.014499;1.483202;;f;FR;f;Europe/Paris;t;FRFJF;;t;;f;8701191;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2747;Condat-le-Lardin;condat-le-lardin;8759438;87594382;45.126729;1.226739;;f;FR;f;Europe/Paris;t;FRFJK;CDT;t;;f;8700843;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2747;Condat-le-Lardin;condat-le-lardin;8759438;87594382;45.126729;1.226739;;f;FR;f;Europe/Paris;t;FRFJK;CDT;t;;f;8700843;f;;f;;f;;f;;;f;;f;8700991;f;;f;f;;;;;;;;;;;;;;;;;;
 2748;La Rivière-de-Mansac;la-riviere-de-mansac;8759441;87594416;45.13971;1.364949;;f;FR;f;Europe/Paris;t;FRFJL;;t;;f;8703599;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2749;Larche;larche;8759442;87594424;45.1166670000;1.4166670000;;f;FR;f;Europe/Paris;t;FRFJM;;t;;f;8703654;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2750;Aubazine—St-Hilaire;aubazine-st-hilaire;8759446;87594465;45.18168;1.641052;;f;FR;f;Europe/Paris;t;FRFJO;;t;;f;8702703;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2751;Cornil;cornil;8759448;87594481;45.2166670000;1.6833330000;;f;FR;f;Europe/Paris;t;FRFJQ;;t;;f;8703158;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2752;Turenne;turenne;8759455;87594556;45.03779;1.600861;;f;FR;f;Europe/Paris;t;FRFJT;;t;;f;8704751;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2753;Les Quatre-Routes-du-Lot;les-quatre-routes-du-lot;8759456;87594564;45.0000000000;1.6500000000;;f;FR;f;Europe/Paris;t;FRFJU;;t;;f;8703783;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2753;Les Quatre-Routes-du-Lot;les-quatre-routes-du-lot;8759456;87594564;45.0000000000;1.6500000000;;f;FR;f;Europe/Paris;t;FRFJU;;t;;f;8703783;f;;f;;f;;f;;;f;;f;8700514;f;;f;f;;;;;;;;;;;;;;;;;;
 2754;Varetz;varetz;8759460;87594606;45.191407;1.447074;;f;FR;f;Europe/Paris;t;FRFJX;;t;;f;8704780;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2755;Le Burg;le-burg;8759461;87594614;45.215624;1.429932;;f;FR;f;Europe/Paris;t;FRFJY;;t;;f;8703694;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2756;St-Aulaire;st-aulaire;8759462;87594622;45.2333330000;1.3666670000;;f;FR;f;Europe/Paris;t;FRFJZ;;t;;f;8702717;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2104,52 +2104,52 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2760;Lubersac;lubersac;8759467;87594671;45.44463022734178;1.388944387435913;;f;FR;f;Europe/Paris;t;FRFKE;;t;;f;8703848;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2761;Le Pigeon;le-pigeon;8759470;87594705;44.903716;1.534099;;f;FR;f;Europe/Paris;t;FRFKH;;t;;f;8704222;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2762;Martel;martel;8759471;87594713;44.9366740000;1.6085100000;;f;FR;f;Europe/Paris;t;FRFKI;;t;;f;8703925;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2763;Vayrac;vayrac;8759473;87594739;44.950127;1.706898;;f;FR;f;Europe/Paris;t;FRFKJ;;t;;f;8704792;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2763;Vayrac;vayrac;8759473;87594739;44.950127;1.706898;;f;FR;f;Europe/Paris;t;FRFKJ;;t;;f;8704792;f;;f;;f;;f;;;f;;f;8700529;f;;f;f;;;;;;;;;;;;;;;;;;
 2764;Bétaille;betaille;8759474;87594747;44.94241122814754;1.734386086463928;;f;FR;f;Europe/Paris;t;FRFKK;;t;;f;8702826;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2765;Puybrun;puybrun;8759475;87594754;44.9166670000;1.8000000000;;f;FR;f;Europe/Paris;t;FRFKL;;t;;f;8704332;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2765;Puybrun;puybrun;8759475;87594754;44.9166670000;1.8000000000;;f;FR;f;Europe/Paris;t;FRFKL;;t;;f;8704332;f;;f;;f;;f;;;f;;f;8700533;f;;f;f;;;;;;;;;;;;;;;;;;
 2766;Laval-de-Cère;laval-de-cere;8759479;87594796;44.95135253050503;1.9315338134765625;;f;FR;f;Europe/Paris;t;FRFKN;;t;;f;8703674;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2767;Masseret;masseret;8759482;87594820;45.5333330000;1.5166670000;4798;f;FR;t;Europe/Paris;t;FRFKP;MST;t;;f;8701613;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2768;St-Rémy;st-remy;8759485;87594853;45.650490869158716;2.266278862953186;;f;FR;f;Europe/Paris;t;FRFKS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2769;St-Pardoux-le-Vieux;st-pardoux-le-vieux;8759486;87594861;45.6166670000;2.2833330000;;f;FR;f;Europe/Paris;t;FRFKT;;t;;f;8704424;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2770;Montureux;montureux;8718554;87185546;47.8166670000;5.9833330000;;f;FR;f;Europe/Paris;t;FRFKU;;t;;f;8701620;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2771;Le Mas-d’Artige;le-mas-dartige;8759489;87594895;45.733591;2.194123;;f;FR;f;Europe/Paris;t;FRFKW;;t;;f;8703933;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2772;Thiviers;thiviers;8759512;87595124;45.419077;0.921106;;f;FR;f;Europe/Paris;t;FRFKX;TIV;t;;f;8702104;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2772;Thiviers;thiviers;8759512;87595124;45.419077;0.921106;;f;FR;f;Europe/Paris;t;FRFKX;TIV;t;;f;8702104;f;;f;;f;;f;;;f;;f;8700463;f;;f;f;;;;;;;;;;;;;;;;;;
 2773;Négrondes;negrondes;8759513;87595132;45.3500000000;0.8666670000;;f;FR;f;Europe/Paris;t;FRFKY;;t;;f;8704091;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2774;Château-l’Évêque;chateau-leveque;8759516;87595165;45.2500000000;0.6833330000;;f;FR;f;Europe/Paris;t;FRFLA;;t;;f;8703057;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2775;Marsac (Dordogne);marsac-dordogne;8759520;;45.1833330000;0.6666670000;;f;FR;f;Europe/Paris;t;FRFLB;;t;;f;8703922;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2776;Fontenay-le-Comte;fontenay-le-comte;9909012;;46.3666670000;-0.7333330000;;t;FR;f;Europe/Paris;f;FRFLC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2777;La Cave;la-cave;8759521;87595215;45.18397;0.63003;;f;FR;f;Europe/Paris;t;FRFLD;;t;;f;8703548;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2778;Razac;razac;8759522;87595223;45.1666670000;0.6166670000;;f;FR;f;Europe/Paris;t;FRFLE;;t;;f;8704346;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2779;St-Astier;st-astier;8759524;87595249;45.138991138759735;0.5227518081665038;;f;FR;f;Europe/Paris;t;FRFLF;STK;t;;f;8700635;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2779;St-Astier;st-astier;8759524;87595249;45.138991138759735;0.5227518081665038;;f;FR;f;Europe/Paris;t;FRFLF;STK;t;;f;8700635;f;;f;;f;;f;;;f;;f;8700321;f;;f;f;;;;;;;;;;;;;;;;;;
 2780;St-Léon-sur-l’Isle;st-leon-sur-lisle;8759526;87595264;45.1166670000;0.5000000000;;f;FR;f;Europe/Paris;t;FRFLG;;t;;f;8704601;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2781;Neuvic;neuvic;8759527;87595272;45.1000000000;0.4666670000;;f;FR;f;Europe/Paris;t;FRFLH;;t;;f;8704102;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2782;Douzillac;douzillac;8759528;87595280;45.0833330000;0.4166670000;;f;FR;f;Europe/Paris;t;FRFLI;;t;;f;8703241;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2783;Mussidan;mussidan;8759529;87595298;45.03437359510477;0.35381555557250977;;f;FR;f;Europe/Paris;t;FRFLJ;MUS;t;;f;8700183;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2784;Montpon-Ménestérol;montpon-menesterol;8759532;87595322;45.006337;0.159387;;f;FR;f;Europe/Paris;t;FRFLL;MPI;t;;f;8701574;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2783;Mussidan;mussidan;8759529;87595298;45.03437359510477;0.35381555557250977;;f;FR;f;Europe/Paris;t;FRFLJ;MUS;t;;f;8700183;f;;f;;f;;f;;;f;;f;8700464;f;;f;f;;;;;;;;;;;;;;;;;;
+2784;Montpon-Ménestérol;montpon-menesterol;8759532;87595322;45.006337;0.159387;;f;FR;f;Europe/Paris;t;FRFLL;MPI;t;;f;8701574;f;;f;;f;;f;;;f;;f;8700320;f;;f;f;;;;;;;;;;;;;;;;;;
 2785;St-Étienne-de-Fontbellon;st-etienne-de-fontbellon;8733707;87337071;44.6000000000;4.3833330000;;f;FR;f;Europe/Paris;t;FRFLN;;t;;f;8705238;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2786;Périgueux St-Georges;perigueux-st-georges;8759550;87595504;45.178498;0.733897;4957;f;FR;f;Europe/Paris;t;FRFLO;;t;;f;8704201;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2787;St-Pierre-de-Chignac;st-pierre-de-chignac;8759552;87595520;45.1333330000;0.8500000000;;f;FR;f;Europe/Paris;t;FRFLP;;t;;f;8704636;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2788;Milhac-d’Auberoche;milhac-dauberoche;8759553;87595538;45.1166670000;0.9166670000;;f;FR;f;Europe/Paris;t;FRFLQ;;t;;f;8703992;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2789;Flère-la-Rivière;flere-la-riviere;8721668;87216689;47.0166670000;1.1000000000;;f;FR;f;Europe/Paris;t;FRFLR;;t;;f;8705196;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2790;Flers;flers;8744800;87448001;48.74470066718565;-0.5731558799743652;;f;FR;f;Europe/Paris;t;FRFLS;FLS;t;;f;8700217;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2790;Flers;flers;8744800;87448001;48.74470066718565;-0.5731558799743652;;f;FR;f;Europe/Paris;t;FRFLS;FLS;t;;f;8700217;f;;f;;f;;f;;;f;;f;8700753;f;;f;f;;;;;;;;;;;;;;;;;;
 2791;Limeyrat;limeyrat;8759555;87595553;45.1666670000;0.9833330000;;f;FR;f;Europe/Paris;t;FRFLT;;t;;f;8703807;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2792;Thenon;thenon;8759557;87595579;45.160187;1.068691;;f;FR;f;Europe/Paris;t;FRFLU;THN;t;;f;8704709;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2793;Flaviac;flaviac;8733699;;44.7500000000;4.6833330000;;f;FR;f;Europe/Paris;t;FRFLV;;t;;f;8705239;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2794;La Bachellerie;la-bachellerie;8759559;87595595;45.1500000000;1.1666670000;;f;FR;f;Europe/Paris;t;FRFLW;;t;;f;8703537;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2795;Les Versannes;les-versannes;8759570;87595702;45.088624;0.857552;;f;FR;f;Europe/Paris;t;FRFLX;;t;;f;8703790;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2796;Mauzens-Miremont;mauzens-miremont;8759572;87595728;45.0000000000;0.9166670000;;f;FR;f;Europe/Paris;t;FRFLZ;;t;;f;8703955;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2797;Les Eyzies;les-eyzies;8759573;87595736;44.941063267716096;1.0082209110260008;;f;FR;f;Europe/Paris;t;FRFMA;;t;;f;8703767;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2798;Le Bugue;le-bugue;8759574;87595744;44.90570123247547;0.9427857398986815;;f;FR;f;Europe/Paris;t;FRFMB;;t;;f;8703692;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2797;Les Eyzies;les-eyzies;8759573;87595736;44.941063267716096;1.0082209110260008;;f;FR;f;Europe/Paris;t;FRFMA;;t;;f;8703767;f;;f;;f;;f;;;f;;f;8700652;f;;f;f;;;;;;;;;;;;;;;;;;
+2798;Le Bugue;le-bugue;8759574;87595744;44.90570123247547;0.9427857398986815;;f;FR;f;Europe/Paris;t;FRFMB;;t;;f;8703692;f;;f;;f;;f;;;f;;f;8700653;f;;f;f;;;;;;;;;;;;;;;;;;
 2799;St-Cyprien-en-Dordogne;st-cyprien-en-dordogne;8759577;87595777;44.863211;1.04344;;f;FR;f;Europe/Paris;t;FRFMC;;t;;f;8704407;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2801;Vezac;vezac;8759581;;44.833492904452555;1.1645561456680298;;f;FR;f;Europe/Paris;t;FRFME;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2802;Belves;belves;8759587;87595876;44.7833330000;1.0000000000;;f;FR;f;Europe/Paris;t;FRFMF;;t;;f;8702809;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2802;Belves;belves;8759587;87595876;44.7833330000;1.0000000000;;f;FR;f;Europe/Paris;t;FRFMF;;t;;f;8702809;f;;f;;f;;f;;;f;;f;8700656;f;;f;f;;;;;;;;;;;;;;;;;;
 2803;Issoudun Place de la Gare;issoudun-place-de-la-gare;8730464;;46.9500000000;2.0000000000;2818;f;FR;f;Europe/Paris;t;FRFMG;;t;;f;8700323;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2804;Villefranche-du-Périgord;villefranche-du-perigord;8759589;87595892;44.627406;1.048537;;f;FR;f;Europe/Paris;t;FRFMH;VPD;t;;f;8704856;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2805;Fourmies;fourmies;8729504;87295048;50.01546107724932;4.053928256034851;;f;FR;f;Europe/Paris;t;FRFMI;;t;;f;8700240;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2807;Reuilly;reuilly;8759703;87597039;47.0833330000;2.0500000000;;f;FR;f;Europe/Paris;t;FRFMK;;t;;f;8702323;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2804;Villefranche-du-Périgord;villefranche-du-perigord;8759589;87595892;44.627406;1.048537;;f;FR;f;Europe/Paris;t;FRFMH;VPD;t;;f;8704856;f;;f;;f;;f;;;f;;f;8700657;f;;f;f;;;;;;;;;;;;;;;;;;
+2805;Fourmies;fourmies;8729504;87295048;50.01546107724932;4.053928256034851;;f;FR;f;Europe/Paris;t;FRFMI;;t;;f;8700240;f;;f;;f;;f;;;f;;f;8700853;f;;f;f;;;;;;;;;;;;;;;;;;
+2807;Reuilly;reuilly;8759703;87597039;47.0833330000;2.0500000000;;f;FR;f;Europe/Paris;t;FRFMK;;t;;f;8702323;f;;f;;f;;f;;;f;;f;8700694;f;;f;f;;;;;;;;;;;;;;;;;;
 2808;Diou (Indre);diou-indre;8759704;87597047;47.0500000000;2.0500000000;;f;FR;f;Europe/Paris;t;FRFML;;t;;f;8702305;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2809;Ste-Lizaigne;ste-lizaigne;8759705;87597054;47.0000000000;2.0166670000;;f;FR;f;Europe/Paris;t;FRFMM;;t;;f;8702327;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2810;Issoudun;issoudun;8759706;87597062;46.948899987382035;1.9857573509216306;2818;f;FR;t;Europe/Paris;t;FRFMN;ISK;t;;f;8702310;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;イスーダン;;;;Исудён;;;伊苏丹
+2810;Issoudun;issoudun;8759706;87597062;46.948899987382035;1.9857573509216306;2818;f;FR;t;Europe/Paris;t;FRFMN;ISK;t;;f;8702310;f;;f;;f;;f;;;f;;f;8700498;f;;f;f;;;;;;;;;;;イスーダン;;;;Исудён;;;伊苏丹
 2811;Neuvy-Pailloux;neuvy-pailloux;8759707;87597070;46.88651775269046;1.8591678142547607;;f;FR;f;Europe/Paris;t;FRFMO;;t;;f;8702322;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2813;Luant;luant;8759709;87597096;46.7333330000;1.5500000000;;f;FR;f;Europe/Paris;t;FRFMQ;;t;;f;8702314;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2814;Lothiers;lothiers;8759710;87597104;46.694682;1.562981;;f;FR;f;Europe/Paris;t;FRFMR;;t;;f;8702318;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2165,14 +2165,14 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2825;Nîmes Gare;nimes-gare;8777500;87775007;43.83233655668918;4.366212487220764;22600;f;FR;f;Europe/Paris;f;FRFNI;NMS;t;FNI;t;8700151;f;;f;FNI;t;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ニーム;님;;;Ним;;;尼姆
 2827;Verneuil—St-Germain;verneuil-st-germain;8759744;87597443;47.069964;1.054749;;f;FR;f;Europe/Paris;t;FRFNK;;t;;f;8705197;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2830;Marsac (Creuse);marsac-creuse;8759762;87597625;46.1000000000;1.6000000000;;f;FR;f;Europe/Paris;t;FRFNO;;t;;f;8703921;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2831;Vieilleville;vieilleville;8759763;87597633;46.091092;1.673638;;f;FR;f;Europe/Paris;t;FRFNP;;t;;f;8704836;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2831;Vieilleville;vieilleville;8759763;87597633;46.091092;1.673638;;f;FR;f;Europe/Paris;t;FRFNP;;t;;f;8704836;f;;f;;f;;f;;;f;;f;8700271;f;;f;f;;;;;;;;;;;;;;;;;;
 2832;Bourganeuf;bourganeuf;8759766;87597666;45.9500000000;1.7500000000;;f;FR;f;Europe/Paris;t;FRFNQ;;t;;f;8702889;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2833;Montaigut;montaigut;8759767;87597674;46.1166670000;1.7333330000;;f;FR;f;Europe/Paris;t;FRFNR;;t;;f;8704018;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2834;Ste-Anastasie;ste-anastasie;8764560;87645606;45.1666670000;2.9833330000;;f;FR;f;Europe/Paris;t;FRFNS;;t;;f;8704964;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2835;Parsac—Gouzon;parsac-gouzon;8759772;87597724;46.198612;2.174436;;f;FR;f;Europe/Paris;t;FRFNV;;t;;f;8704188;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2836;Allanche;allanche;8764561;87645614;45.2333330000;2.9333330000;;f;FR;f;Europe/Paris;t;FRFNW;;t;;f;8702642;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2837;Lavaufranche;lavaufranche;8759774;87597740;46.3166670000;2.2666670000;;f;FR;f;Europe/Paris;t;FRFNX;;t;;f;8703676;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2838;Firminy;firminy;8772672;87726729;45.391707098993855;4.2864274978637695;;f;FR;f;Europe/Paris;t;FRFNY;FNY;t;;f;8703317;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;菲尔米尼
+2838;Firminy;firminy;8772672;87726729;45.391707098993855;4.2864274978637695;;f;FR;f;Europe/Paris;t;FRFNY;FNY;t;;f;8703317;f;;f;;f;;f;;;f;;f;8700487;f;;f;f;;;;;;;;;;;;;;;;;;菲尔米尼
 2839;Lavaveix-les-Mines;lavaveix-les-mines;8759778;87597781;46.0666670000;2.0833330000;;f;FR;f;Europe/Paris;t;FRFOA;;t;;f;8703678;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2840;Aubusson;aubusson;8759782;87597823;45.95965654006829;2.1617209911346436;5604;f;FR;t;Europe/Paris;t;FRFOE;;t;;f;8702712;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Обисон;;;
 2841;Landeyrat;landeyrat;8711017;87110171;45.3000000000;2.8833330000;;f;FR;f;Europe/Paris;t;FRFOF;;t;;f;8703642;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2180,29 +2180,29 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2843;Croze;croze;8759785;87597856;45.81740;2.16254;;f;FR;f;Europe/Paris;t;FRFOH;;t;;f;8703191;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2844;Franois;franois;8771830;87718304;47.2333330000;5.9333330000;;f;FR;f;Europe/Paris;t;FRFOI;;t;;f;8702510;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2845;Clairavaux;clairavaux;8759786;87597864;45.7833330000;2.1666670000;;f;FR;f;Europe/Paris;t;FRFOJ;;t;;f;8703113;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2847;Folligny;folligny;8744764;87447649;48.82983684208951;-1.4072799682617188;;f;FR;f;Europe/Paris;t;FRFOL;FOL;t;;f;8700218;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2847;Folligny;folligny;8744764;87447649;48.82983684208951;-1.4072799682617188;;f;FR;f;Europe/Paris;t;FRFOL;FOL;t;;f;8700218;f;;f;;f;;f;;;f;;f;8700758;f;;f;f;;;;;;;;;;;;;;;;;;
 2848;Le Locle Col des Roches;le-locle-col-des-roches;8759821;87598219;;;4655;f;CH;f;Europe/Zurich;f;FRFOP;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2850;Fougères;fougeres;8747160;87471607;48.35043120511249;-1.1955785751342771;;f;FR;f;Europe/Paris;t;FRFOU;;t;;f;8703342;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;フージェール;;;;Фужер;;;富热尔
 2851;Limoux Flassian;limoux-flassian;8759875;87598755;43.068424;2.218178;4665;f;FR;f;Europe/Paris;t;FRFOV;;t;;f;8703811;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2852;St-Palais;st-palais;8761025;87610253;43.3333330000;-1.0333330000;;f;FR;f;Europe/Paris;t;FRFOY;;t;;f;8704631;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Donapaleu;;;;;;;;;;;Сен-Пале-сюр-Мер;;;滨海圣帕莱
-2853;Muret;muret;8761103;87611038;43.46491197671351;1.3242173194885252;;f;FR;f;Europe/Paris;t;FRFOZ;MET;t;;f;8700473;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ミュレ;;;;Мюре;;;米雷
+2853;Muret;muret;8761103;87611038;43.46491197671351;1.3242173194885252;;f;FR;f;Europe/Paris;t;FRFOZ;MET;t;;f;8700473;f;;f;;f;;f;;;f;;f;8700311;f;;f;f;;;;;;;;;;;ミュレ;;;;Мюре;;;米雷
 2854;Le Fauga;le-fauga;8761104;87611046;43.4000000000;1.2833330000;;f;FR;f;Europe/Paris;t;FRFPA;;t;;f;8701103;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2855;Carbonne;carbonne;8761106;87611061;43.2983852872489;1.2124764919281006;;f;FR;f;Europe/Paris;t;FRFPB;COA;t;;f;8700840;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2856;Cazères-sur-Garonne;cazeres-sur-garonne;8761107;87611079;43.212944;1.083065;;f;FR;f;Europe/Paris;t;FRFPC;CZG;t;;f;8700835;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2855;Carbonne;carbonne;8761106;87611061;43.2983852872489;1.2124764919281006;;f;FR;f;Europe/Paris;t;FRFPB;COA;t;;f;8700840;f;;f;;f;;f;;;f;;f;8700547;f;;f;f;;;;;;;;;;;;;;;;;;
+2856;Cazères-sur-Garonne;cazeres-sur-garonne;8761107;87611079;43.212944;1.083065;;f;FR;f;Europe/Paris;t;FRFPC;CZG;t;;f;8700835;f;;f;;f;;f;;;f;;f;8700548;f;;f;f;;;;;;;;;;;;;;;;;;
 2857;Martres-Tolosane;martres-tolosane;8761108;87611087;43.196295195968034;1.0165518522262573;;f;FR;f;Europe/Paris;t;FRFPD;;t;;f;8701505;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2858;St-Martory;st-martory;8761110;87611103;43.1500000000;0.9333330000;;f;FR;f;Europe/Paris;t;FRFPE;;t;;f;8701621;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2859;Lestelle;lestelle;8761111;87611111;43.1333330000;0.9166670000;;f;FR;f;Europe/Paris;t;FRFPF;;t;;f;8701370;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2860;Labarthe-Inard;labarthe-inard;8761112;87611129;43.10496224898778;0.8519554138183594;;f;FR;f;Europe/Paris;t;FRFPG;;t;;f;8701359;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2861;St-Gaudens;st-gaudens;8761113;87611137;43.10496224898778;0.7293891906738281;;f;FR;f;Europe/Paris;t;FRFPH;SGD;t;;f;8701963;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2861;St-Gaudens;st-gaudens;8761113;87611137;43.10496224898778;0.7293891906738281;;f;FR;f;Europe/Paris;t;FRFPH;SGD;t;;f;8701963;f;;f;;f;;f;;;f;;f;8700313;f;;f;f;;;;;;;;;;;;;;;;;;
 2862;Labroquère—St-Bertrand-de-Comminges;labroquere-st-bertrand-de-comminges;8761116;87611160;43.040432;0.597575;;f;FR;f;Europe/Paris;t;FRFPJ;;t;;f;8703619;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2863;Loures—Barbazan;loures-barbazan;8761117;87611178;43.020862;0.610682;10564;f;FR;f;Europe/Paris;t;FRFPK;LZB;t;;f;8703838;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2864;Marignac—St-Béat;marignac-st-beat;8761119;87611194;42.915572;0.651996;;f;FR;f;Europe/Paris;t;FRFPM;MSB;t;;f;8703910;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2864;Marignac—St-Béat;marignac-st-beat;8761119;87611194;42.915572;0.651996;;f;FR;f;Europe/Paris;t;FRFPM;MSB;t;;f;8703910;f;;f;;f;;f;;;f;;f;8700553;f;;f;f;;;;;;;;;;;;;;;;;;
 2865;Anos;anos;8761120;;43.4000000000;-0.2833330000;;f;FR;f;Europe/Paris;t;FRFPN;;t;;f;8705794;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2866;Lège;lege;8761121;87611210;42.87541373222446;0.6129705905914307;;f;FR;f;Europe/Paris;t;FRFPO;;t;;f;8703748;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2867;Cier-de-Luchon;cier-de-luchon;8761122;87611228;42.8500000000;0.6000000000;;f;FR;f;Europe/Paris;t;FRFPP;;t;;f;8703105;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2868;Varilhes;varilhes;8761132;87611327;43.042967;1.633133;;f;FR;f;Europe/Paris;t;FRFPR;;t;;f;8704781;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2870;Vernet-d’Ariège;vernet-dariege;8761135;87611350;43.18941;1.611622;;f;FR;f;Europe/Paris;t;FRFPT;;t;;f;8704807;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2871;Saverdun;saverdun;8761136;87611368;43.2333330000;1.5833330000;;f;FR;f;Europe/Paris;t;FRFPU;SRN;t;;f;8700498;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2871;Saverdun;saverdun;8761136;87611368;43.2333330000;1.5833330000;;f;FR;f;Europe/Paris;t;FRFPU;SRN;t;;f;8700498;f;;f;;f;;f;;;f;;f;8700565;f;;f;f;;;;;;;;;;;;;;;;;;
 2872;Cintegabelle;cintegabelle;8761137;87611376;43.30541240690961;1.5204048156738281;;f;FR;f;Europe/Paris;t;FRFPV;;t;;f;8703107;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2873;Auterive (Haute Garonne);auterive-haute-garonne;8761138;87611384;43.348962419448135;1.4688098430633543;;f;FR;f;Europe/Paris;t;FRFPW;AIE;t;;f;8702725;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2874;Vénerque—Le-Vernet;venerque-le-vernet;8761139;87611392;43.433458;1.425886;;f;FR;f;Europe/Paris;t;FRFPX;;t;;f;8704800;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2212,14 +2212,14 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2878;Larrazet;larrazet;8761147;87611475;43.9333330000;1.0833330000;;f;FR;f;Europe/Paris;t;FRFQC;;t;;f;8703664;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2879;Porta;porta;8761149;87611491;42.514932;1.824639;;f;FR;f;Europe/Paris;t;FRFQD;;t;;f;8704298;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2880;Fouquereuil;fouquereuil;8734220;87342204;50.5166670000;2.6000000000;;f;FR;f;Europe/Paris;t;FRFQE;;t;;f;8701148;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2881;Porté-Puymorens;porte-puymorens;8761150;87611509;42.5500000000;1.8333330000;;f;FR;f;Europe/Paris;t;FRFQF;PPM;t;;f;8700496;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2882;L’Hospitalet-près-l’Andorre;lhospitalet-pres-landorre;8761151;87611517;42.589488572714245;1.8002986907958982;;f;FR;f;Europe/Paris;t;FRFQG;LHT;t;;f;8700495;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2881;Porté-Puymorens;porte-puymorens;8761150;87611509;42.5500000000;1.8333330000;;f;FR;f;Europe/Paris;t;FRFQF;PPM;t;;f;8700496;f;;f;;f;;f;;;f;;f;8700543;f;;f;f;;;;;;;;;;;;;;;;;;
+2882;L’Hospitalet-près-l’Andorre;lhospitalet-pres-landorre;8761151;87611517;42.589488572714245;1.8002986907958982;;f;FR;f;Europe/Paris;t;FRFQG;LHT;t;;f;8700495;f;;f;;f;;f;;;f;;f;8700542;f;;f;f;;;;;;;;;;;;;;;;;;
 2883;Mérens-les-Vals;merens-les-vals;8761152;87611525;42.6500000000;1.8333330000;;f;FR;f;Europe/Paris;t;FRFQH;MLX;t;;f;8703972;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2884;Luzenac—Garanou;luzenac-garanou;8761155;87611558;42.764283;1.75313;;f;FR;f;Europe/Paris;t;FRFQI;LUG;t;;f;8703869;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2885;Vèbre La Remise;vebre-la-remise;8761156;87611566;42.767501;1.721083;;f;FR;f;Europe/Paris;t;FRFQJ;;t;;f;8704793;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2886;Les Cabannes;les-cabannes;8761157;87611574;42.7833330000;1.6666670000;;f;FR;f;Europe/Paris;t;FRFQK;CNB;t;;f;8703759;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2887;Ussat-les-Bains;ussat-les-bains;8761158;87611582;42.821922;1.62;;f;FR;f;Europe/Paris;t;FRFQL;;t;;f;8704757;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2888;Tarascon-sur-Ariège;tarascon-sur-ariege;8761159;87611590;42.849537;1.599927;;f;FR;f;Europe/Paris;t;FRFQM;TRC;t;;f;8700494;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2887;Ussat-les-Bains;ussat-les-bains;8761158;87611582;42.821922;1.62;;f;FR;f;Europe/Paris;t;FRFQL;;t;;f;8704757;f;;f;;f;;f;;;f;;f;8700662;f;;f;f;;;;;;;;;;;;;;;;;;
+2888;Tarascon-sur-Ariège;tarascon-sur-ariege;8761159;87611590;42.849537;1.599927;;f;FR;f;Europe/Paris;t;FRFQM;TRC;t;;f;8700494;f;;f;;f;;f;;;f;;f;8700532;f;;f;f;;;;;;;;;;;;;;;;;;
 2889;St-Paul—St-Antoine;st-paul-st-antoine;8761160;87611608;42.912902;1.640108;;f;FR;f;Europe/Paris;t;FRFQN;;t;;f;8704634;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2890;St-Jean-de-Verges;st-jean-de-verges;8761162;87611624;43.0166670000;1.6166670000;;f;FR;f;Europe/Paris;t;FRFQO;;t;;f;8703500;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2891;Beaumont-de-Lomagne;beaumont-de-lomagne;8761163;87611632;43.8833330000;0.9833330000;;f;FR;f;Europe/Paris;t;FRFQP;;t;;f;8702787;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2233,7 +2233,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2899;Baziège;baziege;8761172;87611723;43.4500000000;1.6166670000;;f;FR;f;Europe/Paris;t;FRFQX;;t;;f;8702486;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2900;Marsan;marsan;8761175;87611756;43.6666670000;0.7166670000;;f;FR;f;Europe/Paris;t;FRFQY;;t;;f;8700307;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2901;Aubiet;aubiet;8761176;87611764;43.6500000000;0.8000000000;;f;FR;f;Europe/Paris;t;FRFQZ;;t;;f;8702709;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2902;Frasne;frasne;8771513;87715136;46.857667312699796;6.157879829406737;;f;FR;f;Europe/Paris;t;FRFRA;FRA;t;;f;8700163;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+2902;Frasne;frasne;8771513;87715136;46.857667312699796;6.157879829406737;;f;FR;f;Europe/Paris;t;FRFRA;FRA;t;;f;8700163;f;;f;;f;;f;;;f;;f;8700354;f;;f;t;;;;;;;;;;;;;;;;;;
 2903;Gimont—Cahuzac;gimont-cahuzac;8761177;87611772;43.633172;0.867503;;f;FR;f;Europe/Paris;t;FRFRB;GAH;t;;f;8703404;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2905;L’Isle-Jourdain;lisle-jourdain;8761180;87611806;43.6166670000;1.0833330000;;f;FR;f;Europe/Paris;t;FRFRD;LIJ;t;;f;8703535;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2906;Mérenvielle;merenvielle;8761181;87611814;43.6333330000;1.1666670000;;f;FR;f;Europe/Paris;t;FRFRE;MWE;t;;f;8703973;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2241,11 +2241,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2908;Pibrac;pibrac;8761183;87611830;43.6166670000;1.3000000000;;f;FR;f;Europe/Paris;t;FRFRG;PBR;t;;f;8704214;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2909;Montrabé;montrabe;8761184;87611848;43.6500000000;1.5166670000;;f;FR;f;Europe/Paris;t;FRFRH;MTB;t;;f;8704046;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2910;Lamagistère;lamagistere;8761185;87611855;44.1166670000;0.8333330000;;f;FR;f;Europe/Paris;t;FRFRI;;t;;f;8703633;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2911;Valence-d’Agen;valence-dagen;8761186;87611863;44.11191;0.891496;;f;FR;f;Europe/Paris;t;FRFRK;;t;;f;8704768;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2911;Valence-d’Agen;valence-dagen;8761186;87611863;44.11191;0.891496;;f;FR;f;Europe/Paris;t;FRFRK;;t;;f;8704768;f;;f;;f;;f;;;f;;f;8700697;f;;f;f;;;;;;;;;;;;;;;;;;
 2912;Malause;malause;8761187;87611871;44.091364836317545;0.9725260734558104;;f;FR;f;Europe/Paris;t;FRFRL;;t;;f;8703889;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2913;Moissac;moissac;8761188;87611889;44.10241775116368;1.0773253440856934;;f;FR;f;Europe/Paris;t;FRFRM;;t;;f;8704002;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2914;Castelsarrasin;castelsarrasin;8761189;87611897;44.04035368078201;1.1143988370895386;;f;FR;f;Europe/Paris;t;FRFRN;;t;;f;8702982;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2915;Frouard;frouard;8714107;87141077;48.75550973660054;6.144275665283203;;f;FR;f;Europe/Paris;t;FRFRO;FRD;t;;f;8701112;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2913;Moissac;moissac;8761188;87611889;44.10241775116368;1.0773253440856934;;f;FR;f;Europe/Paris;t;FRFRM;;t;;f;8704002;f;;f;;f;;f;;;f;;f;8700696;f;;f;f;;;;;;;;;;;;;;;;;;
+2914;Castelsarrasin;castelsarrasin;8761189;87611897;44.04035368078201;1.1143988370895386;;f;FR;f;Europe/Paris;t;FRFRN;;t;;f;8702982;f;;f;;f;;f;;;f;;f;8700695;f;;f;f;;;;;;;;;;;;;;;;;;
+2915;Frouard;frouard;8714107;87141077;48.75550973660054;6.144275665283203;;f;FR;f;Europe/Paris;t;FRFRO;FRD;t;;f;8701112;f;;f;;f;;f;;;f;;f;8700146;f;;f;f;;;;;;;;;;;;;;;;;;
 2916;Lardenne;lardenne;8761193;87611939;43.59666333482096;1.3833439350128174;;f;FR;f;Europe/Paris;t;FRFRQ;KPL;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2917;Lalande Église;lalande-eglise;8761194;87611947;43.645945;1.428556;;f;FR;f;Europe/Paris;t;FRFRR;;t;;f;8701351;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2918;Route-de-Launaguet;route-de-launaguet;8761195;87611954;43.635347;1.439478;;f;FR;f;Europe/Paris;t;FRFRS;;t;;f;8701889;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2254,24 +2254,24 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2921;Montaudran;montaudran;8761201;87612010;43.572998;1.481179;;f;FR;f;Europe/Paris;t;FRFRW;;t;;f;8702537;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2922;Capens;capens;8761301;87613018;43.3333330000;1.2500000000;;f;FR;f;Europe/Paris;t;FRFRY;;t;;f;8702970;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2923;Floirac;floirac;8761302;;44.9166670000;1.6500000000;;f;FR;f;Europe/Paris;t;FRFRZ;;t;;f;8705867;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2924;Rocamadour—Padirac;rocamadour-padirac;8761304;87613042;44.818354;1.65735;;f;FR;f;Europe/Paris;t;FRFSA;RAP;t;;f;8704375;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2925;Gramat;gramat;8761305;87613059;44.7734119465052;1.7222678661346436;;f;FR;f;Europe/Paris;t;FRFSB;GRT;t;;f;8703425;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2924;Rocamadour—Padirac;rocamadour-padirac;8761304;87613042;44.818354;1.65735;;f;FR;f;Europe/Paris;t;FRFSA;RAP;t;;f;8704375;f;;f;;f;;f;;;f;;f;8700516;f;;f;f;;;;;;;;;;;;;;;;;;
+2925;Gramat;gramat;8761305;87613059;44.7734119465052;1.7222678661346436;;f;FR;f;Europe/Paris;t;FRFSB;GRT;t;;f;8703425;f;;f;;f;;f;;;f;;f;8700517;f;;f;f;;;;;;;;;;;;;;;;;;
 2927;Soulac-sur-Mer Église;soulac-sur-mer-eglise;8731005;;;;2935;f;FR;f;Europe/Paris;f;FRFSE;;t;;f;8705213;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2930;Gourdon;gourdon;8761314;87613141;44.74193250825177;1.3892555236816406;;f;FR;f;Europe/Paris;t;FRFSI;GOV;t;;f;8700537;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;グルドン;;;;Гурдон;;;古尔东
+2930;Gourdon;gourdon;8761314;87613141;44.74193250825177;1.3892555236816406;;f;FR;f;Europe/Paris;t;FRFSI;GOV;t;;f;8700537;f;;f;;f;;f;;;f;;f;8700552;f;;f;f;;;;;;;;;;;グルドン;;;;Гурдон;;;古尔东
 2932;Dégagnac;degagnac;8761317;87613174;44.65348209215186;1.340031623840332;;f;FR;f;Europe/Paris;t;FRFSL;;t;;f;8701016;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2935;Soulac-sur-Mer;soulac-sur-mer;;;;;;t;FR;f;Europe/Paris;f;FRFSO;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2936;Espère—Caillac;espere-caillac;8761321;;44.501946222150664;1.3882148265838623;;f;FR;f;Europe/Paris;t;FRFSP;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2937;Aubin;aubin;8761322;87613224;44.5333330000;2.2500000000;;f;FR;f;Europe/Paris;t;FRFSQ;AVB;t;;f;8702710;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2938;Cransac;cransac;8761323;87613232;44.52278296899612;2.271943688392639;;f;FR;f;Europe/Paris;t;FRFSR;CRZ;t;;f;8703182;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2940;St-Christophe;st-christophe;8761325;87613257;44.46458439872137;2.4076151847839355;;f;FR;f;Europe/Paris;t;FRFST;SIH;t;;f;8704541;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2937;Aubin;aubin;8761322;87613224;44.5333330000;2.2500000000;;f;FR;f;Europe/Paris;t;FRFSQ;AVB;t;;f;8702710;f;;f;;f;;f;;;f;;f;8700538;f;;f;f;;;;;;;;;;;;;;;;;;
+2938;Cransac;cransac;8761323;87613232;44.52278296899612;2.271943688392639;;f;FR;f;Europe/Paris;t;FRFSR;CRZ;t;;f;8703182;f;;f;;f;;f;;;f;;f;8700539;f;;f;f;;;;;;;;;;;;;;;;;;
+2940;St-Christophe;st-christophe;8761325;87613257;44.46458439872137;2.4076151847839355;;f;FR;f;Europe/Paris;t;FRFST;SIH;t;;f;8704541;f;;f;;f;;f;;;f;;f;8700544;f;;f;f;;;;;;;;;;;;;;;;;;
 2942;Lalbenque—Fontanes;lalbenque-fontanes;8761332;87613323;44.33321135034028;1.511671543121338;;f;FR;f;Europe/Paris;t;FRFSX;;t;;f;8701355;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2943;Montpezat-de-Quercy;montpezat-de-quercy;8761333;87613331;44.2333330000;1.4666670000;;f;FR;f;Europe/Paris;t;FRFSY;;t;;f;8701560;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2944;Caussade (Tarn-et-Garonne);caussade-tarn-et-garonne;8761335;87613356;44.162242501197646;1.5336549282073975;;f;FR;f;Europe/Paris;t;FRFTA;CSD;t;;f;8700957;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2944;Caussade (Tarn-et-Garonne);caussade-tarn-et-garonne;8761335;87613356;44.162242501197646;1.5336549282073975;;f;FR;f;Europe/Paris;t;FRFTA;CSD;t;;f;8700957;f;;f;;f;;f;;;f;;f;8700561;f;;f;f;;;;;;;;;;;;;;;;;;
 2945;Réalville;realville;8761338;87613380;44.1166670000;1.4666670000;;f;FR;f;Europe/Paris;t;FRFTC;;t;;f;8701855;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2946;Albias;albias;8761339;87613398;44.0833330000;1.4500000000;;f;FR;f;Europe/Paris;t;FRFTD;;t;;f;8700603;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2949;Najac;najac;8761346;87613463;44.22173754122005;1.9761282205581663;;f;FR;f;Europe/Paris;t;FRFTG;;t;;f;8704078;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2950;Laguépie;laguepie;8761347;87613471;44.145450101692184;1.9691598415374754;;f;FR;f;Europe/Paris;t;FRFTH;;t;;f;8703629;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2951;Lexos;lexos;8761348;87613489;44.14242;1.884867;;f;FR;f;Europe/Paris;t;FRFTI;;t;;f;8703795;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2950;Laguépie;laguepie;8761347;87613471;44.145450101692184;1.9691598415374754;;f;FR;f;Europe/Paris;t;FRFTH;;t;;f;8703629;f;;f;;f;;f;;;f;;f;8700524;f;;f;f;;;;;;;;;;;;;;;;;;
+2951;Lexos;lexos;8761348;87613489;44.14242;1.884867;;f;FR;f;Europe/Paris;t;FRFTI;;t;;f;8703795;f;;f;;f;;f;;;f;;f;8700525;f;;f;f;;;;;;;;;;;;;;;;;;
 2953;Vers;vers;8761352;87613521;44.484963;1.550477;;f;FR;f;Europe/Paris;t;FRFTK;;t;;f;8704814;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2954;St-Géry;st-gery;8761353;87613539;44.4833330000;1.5833330000;;f;FR;f;Europe/Paris;t;FRFTL;;t;;f;8704577;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2955;Conduche;conduche;8761354;87613547;44.484378;1.642023;;f;FR;f;Europe/Paris;t;FRFTM;;t;;f;8703146;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2289,15 +2289,15 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2969;Pont-de-Castelfranc;pont-de-castelfranc;8761376;87613760;44.501161;1.217957;;f;FR;f;Europe/Paris;t;FRFUC;;t;;f;8704258;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2970;Prayssac;prayssac;8761378;87613786;44.5000000000;1.2000000000;;f;FR;f;Europe/Paris;t;FRFUE;;t;;f;8704311;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2971;Puy-l’Évêque;puy-leveque;8761379;87613794;44.504235;1.136623;9503;f;FR;f;Europe/Paris;t;FRFUF;;t;;f;8704331;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2972;Cordes-Vindrac;cordes-vindrac;8761380;87613802;44.067189;1.90022;;f;FR;f;Europe/Paris;t;FRFUG;;t;;f;8703152;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2972;Cordes-Vindrac;cordes-vindrac;8761380;87613802;44.067189;1.90022;;f;FR;f;Europe/Paris;t;FRFUG;;t;;f;8703152;f;;f;;f;;f;;;f;;f;8700526;f;;f;f;;;;;;;;;;;;;;;;;;
 2973;Duravel;duravel;8761383;87613836;44.5166670000;1.0833330000;;f;FR;f;Europe/Paris;t;FRFUJ;;t;;f;8703252;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2974;Soturac;soturac;8761384;87613844;44.488387;1.019062;;f;FR;f;Europe/Paris;t;FRFUK;;t;;f;8704511;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2976;Salles-Courbatiès;salles-courbaties;8761387;87613877;44.475209;2.078746;;f;FR;f;Europe/Paris;t;FRFUM;;t;;f;8704440;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2977;Villeneuve-d’Aveyron;villeneuve-daveyron;8761388;87613885;44.438956;2.063141;;f;FR;f;Europe/Paris;t;FRFUN;;t;;f;8704862;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2978;Villefranche-de-Rouergue;villefranche-de-rouergue;8761389;87613893;44.347455;2.036623;;f;FR;f;Europe/Paris;t;FRFUO;VRW;t;;f;8704855;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ヴィルフランシュ＝ド＝ルエルグ;;;;Вильфранш-де-Руэрг;;;鲁埃格自由城
-2979;Villefranche-de-Lauragais;villefranche-de-lauragais;8761501;87615013;43.398373;1.71462;;f;FR;f;Europe/Paris;t;FRFUP;;t;;f;8702347;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2983;Bram;bram;8761505;87615054;43.24381551033298;2.1192240715026855;;f;FR;f;Europe/Paris;t;FRFUT;BRA;t;;f;8702476;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2984;Lézignan-Corbières;lezignan-corbieres;8761511;87615112;43.199951618859906;2.769949436187744;;f;FR;f;Europe/Paris;t;FRFUX;LZA;t;;f;8702319;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2978;Villefranche-de-Rouergue;villefranche-de-rouergue;8761389;87613893;44.347455;2.036623;;f;FR;f;Europe/Paris;t;FRFUO;VRW;t;;f;8704855;f;;f;;f;;f;;;f;;f;8700523;f;;f;f;;;;;;;;;;;ヴィルフランシュ＝ド＝ルエルグ;;;;Вильфранш-де-Руэрг;;;鲁埃格自由城
+2979;Villefranche-de-Lauragais;villefranche-de-lauragais;8761501;87615013;43.398373;1.71462;;f;FR;f;Europe/Paris;t;FRFUP;;t;;f;8702347;f;;f;;f;;f;;;f;;f;8700299;f;;f;f;;;;;;;;;;;;;;;;;;
+2983;Bram;bram;8761505;87615054;43.24381551033298;2.1192240715026855;;f;FR;f;Europe/Paris;t;FRFUT;BRA;t;;f;8702476;f;;f;;f;;f;;;f;;f;8700297;f;;f;f;;;;;;;;;;;;;;;;;;
+2984;Lézignan-Corbières;lezignan-corbieres;8761511;87615112;43.199951618859906;2.769949436187744;;f;FR;f;Europe/Paris;t;FRFUX;LZA;t;;f;8702319;f;;f;;f;;f;;;f;;f;8700296;f;;f;f;;;;;;;;;;;;;;;;;;
 2985;Couffoulens—Leuc;couffoulens-leuc;8761512;87615120;43.155494;2.316304;;f;FR;f;Europe/Paris;t;FRFUY;;t;;f;8703164;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2986;Verzeille;verzeille;8761513;87615138;43.130468;2.321257;;f;FR;f;Europe/Paris;t;FRFUZ;;t;;f;8704822;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2987;Pomas;pomas;8761514;87615146;43.1166670000;2.3000000000;;f;FR;f;Europe/Paris;t;FRFVA;;t;;f;8704251;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2305,10 +2305,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 2989;Couiza—Montazels;couiza-montazels;8761520;87615203;42.942378;2.248148;;f;FR;f;Europe/Paris;t;FRFVC;;t;;f;8703166;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2990;Espéraza;esperaza;8761521;87615211;42.9333330000;2.2166670000;;f;FR;f;Europe/Paris;t;FRFVD;;t;;f;8703283;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2991;Campagne-sur-Aude;campagne-sur-aude;8761522;87615229;42.9169371596312;2.2056126594543457;;f;FR;f;Europe/Paris;t;FRFVE;;t;;f;8702961;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2992;Gaillac;gaillac;8761525;87615252;43.906040253321954;1.8947982788085935;;f;FR;f;Europe/Paris;t;FRFVF;GAI;t;;f;8703362;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ガヤック;;;;Гайак;;;盖拉克
+2992;Gaillac;gaillac;8761525;87615252;43.906040253321954;1.8947982788085935;;f;FR;f;Europe/Paris;t;FRFVF;GAI;t;;f;8703362;f;;f;;f;;f;;;f;;f;8700527;f;;f;f;;;;;;;;;;;ガヤック;;;;Гайак;;;盖拉克
 2993;Quillan;quillan;8761526;87615260;42.87394343358784;2.1815532445907593;;f;FR;f;Europe/Paris;t;FRFVG;;t;;f;8704337;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2994;Lisle-sur-Tarn;lisle-sur-tarn;8761531;87615310;43.85642074842412;1.808125376701355;;f;FR;f;Europe/Paris;t;FRFVI;LSU;t;;f;8703812;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-2995;Rabastens—Couffouleux;rabastens-couffouleux;8761532;87615328;43.819448973072184;1.7304110527038574;;f;FR;f;Europe/Paris;t;FRFVJ;RAB;t;;f;8704339;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+2994;Lisle-sur-Tarn;lisle-sur-tarn;8761531;87615310;43.85642074842412;1.808125376701355;;f;FR;f;Europe/Paris;t;FRFVI;LSU;t;;f;8703812;f;;f;;f;;f;;;f;;f;8700645;f;;f;f;;;;;;;;;;;;;;;;;;
+2995;Rabastens—Couffouleux;rabastens-couffouleux;8761532;87615328;43.819448973072184;1.7304110527038574;;f;FR;f;Europe/Paris;t;FRFVJ;RAB;t;;f;8704339;f;;f;;f;;f;;;f;;f;8700643;f;;f;f;;;;;;;;;;;;;;;;;;
 2996;Roquesérière;roqueseriere;8761535;87615351;43.7333330000;1.6333330000;;f;FR;f;Europe/Paris;t;FRFVL;;t;;f;8704383;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2997;Montastruc-la-Conseillère;montastruc-la-conseillere;8761536;87615369;43.7166670000;1.6000000000;;f;FR;f;Europe/Paris;t;FRFVM;MCL;t;;f;8704019;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 2998;Gragnague;gragnague;8761537;87615377;43.6833330000;1.5833330000;;f;FR;f;Europe/Paris;t;FRFVN;GAG;t;;f;8703423;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2321,7 +2321,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3005;St-Amans-Soult;st-amans-soult;8761555;87615559;43.4833330000;2.5000000000;;f;FR;f;Europe/Paris;t;FRFVW;;t;;f;8704406;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3006;Albine;albine;8761556;;43.45960883527068;2.53959059715271;;f;FR;f;Europe/Paris;t;FRFVX;;t;;f;8705937;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3007;Labastide-Rouairoux;labastide-rouairoux;8761557;87615575;43.4666670000;2.6500000000;;f;FR;f;Europe/Paris;t;FRFVY;;t;;f;8703618;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3008;Carmaux;carmaux;8761562;87615625;44.048138865070925;2.1525800228118896;;f;FR;f;Europe/Paris;t;FRFWA;CMX;t;;f;8702976;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;卡尔莫
+3008;Carmaux;carmaux;8761562;87615625;44.048138865070925;2.1525800228118896;;f;FR;f;Europe/Paris;t;FRFWA;CMX;t;;f;8702976;f;;f;;f;;f;;;f;;f;8700626;f;;f;f;;;;;;;;;;;;;;;;;;卡尔莫
 3009;Mirepoix;mirepoix;8761563;87615633;43.0833330000;1.8833330000;;f;FR;f;Europe/Paris;t;FRFWB;;t;;f;8703999;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3010;Lacabarède;lacabarede;8761564;;43.4500000000;2.5833330000;;f;FR;f;Europe/Paris;t;FRFWC;;t;;f;8705939;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3011;Tanus;tanus;8761567;87615674;44.098552;2.317131;;f;FR;f;Europe/Paris;t;FRFWD;;t;;f;8704693;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2348,7 +2348,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3039;Fréchet-Aure;frechet-aure;8761867;87618678;42.923824;0.367371;;f;FR;f;Europe/Paris;t;FRFXH;;t;;f;8703350;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3040;Galiax;galiax;8761869;87618694;43.6166670000;0.0166670000;;f;FR;f;Europe/Paris;t;FRFXI;;t;;f;8703365;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3041;Galié;galie;8761870;87618702;42.9833330000;0.6333330000;;f;FR;f;Europe/Paris;t;FRFXJ;;t;;f;8703366;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3042;Saléchan—Siradan;salechan-siradan;8761871;87618710;42.962612;0.63151;10645;f;FR;f;Europe/Paris;t;FRFXK;SZS;t;;f;8704432;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3042;Saléchan—Siradan;salechan-siradan;8761871;87618710;42.962612;0.63151;10645;f;FR;f;Europe/Paris;t;FRFXK;SZS;t;;f;8704432;f;;f;;f;;f;;;f;;f;8700549;f;;f;f;;;;;;;;;;;;;;;;;;
 3045;Mazères-sur-Salat;mazeres-sur-salat;8761879;;43.1333330000;0.9666670000;;f;FR;f;Europe/Paris;t;FRFXO;;t;;f;8703961;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3046;Salies-du-Salat;salies-du-salat;8761880;87618801;43.1166670000;0.9500000000;;f;FR;f;Europe/Paris;t;FRFXP;;t;;f;8704435;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3047;Mane;mane;8761881;87618819;43.0833330000;0.9500000000;;f;FR;f;Europe/Paris;t;FRFXQ;;t;;f;8703897;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2379,7 +2379,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3077;Antist;antist;8762014;87620146;43.1166670000;0.1333330000;;f;FR;f;Europe/Paris;t;FRFYU;;t;;f;8702669;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3078;Cauterets;cauterets;8762015;87620153;42.89122312551464;-0.11367738246917723;;f;FR;f;Europe/Paris;t;FRFYV;;t;;f;8702989;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3079;St-Sulpice-sur-Lèze;st-sulpice-sur-leze;8762019;87620195;43.3333330000;1.3333330000;;f;FR;f;Europe/Paris;t;FRFYX;;t;;f;8704657;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3080;Lapeyrouse;lapeyrouse;8764104;87641043;46.2166670000;2.8666670000;;f;FR;f;Europe/Paris;t;FRFZB;;t;;f;8703650;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3080;Lapeyrouse;lapeyrouse;8764104;87641043;46.2166670000;2.8666670000;;f;FR;f;Europe/Paris;t;FRFZB;;t;;f;8703650;f;;f;;f;;f;;;f;;f;8700458;f;;f;f;;;;;;;;;;;;;;;;;;
 3081;Louroux-de-Bouble;louroux-de-bouble;8764105;87641050;46.2166670000;2.9833330000;;f;FR;f;Europe/Paris;t;FRFZC;;t;;f;8703839;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3082;Bellenaves;bellenaves;8764106;87641068;46.2000000000;3.0833330000;;f;FR;f;Europe/Paris;t;FRFZD;;t;;f;8702802;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3083;St-Bonnet-de-Rochefort;st-bonnet-de-rochefort;8764107;87641076;46.1500000000;3.1333330000;;f;FR;f;Europe/Paris;t;FRFZE;;t;;f;8704537;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2392,30 +2392,30 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3091;Huriel;huriel;8764121;87641217;46.3666670000;2.4833330000;;f;FR;f;Europe/Paris;t;FRFZS;;t;;f;8703477;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3092;La Miouze—Rochefort;la-miouze-rochefort;8764129;87641290;45.763444;2.827404;;f;FR;f;Europe/Paris;t;FRFZX;;t;;f;8703588;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3093;Pontgibaud;pontgibaud;8764131;87641316;45.8333330000;2.8666670000;;f;FR;f;Europe/Paris;t;FRFZZ;;t;;f;8704281;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3094;Vallon-en-Sully;vallon-en-sully;8764135;87641357;46.536328;2.610746;;f;FR;f;Europe/Paris;t;FRGAB;VLL;t;;f;8704770;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3094;Vallon-en-Sully;vallon-en-sully;8764135;87641357;46.536328;2.610746;;f;FR;f;Europe/Paris;t;FRGAB;VLL;t;;f;8704770;f;;f;;f;;f;;;f;;f;8700684;f;;f;f;;;;;;;;;;;;;;;;;;
 3095;Magnette;magnette;8764136;87641365;46.464145;2.60288;;f;FR;f;Europe/Paris;t;FRGAC;;t;;f;8703879;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3096;Les Trillers;les-trillers;8764137;87641373;46.414749;2.600102;;f;FR;f;Europe/Paris;t;FRGAD;;t;;f;8703787;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3097;Le Vauriat;le-vauriat;8764139;87641399;45.860294;2.920469;;f;FR;f;Europe/Paris;t;FRGAE;;t;;f;8703742;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3098;Chamblet;chamblet;8764140;;46.33337293454751;2.7024811506271362;;f;FR;f;Europe/Paris;t;FRGAF;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3099;Commentry;commentry;8764141;87641415;46.29521663946038;2.7399462461471558;;f;FR;f;Europe/Paris;t;FRGAG;CMY;t;;f;8701726;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Коммантри;;;科芒特里
+3099;Commentry;commentry;8764141;87641415;46.29521663946038;2.7399462461471558;;f;FR;f;Europe/Paris;t;FRGAG;CMY;t;;f;8701726;f;;f;;f;;f;;;f;;f;8700459;f;;f;f;;;;;;;;;;;;;;;Коммантри;;;科芒特里
 3100;Durtol—Nohanent;durtol-nohanent;8764144;87641449;45.794788460449034;3.048609495162964;;f;FR;f;Europe/Paris;t;FRGAI;;t;;f;8703253;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3101;St-Sauves-d’Auvergne;st-sauves-dauvergne;8764145;87641456;45.6000000000;2.6833330000;;f;FR;f;Europe/Paris;t;FRGAJ;;t;;f;8704651;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3102;La Bourboule;la-bourboule;8764146;87641464;45.59061787484626;2.7462172508239746;;f;FR;f;Europe/Paris;t;FRGAK;;t;;f;8700102;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;拉布尔布尔
-3103;Le Mont-Dore;le-mont-dore;8764147;87641472;45.579525;2.804922;;f;FR;f;Europe/Paris;t;FRGAL;;t;;f;8700107;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Мон-Дор;;;蒙多尔
-3104;Gannat;gannat;8773240;87732404;46.09814790219846;3.2043921947479244;;f;FR;f;Europe/Paris;t;FRGAN;GAN;t;;f;8700026;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Ганна;;;
+3102;La Bourboule;la-bourboule;8764146;87641464;45.59061787484626;2.7462172508239746;;f;FR;f;Europe/Paris;t;FRGAK;;t;;f;8700102;f;;f;;f;;f;;;f;;f;8700179;f;;f;f;;;;;;;;;;;;;;;;;;拉布尔布尔
+3103;Le Mont-Dore;le-mont-dore;8764147;87641472;45.579525;2.804922;;f;FR;f;Europe/Paris;t;FRGAL;;t;;f;8700107;f;;f;;f;;f;;;f;;f;8700189;f;;f;f;;;;;;;;;;;;;;;Мон-Дор;;;蒙多尔
+3104;Gannat;gannat;8773240;87732404;46.09814790219846;3.2043921947479244;;f;FR;f;Europe/Paris;t;FRGAN;GAN;t;;f;8700026;f;;f;;f;;f;;;f;;f;8700030;f;;f;f;;;;;;;;;;;;;;;Ганна;;;
 3108;Budelière—Chambon;budeliere-chambon;8764181;87641811;46.198612;2.455088;;f;FR;f;Europe/Paris;t;FRGAW;;t;;f;8702935;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3109;Evaux-les-Bains;evaux-les-bains;8764182;87641829;46.1666670000;2.4833330000;;f;FR;f;Europe/Paris;t;FRGAX;;t;;f;8703295;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3111;Auzances;auzances;8764184;87641845;46.0166670000;2.5000000000;;f;FR;f;Europe/Paris;t;FRGAZ;;t;;f;8702735;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3112;Létrade;letrade;8764187;87641878;45.88256;2.487396;;f;FR;f;Europe/Paris;t;FRGBC;;t;;f;8703794;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3113;Giat;giat;8764188;87641886;45.8000000000;2.4833330000;;f;FR;f;Europe/Paris;t;FRGBD;;t;;f;8703394;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3109;Evaux-les-Bains;evaux-les-bains;8764182;87641829;46.1666670000;2.4833330000;;f;FR;f;Europe/Paris;t;FRGAX;;t;;f;8703295;f;;f;;f;;f;;;f;;f;8700166;f;;f;f;;;;;;;;;;;;;;;;;;
+3111;Auzances;auzances;8764184;87641845;46.0166670000;2.5000000000;;f;FR;f;Europe/Paris;t;FRGAZ;;t;;f;8702735;f;;f;;f;;f;;;f;;f;8700167;f;;f;f;;;;;;;;;;;;;;;;;;
+3112;Létrade;letrade;8764187;87641878;45.88256;2.487396;;f;FR;f;Europe/Paris;t;FRGBC;;t;;f;8703794;f;;f;;f;;f;;;f;;f;8700168;f;;f;f;;;;;;;;;;;;;;;;;;
+3113;Giat;giat;8764188;87641886;45.8000000000;2.4833330000;;f;FR;f;Europe/Paris;t;FRGBD;;t;;f;8703394;f;;f;;f;;f;;;f;;f;8700169;f;;f;f;;;;;;;;;;;;;;;;;;
 3114;Ytrac;ytrac;8764510;87645101;44.910683;2.36445;;f;FR;f;Europe/Paris;t;FRGBF;;t;;f;8704909;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3115;Laroquebrou;laroquebrou;8764513;87645135;44.964145092674805;2.1929043531417847;10551;f;FR;f;Europe/Paris;t;FRGBG;;t;;f;8703663;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3115;Laroquebrou;laroquebrou;8764513;87645135;44.964145092674805;2.1929043531417847;10551;f;FR;f;Europe/Paris;t;FRGBG;;t;;f;8703663;f;;f;;f;;f;;;f;;f;8700535;f;;f;f;;;;;;;;;;;;;;;;;;
 3117;Lacapelle-Viescamp;lacapelle-viescamp;8764515;87645150;44.920247;2.26547;;f;FR;f;Europe/Paris;t;FRGBI;;t;;f;8703547;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3118;Maurs;maurs;8764516;87645168;44.706151;2.199561;;f;FR;f;Europe/Paris;t;FRGBJ;;t;;f;8703950;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3119;Pers;pers;8764517;87645176;44.8833330000;2.2333330000;;f;FR;f;Europe/Paris;t;FRGBK;;t;;f;8704204;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3120;Boisset;boisset;8764518;87645184;44.7833330000;2.2500000000;;f;FR;f;Europe/Paris;t;FRGBL;;t;;f;8702857;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3121;Le Rouget;le-rouget;8764519;87645192;44.8500000000;2.2333330000;;f;FR;f;Europe/Paris;t;FRGBM;;t;;f;8703729;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3123;Mauriac;mauriac;8764526;87645267;45.2166670000;2.3333330000;;f;FR;f;Europe/Paris;t;FRGBT;;t;;f;8703949;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3123;Mauriac;mauriac;8764526;87645267;45.2166670000;2.3333330000;;f;FR;f;Europe/Paris;t;FRGBT;;t;;f;8703949;f;;f;;f;;f;;;f;;f;8700558;f;;f;f;;;;;;;;;;;;;;;;;;
 3125;Vendes;vendes;8764528;87645283;45.297057;2.390582;;f;FR;f;Europe/Paris;t;FRGBV;;t;;f;8704798;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3129;Vic-sur-Cère;vic-sur-cere;8764544;87645440;44.976124;2.63205;;f;FR;f;Europe/Paris;t;FRGCC;;t;;f;8704833;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3130;Le Lioran;le-lioran;8764547;87645473;45.090548;2.753341;;f;FR;f;Europe/Paris;t;FRGCF;;t;;f;8703710;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2431,9 +2431,9 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3140;Cahuzac-sur-Adour;cahuzac-sur-adour;8767109;87671099;43.6333330000;-0.0166670000;;f;FR;f;Europe/Paris;t;FRGCU;;t;;f;8702950;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3141;St-Laurent—St-Paul;st-laurent-st-paul;8767110;;43.083385935210316;0.4964876174926757;;f;FR;f;Europe/Paris;t;FRGCV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3142;Cantaous—Tuzaguet;cantaous-tuzaguet;8767111;;43.1028000000;0.4436000000;;f;FR;f;Europe/Paris;t;FRGCW;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3143;Capvern;capvern;8767115;87671156;43.1000000000;0.3166670000;5012;f;FR;t;Europe/Paris;t;FRGCY;;t;;f;8700938;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3143;Capvern;capvern;8767115;87671156;43.1000000000;0.3166670000;5012;f;FR;t;Europe/Paris;t;FRGCY;;t;;f;8700938;f;;f;;f;;f;;;f;;f;8700315;f;;f;f;;;;;;;;;;;;;;;;;;
 3144;Ozon—Lanespède;ozon-lanespede;8767116;87671164;43.171144;0.252399;;f;FR;f;Europe/Paris;t;FRGCZ;;t;;f;8701732;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3145;Tournay;tournay;8767117;87671172;43.183648;0.238942;;f;FR;f;Europe/Paris;t;FRGDA;;t;;f;8700477;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3145;Tournay;tournay;8767117;87671172;43.183648;0.238942;;f;FR;f;Europe/Paris;t;FRGDA;;t;;f;8700477;f;;f;;f;;f;;;f;;f;8700316;f;;f;f;;;;;;;;;;;;;;;;;;
 3146;Bordes—Lhez;bordes-lhez;8767118;87671180;43.2000000000;0.2166670000;;f;FR;f;Europe/Paris;t;FRGDB;;t;;f;8700763;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3149;Séméac—Marcadieu;semeac-marcadieu;8767124;;43.222032;0.095869;;f;FR;f;Europe/Paris;t;FRGDF;;t;;f;8701951;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3150;Ossun;ossun;8767131;87671313;43.1833330000;-0.0333330000;;f;FR;f;Europe/Paris;t;FRGDG;;t;;f;8701724;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2468,12 +2468,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3190;Genève Eaux-Vives;geneve-eaux-vives;8774592;87745927;46.2007119952184;6.166044473648071;5335;f;CH;f;Europe/Zurich;f;FRGEV;;t;;f;8500007;t;;f;;f;;f;;;f;;f;;f;;f;f;;Genf;Geneva;Ginebra;;Ginevra;;Ženeva;;Genf;ジュネーヴ;제네바;Genewa;Genebra;Женева;;Cenevre;日内瓦
 3192;Gex Centre;gex-centre;8774527;87745273;46.33204691423479;6.058391332626343;4647;f;FR;t;Europe/Paris;t;FRGEX;;t;;f;8703392;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3193;Montaut—Bétharram;montaut-betharram;8767211;87672113;43.126989;-0.198302;;f;FR;f;Europe/Paris;t;FRGEZ;;t;;f;8701586;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3195;Coarraze—Nay;coarraze-nay;8767213;87672139;43.18185;-0.241594;;f;FR;f;Europe/Paris;t;FRGFB;CZN;t;;f;8700919;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3195;Coarraze—Nay;coarraze-nay;8767213;87672139;43.18185;-0.241594;;f;FR;f;Europe/Paris;t;FRGFB;CZN;t;;f;8700919;f;;f;;f;;f;;;f;;f;8700317;f;;f;f;;;;;;;;;;;;;;;;;;
 3196;Assat;assat;8767216;87672162;43.2500000000;-0.3000000000;;f;FR;f;Europe/Paris;t;FRGFC;;t;;f;8700630;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3199;Artix;artix;8767221;87672212;43.393104905432835;-0.5701732635498047;;f;FR;f;Europe/Paris;t;FRGFF;;t;;f;8700628;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3202;Orthez;orthez;8767225;87672253;43.48409596170142;-0.7676589488983153;;f;FR;f;Europe/Paris;t;FRGFI;ORT;t;;f;8700478;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;オルテズ;;;;Ортез;;;奥尔泰
-3205;Peyrehorade;peyrehorade;8767233;87672337;43.5500000000;-1.1000000000;;f;FR;f;Europe/Paris;t;FRGFL;PRH;t;;f;8700465;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3210;Granville;granville;8744768;87447680;48.83845267633574;-1.5874171257019043;;f;FR;f;Europe/Paris;t;FRGFR;GRV;t;;f;8700306;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+3199;Artix;artix;8767221;87672212;43.393104905432835;-0.5701732635498047;;f;FR;f;Europe/Paris;t;FRGFF;;t;;f;8700628;f;;f;;f;;f;;;f;;f;8700597;f;;f;f;;;;;;;;;;;;;;;;;;
+3202;Orthez;orthez;8767225;87672253;43.48409596170142;-0.7676589488983153;;f;FR;f;Europe/Paris;t;FRGFI;ORT;t;;f;8700478;f;;f;;f;;f;;;f;;f;8700318;f;;f;t;;;;;;;;;;;オルテズ;;;;Ортез;;;奥尔泰
+3205;Peyrehorade;peyrehorade;8767233;87672337;43.5500000000;-1.1000000000;;f;FR;f;Europe/Paris;t;FRGFL;PRH;t;;f;8700465;f;;f;;f;;f;;;f;;f;8700207;f;;f;f;;;;;;;;;;;;;;;;;;
+3210;Granville;granville;8744768;87447680;48.83845267633574;-1.5874171257019043;;f;FR;f;Europe/Paris;t;FRGFR;GRV;t;;f;8700306;f;;f;;f;;f;;;f;;f;8700759;f;;f;t;;;;;;;;;;;;;;;;;;
 3214;Espès-Undurein;espes-undurein;8767252;87672527;43.2666670000;-0.8833330000;;f;FR;f;Europe/Paris;t;FRGFV;;t;;f;8703284;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3216;Mauléon;mauleon;8767255;87672550;43.2333330000;-0.8833330000;;f;FR;f;Europe/Paris;t;FRGFX;;t;;f;8703945;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3218;Guilherand—Granges;guilherand-granges;8733695;87336958;44.9333330000;4.8666670000;;f;FR;f;Europe/Paris;t;FRGGA;;t;;f;8705240;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2484,18 +2484,18 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3229;Bedous;bedous;8767277;87672774;43.0000000000;-0.6000000000;;f;FR;f;Europe/Paris;t;FRGGM;;t;;f;8702796;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3230;Lescun;lescun;8767279;87672790;42.9333330000;-0.6333330000;;f;FR;f;Europe/Paris;t;FRGGN;;t;;f;8703792;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3231;Etsaut;etsaut;8767282;87672824;42.9166670000;-0.5666670000;;f;FR;f;Europe/Paris;t;FRGGO;;t;;f;8703294;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3232;Guingamp;guingamp;8747320;87473207;48.55564833649686;-3.143506050109863;;f;FR;f;Europe/Paris;t;FRGGP;GGP;t;;f;8700538;f;gbtu20;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ガンガン;갱강;;;Генган;;;甘岡
+3232;Guingamp;guingamp;8747320;87473207;48.55564833649686;-3.143506050109863;;f;FR;f;Europe/Paris;t;FRGGP;GGP;t;;f;8700538;f;gbtu20;t;;f;;f;;;f;;f;8700732;f;;f;t;;;;;;;;;;;ガンガン;갱강;;;Генган;;;甘岡
 3233;Urdos;urdos;8767283;87672832;42.868819;-0.554391;;f;FR;f;Europe/Paris;t;FRGGQ;;t;;f;8704755;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3234;Forges-d’Abel;forges-dabel;8767284;87672840;42.821617;-0.564288;;f;FR;f;Europe/Paris;t;FRGGR;;t;;f;8701143;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3235;Canfranc;canfranc;8767290;;;;6631;f;ES;f;Europe/Madrid;f;FRGGS;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3236;Boucau;boucau;8767309;87673095;43.5277040000;-1.4655590000;;f;FR;f;Europe/Paris;t;FRGGT;;t;;f;8700678;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Bokale;;;;;;;;;;;;;;
 3240;Saubusse-les-Bains;saubusse-les-bains;8767325;87673251;43.660337;-1.190171;;f;FR;f;Europe/Paris;t;FRGGY;;t;;f;8701928;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3241;St-Geours;st-geours;8767326;87673269;43.671268;-1.240933;;f;FR;f;Europe/Paris;t;FRGGZ;;t;;f;8701967;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3242;St-Vincent-de-Tyrosse;st-vincent-de-tyrosse;8767327;87673277;43.65756444769408;-1.3064181804656982;;f;FR;f;Europe/Paris;t;FRGHA;;t;;f;8702163;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3242;St-Vincent-de-Tyrosse;st-vincent-de-tyrosse;8767327;87673277;43.65756444769408;-1.3064181804656982;;f;FR;f;Europe/Paris;t;FRGHA;;t;;f;8702163;f;;f;;f;;f;;;f;;f;8700575;f;;f;f;;;;;;;;;;;;;;;;;;
 3243;Bénesse-Maremne;benesse-maremne;8767328;87673285;43.627657457004695;-1.3697290420532227;;f;FR;f;Europe/Paris;t;FRGHB;;t;;f;8700694;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3244;Labenne;labenne;8767329;87673293;43.58704336534418;-1.4289093017578125;;f;FR;f;Europe/Paris;t;FRGHC;;t;;f;8701361;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3244;Labenne;labenne;8767329;87673293;43.58704336534418;-1.4289093017578125;;f;FR;f;Europe/Paris;t;FRGHC;;t;;f;8701361;f;;f;;f;;f;;;f;;f;8700577;f;;f;f;;;;;;;;;;;;;;;;;;
 3245;Ondres;ondres;8767331;87673319;43.5666670000;-1.4333330000;;f;FR;f;Europe/Paris;t;FRGHD;;t;;f;8701716;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3247;Guéthary;guethary;8767345;87673459;43.42535304691872;-1.6098511219024658;;f;FR;f;Europe/Paris;t;FRGHG;GTH;t;;f;8701222;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3247;Guéthary;guethary;8767345;87673459;43.42535304691872;-1.6098511219024658;;f;FR;f;Europe/Paris;t;FRGHG;GTH;t;;f;8701222;f;;f;;f;;f;;;f;;f;8700187;f;;f;f;;;;;;;;;;;;;;;;;;
 3249;Villefranque (Pyrénées Atlantiques);villefranque-pyrenees-atlantiques;8767361;87673616;43.431499;-1.45645;;f;FR;f;Europe/Paris;t;FRGHI;;t;;f;8704858;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Milafranga;;;;;;;;;;;;;;
 3250;Ustaritz;ustaritz;8767362;87673624;43.404801;-1.448971;;f;FR;f;Europe/Paris;t;FRGHJ;;t;;f;8704758;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Uztaritze;;;;;;;;;;;;;;于斯塔里特
 3251;Jatxou;jatxou;8767363;87673632;43.3833330000;-1.4333330000;;f;FR;f;Europe/Paris;t;FRGHK;;t;;f;8703497;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Lapurdi;;;;;;;;;;;;;;
@@ -2508,7 +2508,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3261;Montierchaume Bourg;montierchaume-bourg;8736087;87360875;46.8666670000;1.7666670000;2819;f;FR;t;Europe/Paris;t;FRGHY;;t;;f;8700462;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3262;Cheppes-la-Prairie;cheppes-la-prairie;8767406;87674069;48.8333330000;4.4666670000;;f;FR;f;Europe/Paris;t;FRGIB;;t;;f;8700897;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3263;Givors;givors;;;45.5833330000;4.7666670000;;t;FR;f;Europe/Paris;f;FRGIC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3264;Givors Ville;givors-ville;8772240;87722405;45.585125;4.765712;3263;f;FR;t;Europe/Paris;t;FRHEE;GIV;t;;f;8703410;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3264;Givors Ville;givors-ville;8772240;87722405;45.585125;4.765712;3263;f;FR;t;Europe/Paris;t;FRHEE;GIV;t;;f;8703410;f;;f;;f;;f;;;f;;f;8700308;f;;f;f;;;;;;;;;;;;;;;;;;
 3265;Togny-aux-Bœufs;togny-aux-boeufs;8767413;87674135;48.85265;4.440635;;f;FR;f;Europe/Paris;t;FRGIH;;t;;f;8702085;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3266;Dolleren;dolleren;8767416;;47.8060640000;6.9336610000;;f;FR;f;Europe/Paris;t;FRGIJ;;t;;f;8704975;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3267;Monswiller;monswiller;8767417;87674176;48.7500000000;7.3833330000;;f;FR;f;Europe/Paris;t;FRGIK;;t;;f;8701634;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2540,31 +2540,31 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3345;Champigny-sur-Yonne;champigny-sur-yonne;8768312;87683128;48.323743;3.130565;;f;FR;f;Europe/Paris;t;FRGMO;;t;;f;8700861;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3346;Pont-sur-Yonne;pont-sur-yonne;8768313;87683136;48.286298482229384;3.2016563415527344;;f;FR;f;Europe/Paris;t;FRGMP;;t;;f;8701819;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3347;Étigny-Véron;etigny-veron;8768320;87683201;48.138673;3.29051;;f;FR;f;Europe/Paris;t;FRGMQ;;t;;f;8701092;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3348;Villeneuve-sur-Yonne;villeneuve-sur-yonne;8768321;87683219;48.085016;3.286923;;f;FR;f;Europe/Paris;t;FRGMR;;t;;f;8702194;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3348;Villeneuve-sur-Yonne;villeneuve-sur-yonne;8768321;87683219;48.085016;3.286923;;f;FR;f;Europe/Paris;t;FRGMR;;t;;f;8702194;f;;f;;f;;f;;;f;;f;8700361;f;;f;f;;;;;;;;;;;;;;;;;;
 3349;St-Julien-du-Sault;st-julien-du-sault;8768322;87683227;48.0333330000;3.3000000000;;f;FR;f;Europe/Paris;t;FRGMS;;t;;f;8701985;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3351;Joigny;joigny;8768324;87683243;47.97370219744604;3.3929461240768433;;f;FR;f;Europe/Paris;t;FRGMU;JOI;t;;f;8700561;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3351;Joigny;joigny;8768324;87683243;47.97370219744604;3.3929461240768433;;f;FR;f;Europe/Paris;t;FRGMU;JOI;t;;f;8700561;f;;f;;f;;f;;;f;;f;8700359;f;;f;f;;;;;;;;;;;;;;;;;;
 3354;Neuvy-Sautour;neuvy-sautour;8768334;87683342;48.03439221867337;3.7990969419479366;4529;f;FR;t;Europe/Paris;t;FRGMX;;t;;f;8706445;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3357;Chemilly-Appoigny;chemilly-appoigny;8768353;87683532;47.897241;3.554415;;f;FR;f;Europe/Paris;t;FRGNA;;t;;f;8703087;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3358;Grenoble;grenoble;8774700;87747006;45.19141330598916;5.714542865753174;3366;f;FR;t;Europe/Paris;t;FRGNB;GRE;t;GNB;t;8700034;f;;f;;f;8774700;f;;;f;;f;;f;;f;t;;;;;;;;;;;グルノーブル;그르노블;;;Гренобль;;;格勒诺布尔
+3357;Chemilly-Appoigny;chemilly-appoigny;8768353;87683532;47.897241;3.554415;;f;FR;f;Europe/Paris;t;FRGNA;;t;;f;8703087;f;;f;;f;;f;;;f;;f;8700475;f;;f;f;;;;;;;;;;;;;;;;;;
+3358;Grenoble;grenoble;8774700;87747006;45.19141330598916;5.714542865753174;3366;f;FR;t;Europe/Paris;t;FRGNB;GRE;t;GNB;t;8700034;f;;f;;f;8774700;f;;;f;;f;8700041;f;;f;t;;;;;;;;;;;グルノーブル;그르노블;;;Гренобль;;;格勒诺布尔
 3359;Monéteau-Gurgy;moneteau-gurgy;8768355;87683557;47.850785;3.579981;;f;FR;f;Europe/Paris;t;FRGND;;t;;f;8704009;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3360;Augy-Vaux;augy-vaux;8768360;87683607;47.766331;3.611182;;f;FR;f;Europe/Paris;t;FRGNF;;t;;f;8702716;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3361;Champs-St-Bris;champs-st-bris;8768361;87683615;47.738824;3.603478;;f;FR;f;Europe/Paris;t;FRGNG;;t;;f;8703031;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3362;Vincelles;vincelles;8768363;87683631;47.704224;3.628477;;f;FR;f;Europe/Paris;t;FRGNH;;t;;f;8704884;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3363;Vermenton;vermenton;8768366;87683664;47.660591;3.732024;;f;FR;f;Europe/Paris;t;FRGNI;;t;;f;8704802;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3362;Vincelles;vincelles;8768363;87683631;47.704224;3.628477;;f;FR;f;Europe/Paris;t;FRGNH;;t;;f;8704884;f;;f;;f;;f;;;f;;f;8700474;f;;f;f;;;;;;;;;;;;;;;;;;
+3363;Vermenton;vermenton;8768366;87683664;47.660591;3.732024;;f;FR;f;Europe/Paris;t;FRGNI;;t;;f;8704802;f;;f;;f;;f;;;f;;f;8700416;f;;f;f;;;;;;;;;;;;;;;;;;
 3364;Lucy-sur-Cure-Bessy;lucy-sur-cure-bessy;8768367;87683672;47.62814;3.745876;;f;FR;f;Europe/Paris;t;FRGNJ;;t;;f;8703853;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3365;Arcy-sur-Cure;arcy-sur-cure;8768368;87683680;47.6000000000;3.7500000000;;f;FR;f;Europe/Paris;t;FRGNK;;t;;f;8702678;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3365;Arcy-sur-Cure;arcy-sur-cure;8768368;87683680;47.6000000000;3.7500000000;;f;FR;f;Europe/Paris;t;FRGNK;;t;;f;8702678;f;;f;;f;;f;;;f;;f;8700469;f;;f;f;;;;;;;;;;;;;;;;;;
 3366;Grenoble;grenoble;;;45.1666670000;5.7166670000;;t;FR;f;Europe/Paris;f;FRGNL;;t;;f;;f;u0h0fn;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 3367;Grenoble Universités Gières;grenoble-universites-gieres;8774740;87747402;45.185024;5.784702;3366;f;FR;f;Europe/Paris;t;FRHVS;GRS;t;;f;8703396;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3369;Voutenay;voutenay;8768370;87683706;47.561341;3.78035;;f;FR;f;Europe/Paris;t;FRGNM;;t;;f;8704905;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3370;Sermizelles-Vézelay;sermizelles-vezelay;8768372;87683722;47.528881;3.792899;;f;FR;f;Europe/Paris;t;FRGNN;;t;;f;8704485;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3371;Avallon;avallon;8768378;87683789;47.49571939080665;3.912549018859863;;f;FR;f;Europe/Paris;t;FRGNS;;t;;f;8702737;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;アヴァヨン;;;;Аваллон;;;阿瓦隆
+3370;Sermizelles-Vézelay;sermizelles-vezelay;8768372;87683722;47.528881;3.792899;;f;FR;f;Europe/Paris;t;FRGNN;;t;;f;8704485;f;;f;;f;;f;;;f;;f;8700417;f;;f;f;;;;;;;;;;;;;;;;;;
+3371;Avallon;avallon;8768378;87683789;47.49571939080665;3.912549018859863;;f;FR;f;Europe/Paris;t;FRGNS;;t;;f;8702737;f;;f;;f;;f;;;f;;f;8700418;f;;f;f;;;;;;;;;;;アヴァヨン;;;;Аваллон;;;阿瓦隆
 3372;Argent-sur-Sauldre;argent-sur-sauldre;8731452;87314526;47.5500000000;2.4500000000;;f;FR;f;Europe/Paris;t;FRGNT;;t;;f;8700483;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3373;St-Genou;st-genou;8720678;87206789;46.9333330000;1.3333330000;;f;FR;f;Europe/Paris;t;FRGNU;;t;;f;8705194;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3374;Mailly-la-Ville;mailly-la-ville;8768384;87683847;47.604157;3.675167;;f;FR;f;Europe/Paris;t;FRGNV;;t;;f;8703881;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3375;Montargis;montargis;8768400;87684001;48.00687897345727;2.742912769317627;;f;FR;f;Europe/Paris;t;FRGNX;MSR;t;;f;8700117;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モンタルジ;;;;Монтаржи;;;蒙塔日
+3374;Mailly-la-Ville;mailly-la-ville;8768384;87683847;47.604157;3.675167;;f;FR;f;Europe/Paris;t;FRGNV;;t;;f;8703881;f;;f;;f;;f;;;f;;f;8700399;f;;f;f;;;;;;;;;;;;;;;;;;
+3375;Montargis;montargis;8768400;87684001;48.00687897345727;2.742912769317627;;f;FR;f;Europe/Paris;t;FRGNX;MSR;t;;f;8700117;f;;f;;f;;f;;;f;;f;8700212;f;;f;t;;;;;;;;;;;モンタルジ;;;;Монтаржи;;;蒙塔日
 3380;Souppes—Château-Landon;souppes-chateau-landon;8768421;87684217;48.181695;2.735093;;f;FR;f;Europe/Paris;t;FRGOC;SPP;t;;f;8704519;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3383;Nogent-sur-Vernisson;nogent-sur-vernisson;8768427;87684274;47.852680257849;2.7376556396484375;;f;FR;f;Europe/Paris;t;FRGOG;NGI;t;;f;8704121;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3384;Gien;gien;8768429;87684290;47.699162549079034;2.6366114616394043;;f;FR;f;Europe/Paris;t;FRGOH;GIE;t;;f;8703395;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3384;Gien;gien;8768429;87684290;47.699162549079034;2.6366114616394043;;f;FR;f;Europe/Paris;t;FRGOH;GIE;t;;f;8703395;f;;f;;f;;f;;;f;;f;8700213;f;;f;f;;;;;;;;;;;;;;;;;;
 3389;Paris-Gare-de-Lyon A;paris-gare-de-lyon-a;8768610;;;;4916;f;FR;f;Europe/Paris;f;FRGOO;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3390;Paris-Gare-de-Lyon B;paris-gare-de-lyon-b;8768611;87686113;;;4916;f;FR;f;Europe/Paris;f;FRGOP;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3396;Pontaix;pontaix;8768850;87688507;44.7500000000;5.2666670000;;f;FR;f;Europe/Paris;t;FRGPA;;t;;f;8702564;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2576,7 +2576,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3407;St-Léger-des-Vignes;st-leger-des-vignes;8769162;87691626;46.838310089634184;3.4569382667541504;;f;FR;f;Europe/Paris;t;FRGPU;;t;;f;8703749;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3408;Verneuil;verneuil;8769167;87691675;46.86096864442277;3.557596206665039;;f;FR;f;Europe/Paris;t;FRGPV;;t;;f;8702202;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3409;Avrée;avree;8769172;87691725;46.8166670000;3.8666670000;;f;FR;f;Europe/Paris;t;FRGPW;;t;;f;8702744;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3410;Le Creusot;le-creusot;8769400;87694000;46.80777784231953;4.430376291275024;;f;FR;f;Europe/Paris;t;FRGPX;;t;;f;8700254;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ル＝クルーゾ;;;;Ле-Крёзо;;;
+3410;Le Creusot;le-creusot;8769400;87694000;46.80777784231953;4.430376291275024;;f;FR;f;Europe/Paris;t;FRGPX;;t;;f;8700254;f;;f;;f;;f;;;f;;f;8700389;f;;f;f;;;;;;;;;;;ル＝クルーゾ;;;;Ле-Крёзо;;;
 3411;St-Didier-sur-Arroux;st-didier-sur-arroux;8769413;;46.83311371124671;4.115645885467529;;f;FR;f;Europe/Paris;t;FRGPY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3412;Mesvres;mesvres;8769415;87694158;46.8666670000;4.2500000000;;f;FR;f;Europe/Paris;t;FRGPZ;;t;;f;8703981;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3413;Broye;broye;8769416;87694166;46.8666670000;4.3000000000;;f;FR;f;Europe/Paris;t;FRGQA;;t;;f;8702930;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2584,11 +2584,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3415;Marmagne-sous-Creusot;marmagne-sous-creusot;8769418;87694182;46.833421;4.360028;;f;FR;f;Europe/Paris;t;FRGQC;;t;;f;8703917;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3417;St-Léger-sur-Dheune;st-leger-sur-dheune;8769436;87694364;46.8500000000;4.6333330000;;f;FR;f;Europe/Paris;t;FRGQK;;t;;f;8704600;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3419;Cheilly-lès-Maranges;cheilly-les-maranges;8769439;87694398;46.9000000000;4.6666670000;;f;FR;f;Europe/Paris;t;FRGQN;;t;;f;8703084;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3422;Sincey-lès-Rouvray;sincey-les-rouvray;8769443;87694430;47.4333330000;4.1333330000;;f;FR;f;Europe/Paris;t;FRGQR;;t;;f;8704501;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3422;Sincey-lès-Rouvray;sincey-les-rouvray;8769443;87694430;47.4333330000;4.1333330000;;f;FR;f;Europe/Paris;t;FRGQR;;t;;f;8704501;f;;f;;f;;f;;;f;;f;8700419;f;;f;f;;;;;;;;;;;;;;;;;;
 3423;La Roche-en-Brenil;la-roche-en-brenil;8769444;87694448;47.3666670000;4.1666670000;;f;FR;f;Europe/Paris;t;FRGQS;;t;;f;8703603;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3424;Molphey;molphey;8769445;87694455;47.3500000000;4.2166670000;;f;FR;f;Europe/Paris;t;FRGQT;;t;;f;8704005;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3425;St-Didier;st-didier;8769446;87694463;47.3333330000;4.1833330000;;f;FR;f;Europe/Paris;t;FRGQU;;t;;f;8704547;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3426;Saulieu;saulieu;8769447;87694471;47.2666670000;4.2333330000;;f;FR;f;Europe/Paris;t;FRGQV;;t;;f;8704457;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3426;Saulieu;saulieu;8769447;87694471;47.2666670000;4.2333330000;;f;FR;f;Europe/Paris;t;FRGQV;;t;;f;8704457;f;;f;;f;;f;;;f;;f;8700422;f;;f;f;;;;;;;;;;;;;;;;;;
 3427;St-Martin-de-la-Mer;st-martin-de-la-mer;8769448;87694489;47.2333330000;4.2333330000;;f;FR;f;Europe/Paris;t;FRGQW;;t;;f;8704614;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3428;Liernais;liernais;8769449;87694497;47.2000000000;4.2833330000;;f;FR;f;Europe/Paris;t;FRGQX;;t;;f;8703801;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3429;Brazey-en-Morvan;brazey-en-morvan;8769451;87694513;47.17162034221716;4.286899566650391;;f;FR;f;Europe/Paris;t;FRGQY;;t;;f;8702905;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2596,58 +2596,58 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3431;Barnay;barnay;8769453;87694539;47.0833330000;4.3333330000;;f;FR;f;Europe/Paris;t;FRGRA;;t;;f;8702774;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3432;Cordesse—Igornay;cordesse-igornay;8769454;87694547;47.048866;4.349394;;f;FR;f;Europe/Paris;t;FRGRB;;t;;f;8703153;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3433;L’Orme—St-Pantaléon;lorme-st-pantaleon;8769456;87694562;46.957715;4.328755;;f;FR;f;Europe/Paris;t;FRGRC;;t;;f;8703536;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3434;Autun;autun;8769457;87694570;46.95488705827472;4.29289698600769;;f;FR;f;Europe/Paris;t;FRGRD;;t;;f;8702729;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;オータン;;;;Отён;;;
+3434;Autun;autun;8769457;87694570;46.95488705827472;4.29289698600769;;f;FR;f;Europe/Paris;t;FRGRD;;t;;f;8702729;f;;f;;f;;f;;;f;;f;8700423;f;;f;t;;;;;;;;;;;オータン;;;;Отён;;;
 3435;Brion—Laizy;brion-laizy;8769459;87694596;46.908877;4.206996;;f;FR;f;Europe/Paris;t;FRGRE;;t;;f;8702925;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3436;Blanzy;blanzy;8769461;87694612;46.7000000000;4.3833330000;;f;FR;f;Europe/Paris;t;FRGRG;;t;;f;8702844;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3437;Montceau-les-Mines;montceau-les-mines;8769462;87694620;46.67065769966562;4.3610358238220215;;f;FR;f;Europe/Paris;t;FRGRH;;t;;f;8704027;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Монке-ле-Мине;;;
+3437;Montceau-les-Mines;montceau-les-mines;8769462;87694620;46.67065769966562;4.3610358238220215;;f;FR;f;Europe/Paris;t;FRGRH;;t;;f;8704027;f;;f;;f;;f;;;f;;f;8700384;f;;f;f;;;;;;;;;;;;;;;Монке-ле-Мине;;;
 3438;Galuzot;galuzot;8769463;87694638;46.642032;4.33004;;f;FR;f;Europe/Paris;t;FRGRI;;t;;f;8703367;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3439;Ciry-le-Noble;ciry-le-noble;8769464;87694646;46.6000000000;4.3000000000;;f;FR;f;Europe/Paris;t;FRGRJ;;t;;f;8703108;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3440;Génelard;genelard;8769465;87694653;46.5833330000;4.2333330000;;f;FR;f;Europe/Paris;t;FRGRK;;t;;f;8703379;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3442;Digoin;digoin;8769469;87694695;46.485185449463906;3.9876937866210938;;f;FR;f;Europe/Paris;t;FRGRN;;t;;f;8703214;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ディゴワン;;;;Дигуэн;;;迪古安
+3442;Digoin;digoin;8769469;87694695;46.485185449463906;3.9876937866210938;;f;FR;f;Europe/Paris;t;FRGRN;;t;;f;8703214;f;;f;;f;;f;;;f;;f;8700386;f;;f;f;;;;;;;;;;;ディゴワン;;;;Дигуэн;;;迪古安
 3443;St-Julien—Changy;st-julien-changy;8769471;87694711;46.394685;4.25383;;f;FR;f;Europe/Paris;t;FRGRP;;t;;f;8703515;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3444;Dardilly Le Jubin;dardilly-le-jubin;8772144;87721449;45.815321;4.761208;26825;f;FR;f;Europe/Paris;t;FRGRQ;DDJ;t;;f;8703199;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3445;Chauffailles;chauffailles;8769477;87694778;46.20745791526318;4.3454307317733765;;f;FR;f;Europe/Paris;t;FRGRR;;t;;f;8703074;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3445;Chauffailles;chauffailles;8769477;87694778;46.20745791526318;4.3454307317733765;;f;FR;f;Europe/Paris;t;FRGRR;;t;;f;8703074;f;;f;;f;;f;;;f;;f;8700436;f;;f;f;;;;;;;;;;;;;;;;;;
 3448;Marcigny—St-Martin-du-Lac;marcigny-st-martin-du-lac;8769482;87694828;46.260692;4.042269;;f;FR;f;Europe/Paris;t;FRGRU;;t;;f;8704992;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3449;St-Agnan;st-agnan;8769485;87694851;46.5000000000;3.8666670000;;f;FR;f;Europe/Paris;t;FRGRV;;t;;f;8702620;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3450;Gilly-sur-Loire;gilly-sur-loire;8769486;87694869;46.5333330000;3.7833330000;;f;FR;f;Europe/Paris;t;FRGRW;;t;;f;8703403;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3450;Gilly-sur-Loire;gilly-sur-loire;8769486;87694869;46.5333330000;3.7833330000;;f;FR;f;Europe/Paris;t;FRGRW;;t;;f;8703403;f;;f;;f;;f;;;f;;f;8700387;f;;f;f;;;;;;;;;;;;;;;;;;
 3451;Charolles;charolles;8769488;87694885;46.4333330000;4.2833330000;;f;FR;f;Europe/Paris;t;FRGRX;;t;;f;8703049;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;シャロル;;;;Шароль;;;沙罗勒
 3452;Gray;gray;8718557;87185579;47.4500000000;5.5833330000;;f;FR;f;Europe/Paris;t;FRGRY;;t;;f;8701218;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3454;Briare;briare;8769608;87696088;47.64642437575518;2.7336645126342773;;f;FR;f;Europe/Paris;t;FRGSC;BEW;t;;f;8702920;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3456;Cosne-sur-Loire;cosne-sur-loire;8769614;87696146;47.41513700627;2.931804656982422;;f;FR;f;Europe/Paris;t;FRGSH;COS;t;;f;8703161;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3454;Briare;briare;8769608;87696088;47.64642437575518;2.7336645126342773;;f;FR;f;Europe/Paris;t;FRGSC;BEW;t;;f;8702920;f;;f;;f;;f;;;f;;f;8700484;f;;f;f;;;;;;;;;;;;;;;;;;
+3456;Cosne-sur-Loire;cosne-sur-loire;8769614;87696146;47.41513700627;2.931804656982422;;f;FR;f;Europe/Paris;t;FRGSH;COS;t;;f;8703161;f;;f;;f;;f;;;f;;f;8700214;f;;f;f;;;;;;;;;;;;;;;;;;
 3457;Tracy—Sancerre;tracy-sancerre;8769616;87696161;47.337707;2.88035;;f;FR;f;Europe/Paris;t;FRGSI;TAY;t;;f;8704738;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3458;Pouilly-sur-Loire;pouilly-sur-loire;8769617;87696179;47.28212585456007;2.966029644012451;;f;FR;f;Europe/Paris;t;FRGSJ;PYL;t;;f;8704302;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;プイィ＝シュル＝ロワール;;;;;;;卢瓦尔河畔普伊
+3458;Pouilly-sur-Loire;pouilly-sur-loire;8769617;87696179;47.28212585456007;2.966029644012451;;f;FR;f;Europe/Paris;t;FRGSJ;PYL;t;;f;8704302;f;;f;;f;;f;;;f;;f;8700586;f;;f;f;;;;;;;;;;;プイィ＝シュル＝ロワール;;;;;;;卢瓦尔河畔普伊
 3459;Mesves—Bulcy;mesves-bulcy;8769618;87696187;47.242125;3.006675;;f;FR;f;Europe/Paris;t;FRGSK;;t;;f;8703980;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3460;La Charité-sur-Loire;la-charite-sur-loire;8769619;87696195;47.179781155783104;3.0242228507995605;;f;FR;f;Europe/Paris;t;FRGSL;LAT;t;;f;8703555;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Ля-Шарите-сюр-Луар;;;卢瓦尔河畔拉沙里泰
+3460;La Charité-sur-Loire;la-charite-sur-loire;8769619;87696195;47.179781155783104;3.0242228507995605;;f;FR;f;Europe/Paris;t;FRGSL;LAT;t;;f;8703555;f;;f;;f;;f;;;f;;f;8700215;f;;f;f;;;;;;;;;;;;;;;Ля-Шарите-сюр-Луар;;;卢瓦尔河畔拉沙里泰
 3461;Tronsanges;tronsanges;8769620;87696203;47.113067;3.054094;;f;FR;f;Europe/Paris;t;FRGSM;;t;;f;8704746;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3462;Pougues-les-Eaux;pougues-les-eaux;8769621;87696211;47.0666670000;3.1000000000;;f;FR;f;Europe/Paris;t;FRGSN;PSU;t;;f;8704301;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3463;Fourchambault;fourchambault;8769622;87696229;47.01888668067651;3.087222576141357;;f;FR;f;Europe/Paris;t;FRGSO;FLT;t;;f;8703343;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3462;Pougues-les-Eaux;pougues-les-eaux;8769621;87696211;47.0666670000;3.1000000000;;f;FR;f;Europe/Paris;t;FRGSN;PSU;t;;f;8704301;f;;f;;f;;f;;;f;;f;8700485;f;;f;f;;;;;;;;;;;;;;;;;;
+3463;Fourchambault;fourchambault;8769622;87696229;47.01888668067651;3.087222576141357;;f;FR;f;Europe/Paris;t;FRGSO;FLT;t;;f;8703343;f;;f;;f;;f;;;f;;f;8700497;f;;f;f;;;;;;;;;;;;;;;;;;
 3464;Dardilly Les Mouilles;dardilly-les-mouilles;8772148;87721480;45.797055;4.759959;26825;f;FR;f;Europe/Paris;t;FRGSP;DDY;t;;f;8703200;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3465;St-Pierre-le-Moutier;st-pierre-le-moutier;8769629;87696294;46.79322873467295;3.1117379665374756;;f;FR;f;Europe/Paris;t;FRGSR;SPM;t;;f;8704641;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3465;St-Pierre-le-Moutier;st-pierre-le-moutier;8769629;87696294;46.79322873467295;3.1117379665374756;;f;FR;f;Europe/Paris;t;FRGSR;SPM;t;;f;8704641;f;;f;;f;;f;;;f;;f;8700135;f;;f;f;;;;;;;;;;;;;;;;;;
 3466;Chantenay-St-Imbert;chantenay-st-imbert;8769630;87696302;46.7333330000;3.1833330000;;f;FR;f;Europe/Paris;t;FRGSS;;t;;f;8703039;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3467;Villeneuve-sur-Allier;villeneuve-sur-allier;8769631;87696310;46.659121;3.246984;;f;FR;f;Europe/Paris;t;FRGST;;t;;f;8704868;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3468;Bessay;bessay;8769633;87696336;46.4333330000;3.3666670000;10694;f;FR;f;Europe/Paris;t;FRGSU;BSS;t;;f;8702823;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3470;Varennes-sur-Allier;varennes-sur-allier;8769635;87696351;46.31513;3.394326;;f;FR;f;Europe/Paris;t;FRGSW;VAA;t;;f;8704777;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3470;Varennes-sur-Allier;varennes-sur-allier;8769635;87696351;46.31513;3.394326;;f;FR;f;Europe/Paris;t;FRGSW;VAA;t;;f;8704777;f;;f;;f;;f;;;f;;f;8700218;f;;f;f;;;;;;;;;;;;;;;;;;
 3472;Billy—Marcenat;billy-marcenat;8769637;87696377;46.23551680166985;3.426532745361328;;f;FR;f;Europe/Paris;t;FRGSY;;t;;f;8702840;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3473;Montbeugny;montbeugny;8769640;87696401;46.5333330000;3.4833330000;;f;FR;f;Europe/Paris;t;FRGTA;;t;;f;8704022;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3474;Thiel-sur-Acolin;thiel-sur-acolin;8769641;87696419;46.525451;3.57918;;f;FR;f;Europe/Paris;t;FRGTB;;t;;f;8704711;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3475;Dompierre—Sept-Fons;dompierre-sept-fons;8769642;87696427;46.526341;3.674961;;f;FR;f;Europe/Paris;t;FRGTC;;t;;f;8703233;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3475;Dompierre—Sept-Fons;dompierre-sept-fons;8769642;87696427;46.526341;3.674961;;f;FR;f;Europe/Paris;t;FRGTC;;t;;f;8703233;f;;f;;f;;f;;;f;;f;8700388;f;;f;f;;;;;;;;;;;;;;;;;;
 3476;Diou (Allier);diou-allier;8769643;87696435;46.527267;3.749373;;f;FR;f;Europe/Paris;t;FRGTD;;t;;f;8703218;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3477;Imphy;imphy;8769645;87696450;46.9333330000;3.2500000000;;f;FR;f;Europe/Paris;t;FRGTE;;t;;f;8703480;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3477;Imphy;imphy;8769645;87696450;46.9333330000;3.2500000000;;f;FR;f;Europe/Paris;t;FRGTE;;t;;f;8703480;f;;f;;f;;f;;;f;;f;8700396;f;;f;f;;;;;;;;;;;;;;;;;;
 3478;Béard;beard;8769646;87696468;46.8666670000;3.3333330000;;f;FR;f;Europe/Paris;t;FRGTF;;t;;f;8702786;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3479;Sougy;sougy;8769647;87696476;46.849108;3.390227;;f;FR;f;Europe/Paris;t;FRGTG;;t;;f;8704516;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3480;Decize;decize;8769648;87696484;46.837400025761106;3.4673774242401123;;f;FR;f;Europe/Paris;t;FRGTH;DZE;t;;f;8703205;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Десиз;;;代西兹
-3481;Cercy-la-Tour;cercy-la-tour;8769649;87696492;46.85790208077076;3.6450952291488643;;f;FR;f;Europe/Paris;t;FRGTI;;t;;f;8700170;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3480;Decize;decize;8769648;87696484;46.837400025761106;3.4673774242401123;;f;FR;f;Europe/Paris;t;FRGTH;DZE;t;;f;8703205;f;;f;;f;;f;;;f;;f;8700395;f;;f;f;;;;;;;;;;;;;;;Десиз;;;代西兹
+3481;Cercy-la-Tour;cercy-la-tour;8769649;87696492;46.85790208077076;3.6450952291488643;;f;FR;f;Europe/Paris;t;FRGTI;;t;;f;8700170;f;;f;;f;;f;;;f;;f;8700394;f;;f;f;;;;;;;;;;;;;;;;;;
 3482;Fours;fours;8769651;87696518;46.8166670000;3.7166670000;;f;FR;f;Europe/Paris;t;FRGTJ;;t;;f;8703345;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3483;Rémilly—St-Honoré-les-Bains;remilly-st-honore-les-bains;8769652;87696526;46.8166670000;3.8166670000;;f;FR;f;Europe/Paris;t;FRGTK;;t;;f;8704354;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3484;Luzy;luzy;8769653;87696534;46.79408078480591;3.9693421125411987;;f;FR;f;Europe/Paris;t;FRGTL;;t;;f;8703870;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3483;Rémilly—St-Honoré-les-Bains;remilly-st-honore-les-bains;8769652;87696526;46.8166670000;3.8166670000;;f;FR;f;Europe/Paris;t;FRGTK;;t;;f;8704354;f;;f;;f;;f;;;f;;f;8700393;f;;f;f;;;;;;;;;;;;;;;;;;
+3484;Luzy;luzy;8769653;87696534;46.79408078480591;3.9693421125411987;;f;FR;f;Europe/Paris;t;FRGTL;;t;;f;8703870;f;;f;;f;;f;;;f;;f;8700392;f;;f;f;;;;;;;;;;;;;;;;;;
 3485;Millay;millay;8769654;;46.8333330000;3.9833330000;;f;FR;f;Europe/Paris;f;FRGTM;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3486;Corbigny;corbigny;8769661;87696617;47.25476684472721;3.677372932434082;;f;FR;f;Europe/Paris;t;FRGTP;;t;;f;8703151;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3487;Dirol;dirol;8769662;87696625;47.3166670000;3.6500000000;;f;FR;f;Europe/Paris;t;FRGTQ;;t;;f;8703220;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3488;Flez—Cuzy—Tannay;flez-cuzy-tannay;8769663;87696633;47.363057;3.614985;;f;FR;f;Europe/Paris;t;FRGTR;;t;;f;8703322;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3486;Corbigny;corbigny;8769661;87696617;47.25476684472721;3.677372932434082;;f;FR;f;Europe/Paris;t;FRGTP;;t;;f;8703151;f;;f;;f;;f;;;f;;f;8700415;f;;f;f;;;;;;;;;;;;;;;;;;
+3487;Dirol;dirol;8769662;87696625;47.3166670000;3.6500000000;;f;FR;f;Europe/Paris;t;FRGTQ;;t;;f;8703220;f;;f;;f;;f;;;f;;f;8700414;f;;f;f;;;;;;;;;;;;;;;;;;
+3488;Flez—Cuzy—Tannay;flez-cuzy-tannay;8769663;87696633;47.363057;3.614985;;f;FR;f;Europe/Paris;t;FRGTR;;t;;f;8703322;f;;f;;f;;f;;;f;;f;8700413;f;;f;f;;;;;;;;;;;;;;;;;;
 3489;Asnois;asnois;8769664;87696641;47.4000000000;3.6000000000;;f;FR;f;Europe/Paris;t;FRGTS;;t;;f;8702698;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3490;Clamecy;clamecy;8769680;87696807;47.466690449746174;3.5207748413085938;;f;FR;f;Europe/Paris;t;FRGTX;;t;;f;8703115;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3491;Coulanges-sur-Yonne;coulanges-sur-yonne;8769683;87696831;47.5166670000;3.5333330000;;f;FR;f;Europe/Paris;t;FRGTZ;;t;;f;8703167;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3492;Châtel-Censoir;chatel-censoir;8769685;87696856;47.5166670000;3.6333330000;;f;FR;f;Europe/Paris;t;FRGUB;;t;;f;8703064;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3491;Coulanges-sur-Yonne;coulanges-sur-yonne;8769683;87696831;47.5166670000;3.5333330000;;f;FR;f;Europe/Paris;t;FRGTZ;;t;;f;8703167;f;;f;;f;;f;;;f;;f;8700412;f;;f;f;;;;;;;;;;;;;;;;;;
+3492;Châtel-Censoir;chatel-censoir;8769685;87696856;47.5166670000;3.6333330000;;f;FR;f;Europe/Paris;t;FRGUB;;t;;f;8703064;f;;f;;f;;f;;;f;;f;8700411;f;;f;f;;;;;;;;;;;;;;;;;;
 3493;La Chapelle-sous-Dun;la-chapelle-sous-dun;8769900;87699009;46.2666670000;4.3000000000;;f;FR;f;Europe/Paris;t;FRGUC;;t;;f;8703553;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3494;Malbuisson;malbuisson;8769985;87699850;46.8000000000;6.3000000000;;f;FR;f;Europe/Paris;t;FRGUD;;t;;f;8702538;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3496;Rully;rully;8771202;87712026;46.8666670000;4.7500000000;;f;FR;f;Europe/Paris;t;FRGUP;;t;;f;8701903;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2675,24 +2675,24 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3522;Verrey;verrey;8771308;87713081;47.438818;4.669572;;f;FR;f;Europe/Paris;t;FRGVZ;;t;;f;8702166;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3523;Thenissey;thenissey;8771309;87713099;47.49474;4.622244;;f;FR;f;Europe/Paris;t;FRGWA;;t;;f;8702102;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3524;Urdos Douane;urdos-douane;8746527;87465278;42.865628;-0.554391;;f;FR;f;Europe/Paris;t;FRGWB;;t;;f;8706311;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3525;Les Laumes Alésia;les-laumes-alesia;8771311;87713115;47.543309;4.462613;;f;FR;f;Europe/Paris;t;FRGWC;LLA;t;;f;8701460;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3525;Les Laumes Alésia;les-laumes-alesia;8771311;87713115;47.543309;4.462613;;f;FR;f;Europe/Paris;t;FRGWC;LLA;t;;f;8701460;f;;f;;f;;f;;;f;;f;8700352;f;;f;f;;;;;;;;;;;;;;;;;;
 3526;Sansanet;sansanet;8746529;;42.798435486182775;-0.5540692806243896;;f;FR;f;Europe/Paris;t;FRGWD;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3527;Montbard;montbard;8771313;87713131;47.618560012030684;4.336230754852295;;f;FR;f;Europe/Paris;t;FRGWE;MBA;t;;f;8701558;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-3528;Nuits-sous-Ravières;nuits-sous-ravieres;8771315;87713156;47.729286;4.21132;;f;FR;f;Europe/Paris;t;FRGWF;;t;;f;8701690;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3532;Tonnerre;tonnerre;8771319;87713198;47.859549;3.973672;;f;FR;f;Europe/Paris;t;FRGWJ;;t;;f;8702118;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3527;Montbard;montbard;8771313;87713131;47.618560012030684;4.336230754852295;;f;FR;f;Europe/Paris;t;FRGWE;MBA;t;;f;8701558;f;;f;;f;;f;;;f;;f;8700353;f;;f;t;;;;;;;;;;;;;;;;;;
+3528;Nuits-sous-Ravières;nuits-sous-ravieres;8771315;87713156;47.729286;4.21132;;f;FR;f;Europe/Paris;t;FRGWF;;t;;f;8701690;f;;f;;f;;f;;;f;;f;8700355;f;;f;f;;;;;;;;;;;;;;;;;;
+3532;Tonnerre;tonnerre;8771319;87713198;47.859549;3.973672;;f;FR;f;Europe/Paris;t;FRGWJ;;t;;f;8702118;f;;f;;f;;f;;;f;;f;8700357;f;;f;f;;;;;;;;;;;;;;;;;;
 3533;Flogny;flogny;8771320;;47.9500000000;3.8666670000;;f;FR;f;Europe/Paris;t;FRGWK;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3534;Peyranère;peyranere;8746530;;42.803855304268154;-0.5481576919555664;;f;FR;f;Europe/Paris;t;FRGWL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3535;Somport Station;somport-station;8746531;87465310;42.795287;-0.547892;;f;FR;f;Europe/Paris;t;FRGWM;;t;;f;8706314;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3536;Sémur-en-Auxois;semur-en-auxois;8771326;87713263;47.4833330000;4.3333330000;;f;FR;f;Europe/Paris;t;FRGWN;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3537;St-Amandin;st-amandin;8711020;87110205;45.3666670000;2.7000000000;;f;FR;f;Europe/Paris;t;FRGWO;;t;;f;8704526;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3538;Genlis;genlis;8771331;87713313;47.24426503495377;5.223913192749023;;f;FR;f;Europe/Paris;t;FRGWP;GLS;t;;f;8700154;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3538;Genlis;genlis;8771331;87713313;47.24426503495377;5.223913192749023;;f;FR;f;Europe/Paris;t;FRGWP;GLS;t;;f;8700154;f;;f;;f;;f;;;f;;f;8700319;f;;f;f;;;;;;;;;;;;;;;;;;
 3539;Collonges (Côte d’Or);collonges-cote-dor;8771332;87713321;47.2166670000;5.2666670000;;f;FR;f;Europe/Paris;t;FRGWQ;;t;;f;8702600;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3540;Villers-les-Pots;villers-les-pots;8771333;87713339;47.206636;5.347853;;f;FR;f;Europe/Paris;t;FRGWR;;t;;f;8702601;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3541;Auxonne;auxonne;8771334;87713347;47.19266160324558;5.37730872631073;;f;FR;f;Europe/Paris;t;FRGWS;AXO;t;;f;8700115;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Осон;;;奥克松
+3541;Auxonne;auxonne;8771334;87713347;47.19266160324558;5.37730872631073;;f;FR;f;Europe/Paris;t;FRGWS;AXO;t;;f;8700115;f;;f;;f;;f;;;f;;f;8700209;f;;f;f;;;;;;;;;;;;;;;Осон;;;奥克松
 3542;Villers-Rotin;villers-rotin;8771335;;47.157545645029444;5.406888127326964;;f;FR;f;Europe/Paris;t;FRGWT;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3543;Gevrey-Chambertin;gevrey-chambertin;8771350;87713503;47.2333330000;4.9500000000;;f;FR;f;Europe/Paris;t;FRGXA;;t;;f;8700346;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ジュヴレ＝シャンベルタン;;;;Жевре-Шамбертен;;;热夫雷尚贝尔坦
 3544;Vougeot;vougeot;8771351;87713511;47.175398;4.971547;;f;FR;f;Europe/Paris;t;FRGXB;;t;;f;8702206;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3545;Nuits-St-Georges;nuits-st-georges;8771352;87713529;47.1305930853082;4.956196546554565;;f;FR;f;Europe/Paris;t;FRGXC;NUI;t;;f;8701688;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ニュイ＝サン＝ジョルジュ;;;;Нюи-Сен-Жорж;;;尼伊特圣若尔热
+3545;Nuits-St-Georges;nuits-st-georges;8771352;87713529;47.1305930853082;4.956196546554565;;f;FR;f;Europe/Paris;t;FRGXC;NUI;t;;f;8701688;f;;f;;f;;f;;;f;;f;8700351;f;;f;f;;;;;;;;;;;ニュイ＝サン＝ジョルジュ;;;;Нюи-Сен-Жорж;;;尼伊特圣若尔热
 3546;Corgoloin;corgoloin;8771353;87713537;47.0833330000;4.9166670000;;f;FR;f;Europe/Paris;t;FRGXD;;t;;f;8700926;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3547;Meursault;meursault;8771356;87713560;46.9833330000;4.7666670000;;f;FR;f;Europe/Paris;t;FRGXE;;t;;f;8701509;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3548;Fontaines—Mercurey;fontaines-mercurey;8771358;87713586;46.851364;4.775024;;f;FR;f;Europe/Paris;t;FRGXF;;t;;f;8701146;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2703,13 +2703,13 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3553;Pagny;pagny;8771366;87713669;47.0500000000;5.1833330000;;f;FR;f;Europe/Paris;t;FRGXK;;t;;f;8702559;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3554;Seurre;seurre;8771367;87713677;47.0000000000;5.1500000000;;f;FR;f;Europe/Paris;t;FRGXL;;t;;f;8702583;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3557;Mervans;mervans;8771370;87713701;46.8000000000;5.1833330000;;f;FR;f;Europe/Paris;t;FRGXO;;t;;f;8702543;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3560;Louhans;louhans;8771373;87713735;46.630884430477884;5.2174705266952515;;f;FR;f;Europe/Paris;t;FRGXR;;t;;f;8702531;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ルーアン;;;;;;;盧昂
+3560;Louhans;louhans;8771373;87713735;46.630884430477884;5.2174705266952515;;f;FR;f;Europe/Paris;t;FRGXR;;t;;f;8702531;f;;f;;f;;f;;;f;;f;8700156;f;;f;f;;;;;;;;;;;ルーアン;;;;;;;盧昂
 3562;Frontenaud;frontenaud;8771375;;46.5500000000;5.3000000000;;f;FR;f;Europe/Paris;t;FRGXT;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3563;Dommartin-les-Cuiseaux;dommartin-les-cuiseaux;8771376;;46.5000000000;5.3000000000;;f;FR;f;Europe/Paris;t;FRGXU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3564;Ruffey;ruffey;8771382;87713826;47.370587;5.079358;;f;FR;f;Europe/Paris;t;FRGXY;;t;;f;8701911;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3565;St-Julien—Clénay;st-julien-clenay;8771383;87713834;47.406016;5.128184;;f;FR;f;Europe/Paris;t;FRGXZ;;t;;f;8701981;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3566;Gemeaux;gemeaux;8771384;87713842;47.4833330000;5.1333330000;;f;FR;f;Europe/Paris;t;FRGYA;;t;;f;8701199;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3567;Is-sur-Tille;is-sur-tille;8771385;87713859;47.5204177883841;5.129585266113281;;f;FR;f;Europe/Paris;t;FRGYB;IST;t;;f;8700469;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3567;Is-sur-Tille;is-sur-tille;8771385;87713859;47.5204177883841;5.129585266113281;;f;FR;f;Europe/Paris;t;FRGYB;IST;t;;f;8700469;f;;f;;f;;f;;;f;;f;8700261;f;;f;f;;;;;;;;;;;;;;;;;;
 3571;Champsigny;champsigny;8771392;;;;;f;FR;f;Europe/Paris;f;FRGYF;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3572;Change;change;8771393;87713933;46.9333330000;4.6333330000;;f;FR;f;Europe/Paris;t;FRGYG;;t;;f;8703036;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3573;Changey;changey;;;47.9333330000;5.3833330000;;f;FR;f;Europe/Paris;f;FRGYH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2727,9 +2727,9 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3590;Champagnole;champagnole;8771532;87715326;46.74934094220289;5.910113453865051;;f;FR;f;Europe/Paris;t;FRGYZ;;t;;f;8703028;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;尚帕尼奥勒
 3592;La Chaux-des-Crotenay;la-chaux-des-crotenay;8771538;87715383;46.654518;5.943784;;f;FR;f;Europe/Paris;t;FRGZC;;t;;f;8703558;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3593;La Chaumusse Fort du Plasne;la-chaumusse-fort-du-plasne;8771539;87715391;46.604988;5.961484;;f;FR;f;Europe/Paris;t;FRGZD;;t;;f;8703557;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3594;St-Laurent-en-Grandvaux;st-laurent-en-grandvaux;8771541;87715417;46.5833330000;5.9500000000;;f;FR;f;Europe/Paris;t;FRGZE;;t;;f;8704599;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3594;St-Laurent-en-Grandvaux;st-laurent-en-grandvaux;8771541;87715417;46.5833330000;5.9500000000;;f;FR;f;Europe/Paris;t;FRGZE;;t;;f;8704599;f;;f;;f;;f;;;f;;f;8700323;f;;f;f;;;;;;;;;;;;;;;;;;
 3595;Morbier;morbier;8771543;87715433;46.5333330000;6.0166670000;;f;FR;f;Europe/Paris;t;FRGZF;;t;;f;8704058;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3596;Morez;morez;8771544;87715441;46.52621355751299;6.023597717285156;;f;FR;f;Europe/Paris;t;FRGZG;MRZ;t;;f;8702463;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3596;Morez;morez;8771544;87715441;46.52621355751299;6.023597717285156;;f;FR;f;Europe/Paris;t;FRGZG;MRZ;t;;f;8702463;f;;f;;f;;f;;;f;;f;8700324;f;;f;f;;;;;;;;;;;;;;;;;;
 3597;Les Hôpitaux-Neufs;les-hopitaux-neufs;8771551;87715516;46.778488;6.373073;;f;FR;f;Europe/Paris;t;FRGZH;;t;;f;8701278;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3598;Jougne;jougne;8771552;87715524;46.7666670000;6.4000000000;;f;FR;f;Europe/Paris;t;FRGZI;;t;;f;8701323;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3600;Vallorbe Frontière;vallorbe-frontiere;8771591;87715912;;;6367;f;CH;f;Europe/Zurich;f;FRGZL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2738,22 +2738,22 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3603;Torpes—Boussières;torpes-boussieres;8771811;87718114;47.16373;5.889121;;f;FR;f;Europe/Paris;t;FRGZO;;t;;f;8702585;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3604;Byans;byans;8771812;87718122;47.1166670000;5.8666670000;;f;FR;f;Europe/Paris;t;FRGZP;;t;;f;8702485;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3605;Liesle;liesle;8771813;87718130;47.0500000000;5.8166670000;;f;FR;f;Europe/Paris;t;FRGZQ;;t;;f;8702529;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3606;Arbois;arbois;8771815;87718155;46.91247245408317;5.764775276184082;;f;FR;f;Europe/Paris;t;FRGZR;;t;;f;8702470;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;阿尔布瓦
-3608;Poligny;poligny;8771818;87718189;46.84434621182232;5.700096487998962;;f;FR;f;Europe/Paris;t;FRGZT;;t;;f;8702562;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3606;Arbois;arbois;8771815;87718155;46.91247245408317;5.764775276184082;;f;FR;f;Europe/Paris;t;FRGZR;;t;;f;8702470;f;;f;;f;;f;;;f;;f;8700495;f;;f;f;;;;;;;;;;;;;;;;;;阿尔布瓦
+3608;Poligny;poligny;8771818;87718189;46.84434621182232;5.700096487998962;;f;FR;f;Europe/Paris;t;FRGZT;;t;;f;8702562;f;;f;;f;;f;;;f;;f;8700492;f;;f;f;;;;;;;;;;;;;;;;;;
 3609;St-Lothain;st-lothain;8771819;87718197;46.8166670000;5.6333330000;;f;FR;f;Europe/Paris;t;FRGZU;;t;;f;8702533;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3611;Domblans—Voiteur;domblans-voiteur;8771821;87718213;46.762838;5.597888;;f;FR;f;Europe/Paris;t;FRGZW;;t;;f;8702503;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3613;Cousance;cousance;8771827;87718270;46.5333330000;5.4000000000;;f;FR;f;Europe/Paris;t;FRGZZ;;t;;f;8702497;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3613;Cousance;cousance;8771827;87718270;46.5333330000;5.4000000000;;f;FR;f;Europe/Paris;t;FRGZZ;;t;;f;8702497;f;;f;;f;;f;;;f;;f;8700508;f;;f;f;;;;;;;;;;;;;;;;;;
 3615;Dannemarie—Velesmes;dannemarie-velesmes;8771831;87718312;47.203723;5.873488;;f;FR;f;Europe/Paris;t;FRHAB;;t;;f;8702610;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3616;St-Vit;st-vit;8771832;87718320;47.18354389663679;5.808924436569214;;f;FR;f;Europe/Paris;t;FRHAC;;t;;f;8702609;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3616;St-Vit;st-vit;8771832;87718320;47.18354389663679;5.808924436569214;;f;FR;f;Europe/Paris;t;FRHAC;;t;;f;8702609;f;;f;;f;;f;;;f;;f;8700491;f;;f;f;;;;;;;;;;;;;;;;;;
 3617;Ranchot;ranchot;8771833;87718338;47.152500605109616;5.724649429321289;;f;FR;f;Europe/Paris;t;FRHAD;;t;;f;8702608;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3619;Orchamps;orchamps;8771836;87718361;47.150107417974155;5.659192800521851;;f;FR;f;Europe/Paris;t;FRHAF;;t;;f;8702606;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3619;Orchamps;orchamps;8771836;87718361;47.150107417974155;5.659192800521851;;f;FR;f;Europe/Paris;t;FRHAF;;t;;f;8702606;f;;f;;f;;f;;;f;;f;8700489;f;;f;f;;;;;;;;;;;;;;;;;;
 3620;Haguenau;haguenau;8721305;87213058;48.8133001777345;7.782214879989623;;f;FR;f;Europe/Paris;t;FRHAG;HAG;t;;f;8700347;f;;f;;f;;f;;;f;;f;;f;;f;t;;Hagenau;;;;;;;;;アグノー;;;;Агно;;;阿盖诺
-3621;Roche-lez-Beaupré;roche-lez-beaupre;8771840;87718403;47.2833330000;6.1166670000;;f;FR;f;Europe/Paris;t;FRHAJ;;t;;f;8702574;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3622;Novillars;novillars;8771841;87718411;47.2833330000;6.1333330000;;f;FR;f;Europe/Paris;t;FRHAK;;t;;f;8702554;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3623;Deluz;deluz;8771842;87718429;47.3000000000;6.2000000000;;f;FR;f;Europe/Paris;t;FRHAL;;t;;f;8702505;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3624;Laissey;laissey;8771843;87718437;47.3000000000;6.2333330000;;f;FR;f;Europe/Paris;t;FRHAM;;t;;f;8702523;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3621;Roche-lez-Beaupré;roche-lez-beaupre;8771840;87718403;47.2833330000;6.1166670000;;f;FR;f;Europe/Paris;t;FRHAJ;;t;;f;8702574;f;;f;;f;;f;;;f;;f;8700420;f;;f;f;;;;;;;;;;;;;;;;;;
+3622;Novillars;novillars;8771841;87718411;47.2833330000;6.1333330000;;f;FR;f;Europe/Paris;t;FRHAK;;t;;f;8702554;f;;f;;f;;f;;;f;;f;8700410;f;;f;f;;;;;;;;;;;;;;;;;;
+3623;Deluz;deluz;8771842;87718429;47.3000000000;6.2000000000;;f;FR;f;Europe/Paris;t;FRHAL;;t;;f;8702505;f;;f;;f;;f;;;f;;f;8700409;f;;f;f;;;;;;;;;;;;;;;;;;
+3624;Laissey;laissey;8771843;87718437;47.3000000000;6.2333330000;;f;FR;f;Europe/Paris;t;FRHAM;;t;;f;8702523;f;;f;;f;;f;;;f;;f;8700408;f;;f;f;;;;;;;;;;;;;;;;;;
 3625;Han-sur-Nied;han-sur-nied;8719313;87193136;48.99027129751057;6.436572074890136;;f;FR;f;Europe/Paris;t;FRHAN;;t;;f;8701285;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3628;Baume-les-Dames;baume-les-dames;8771846;87718460;47.35403043119458;6.359431743621826;;f;FR;f;Europe/Paris;t;FRHAQ;;t;;f;8700286;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3628;Baume-les-Dames;baume-les-dames;8771846;87718460;47.35403043119458;6.359431743621826;;f;FR;f;Europe/Paris;t;FRHAQ;;t;;f;8700286;f;;f;;f;;f;;;f;;f;8700993;f;;f;f;;;;;;;;;;;;;;;;;;
 3630;Saône;saone;8771850;87718502;47.2333330000;6.1166670000;;f;FR;f;Europe/Paris;t;FRHAS;;t;;f;8704448;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3631;Mamirolle;mamirolle;8771851;87718510;47.2000000000;6.1666670000;;f;FR;f;Europe/Paris;t;FRHAT;;t;;f;8703896;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3632;L’Hôpital-du-Gros-Bois;lhopital-du-gros-bois;8771852;87718528;47.169106;6.213083;;f;FR;f;Europe/Paris;t;FRHAU;;t;;f;8703533;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2772,18 +2772,18 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3650;Etais;etais;8771993;87719930;47.7000000000;4.4333330000;;f;FR;f;Europe/Paris;t;FRHBX;;t;;f;8703289;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3651;Puits;puits;8771994;87719948;47.7333330000;4.4666670000;;f;FR;f;Europe/Paris;t;FRHBY;;t;;f;8704327;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3652;Lyon Vaise;lyon-vaise;8772100;87721001;45.78033431901409;4.804297685623169;4718;f;FR;f;Europe/Paris;t;FRHCD;LVI;t;;f;8701466;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
-3653;Amplepuis;amplepuis;8772103;87721035;45.97072729230144;4.326939582824707;;f;FR;f;Europe/Paris;t;FRHCE;AMP;t;;f;8702654;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3654;St-Victor—Thizy;st-victor-thizy;8772104;87721043;46.002486;4.281022;;f;FR;f;Europe/Paris;t;FRHCF;SVH;t;;f;8704664;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3653;Amplepuis;amplepuis;8772103;87721035;45.97072729230144;4.326939582824707;;f;FR;f;Europe/Paris;t;FRHCE;AMP;t;;f;8702654;f;;f;;f;;f;;;f;;f;8700438;f;;f;f;;;;;;;;;;;;;;;;;;
+3654;St-Victor—Thizy;st-victor-thizy;8772104;87721043;46.002486;4.281022;;f;FR;f;Europe/Paris;t;FRHCF;SVH;t;;f;8704664;f;;f;;f;;f;;;f;;f;8700437;f;;f;f;;;;;;;;;;;;;;;;;;
 3655;Régny;regny;8772105;87721050;45.9876218639935;4.215102195739746;;f;FR;f;Europe/Paris;t;FRHCG;RGY;t;;f;8704349;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3656;Couzon-au-Mont-d’Or;couzon-au-mont-dor;8772124;87721241;45.8333330000;4.8333330000;;f;FR;f;Europe/Paris;t;FRHCI;KMD;t;;f;8700994;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3658;Quincieux;quincieux;8772129;87721290;45.90673323808819;4.7786664962768555;;f;FR;f;Europe/Paris;t;FRHCK;QUX;t;;f;8701826;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3659;Anse;anse;8772132;87721324;45.93929907870687;4.719754457473755;;f;FR;f;Europe/Paris;t;FRHCM;ANS;t;;f;8700614;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3660;St-Georges-de-Reneins;st-georges-de-reneins;8772134;87721340;46.0666670000;4.7166670000;;f;FR;f;Europe/Paris;t;FRHCN;SDI;t;;f;8701978;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3661;Belleville-sur-Saône;belleville-sur-saone;8772135;87721357;46.11189093223572;4.729013442993164;;f;FR;f;Europe/Paris;t;FRHCO;BVL;t;;f;8702331;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Belleville sobre Saona;;;;;;;;;;;;;;
+3661;Belleville-sur-Saône;belleville-sur-saone;8772135;87721357;46.11189093223572;4.729013442993164;;f;FR;f;Europe/Paris;t;FRHCO;BVL;t;;f;8702331;f;;f;;f;;f;;;f;;f;8700348;f;;f;f;;;;Belleville sobre Saona;;;;;;;;;;;;;;
 3663;Chazay—Marcilly;chazay-marcilly;8772141;87721415;45.87296;4.725215;;f;FR;f;Europe/Paris;t;FRHCQ;CZM;t;;f;8703081;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3664;St-Romain-de-Popey;st-romain-de-popey;8772145;87721456;45.8500000000;4.5333330000;;f;FR;f;Europe/Paris;t;FRHCR;SNP;t;;f;8704426;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3665;Pontcharra—St-Forgeux;pontcharra-st-forgeux;8772146;87721464;45.871486;4.492772;;f;FR;f;Europe/Paris;t;FRHCS;PNF;t;;f;8704278;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3666;Tarare;tarare;8772147;87721472;45.889752;4.439035;;f;FR;f;Europe/Paris;t;FRHCT;TAR;t;;f;8704694;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3666;Tarare;tarare;8772147;87721472;45.889752;4.439035;;f;FR;f;Europe/Paris;t;FRHCT;TAR;t;;f;8704694;f;;f;;f;;f;;;f;;f;8700439;f;;f;f;;;;;;;;;;;;;;;;;;
 3667;Écully—La Demi-Lune;ecully-la-demi-lune;8772150;87721506;45.765692;4.779151;;f;FR;f;Europe/Paris;t;FRHCU;ECY;t;;f;8703259;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3668;Le Méridien;le-meridien;8772152;87721522;45.768829;4.748362;;f;FR;f;Europe/Paris;t;FRHCV;WER;t;;f;8703974;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3669;Charbonnières-les-Bains;charbonnieres-les-bains;8772153;87721530;45.78210388081568;4.735912084579468;4862;f;FR;t;Europe/Paris;t;FRHCW;CRB;t;;f;8703045;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2803,32 +2803,32 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3687;St-Nizier-d’Azergues;st-nizier-dazergues;8772187;87721878;46.081797;4.483181;;f;FR;f;Europe/Paris;t;FRHDR;;t;;f;8704117;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3689;Poule;poule;8772189;87721894;46.1500000000;4.4666670000;;f;FR;f;Europe/Paris;t;FRHDT;;t;;f;8704303;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3690;Bois-d’Oingt Centre;bois-doingt-centre;8740976;87409763;45.913483;4.568614;;f;FR;f;Europe/Paris;t;FRHDU;BOT;t;;f;8705511;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3691;Oullins;oullins;8772220;87722207;45.716630143364306;4.813567399978638;;f;FR;f;Europe/Paris;t;FRHDV;OUL;t;;f;8704163;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+3691;Oullins;oullins;8772220;87722207;45.716630143364306;4.813567399978638;;f;FR;f;Europe/Paris;t;FRHDV;OUL;t;;f;8704163;f;;f;;f;;f;;;f;;f;8700457;f;;f;t;;;;;;;;;;;;;;;;;;
 3692;Pierre-Bénite;pierre-benite;8772223;87722231;45.7000000000;4.8166670000;;f;FR;f;Europe/Paris;t;FRHDW;PRB;t;;f;8704216;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3694;Vernaison;vernaison;8772226;87722264;45.645551;4.813354;;f;FR;f;Europe/Paris;t;FRHDY;VNI;t;;f;8704804;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3694;Vernaison;vernaison;8772226;87722264;45.645551;4.813354;;f;FR;f;Europe/Paris;t;FRHDY;VNI;t;;f;8704804;f;;f;;f;;f;;;f;;f;8700802;f;;f;f;;;;;;;;;;;;;;;;;;
 3695;Grigny Le Sablon;grigny-le-sablon;8772229;87722298;45.606888;4.796023;;f;FR;f;Europe/Paris;t;FRHEB;LSB;t;;f;8703730;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3698;Feyzin;feyzin;8772253;87722538;45.6666670000;4.8500000000;;f;FR;f;Europe/Paris;t;FRHEG;FEY;t;;f;8701126;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3699;Sérézin;serezin;8772254;87722546;45.6333330000;4.8333330000;;f;FR;f;Europe/Paris;t;FRHEH;SZN;t;;f;8702034;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3700;Ternay;ternay;8772255;87722553;45.602906;4.814739;;f;FR;f;Europe/Paris;t;FRHEI;TNN;t;;f;8702137;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3701;Estressin;estressin;8772257;87722579;45.540135077108445;4.868268370628357;;f;FR;f;Europe/Paris;t;FRHEJ;ESN;t;;f;8701081;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3701;Estressin;estressin;8772257;87722579;45.540135077108445;4.868268370628357;;f;FR;f;Europe/Paris;t;FRHEJ;ESN;t;;f;8701081;f;;f;;f;;f;;;f;;f;8700806;f;;f;f;;;;;;;;;;;;;;;;;;
 3702;St-Clair Les Roches;st-clair-les-roches;8772265;87722652;45.450251;4.76982;;f;FR;f;Europe/Paris;t;FRHEL;SKR;t;;f;8701992;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3703;Le Péage-de-Roussillon;le-peage-de-roussillon;8772267;87722678;45.37176004829549;4.795317649841309;;f;FR;f;Europe/Paris;t;FRHEN;PGR;t;;f;8701753;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3703;Le Péage-de-Roussillon;le-peage-de-roussillon;8772267;87722678;45.37176004829549;4.795317649841309;;f;FR;f;Europe/Paris;t;FRHEN;PGR;t;;f;8701753;f;;f;;f;;f;;;f;;f;8700245;f;;f;f;;;;;;;;;;;;;;;;;;
 3704;Brignais;brignais;8772272;87722728;45.6666670000;4.7500000000;;f;FR;f;Europe/Paris;t;FRHEP;BGN;t;;f;8702923;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3705;Vénissieux;venissieux;8772332;87723320;45.705617;4.888064;;f;FR;f;Europe/Paris;t;FRHER;VSX;t;;f;8700380;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ヴェニシュー;;;;Венисьё;;;維尼西厄
 3706;Hesdigneul;hesdigneul;8731710;87317107;50.6609475;1.6669967;;f;FR;f;Europe/Paris;t;FRHES;;t;;f;8701283;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3707;St-Priest;st-priest;8772335;87723353;45.68664330350297;4.934298992156982;;f;FR;f;Europe/Paris;t;FRHET;SPR;t;;f;8702568;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3709;St-Quentin-Fallavier;st-quentin-fallavier;8772338;87723387;45.63810730537974;5.099973678588867;;f;FR;f;Europe/Paris;t;FRHEW;SQF;t;;f;8702570;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3710;La Verpillière;la-verpilliere;8772339;87723395;45.62754423546908;5.150742530822754;;f;FR;f;Europe/Paris;t;FRHEX;VEI;t;;f;8702454;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3711;Bourgoin-Jallieu;bourgoin-jallieu;8772342;87723429;45.58389796620669;5.273271203041077;;f;FR;f;Europe/Paris;t;FRHEY;BRG;t;;f;8702481;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+3711;Bourgoin-Jallieu;bourgoin-jallieu;8772342;87723429;45.58389796620669;5.273271203041077;;f;FR;f;Europe/Paris;t;FRHEY;BRG;t;;f;8702481;f;;f;;f;;f;;;f;;f;8700231;f;;f;t;;;;;;;;;;;;;;;;;;
 3712;Cessieu;cessieu;8772345;87723452;45.5666670000;5.3666670000;;f;FR;f;Europe/Paris;t;FRHFA;CIU;t;;f;8702495;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3713;La Tour-du-Pin;la-tour-du-pin;8772347;87723478;45.560232980936135;5.449647903442383;;f;FR;f;Europe/Paris;t;FRHFB;LTP;t;;f;8700124;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+3713;La Tour-du-Pin;la-tour-du-pin;8772347;87723478;45.560232980936135;5.449647903442383;;f;FR;f;Europe/Paris;t;FRHFB;LTP;t;;f;8700124;f;;f;;f;;f;;;f;;f;8700232;f;;f;t;;;;;;;;;;;;;;;;;;
 3714;Crépieux-la-Pape;crepieux-la-pape;8772350;87723502;45.8000000000;4.8666670000;;f;FR;f;Europe/Paris;t;FRHFC;CLP;t;;f;8702493;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3715;Miribel;miribel;8772352;87723528;45.82205184052543;4.9538737535476685;;f;FR;f;Europe/Paris;t;FRHFE;MIB;t;;f;8702546;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3716;St-Maurice-de-Beynost;st-maurice-de-beynost;8772353;87723536;45.8333330000;4.9666670000;;f;FR;f;Europe/Paris;t;FRHFF;SMY;t;;f;8702540;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3717;Beynost;beynost;8772354;87723544;45.83388263383247;5.00701904296875;;f;FR;f;Europe/Paris;t;FRHFG;BNO;t;;f;8702479;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3719;Montluel;montluel;8772356;87723569;45.84776985993233;5.0575196743011475;;f;FR;f;Europe/Paris;t;FRHFI;MLU;t;;f;8702548;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3720;Meximieux—Pérouges;meximieux-perouges;8772358;87723585;45.901671;5.193517;;f;FR;f;Europe/Paris;t;FRHFJ;MEX;t;;f;8702552;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3721;Sathonay—Rillieux;sathonay-rillieux;8772370;87723700;45.82013;4.875425;;f;FR;f;Europe/Paris;t;FRHFL;SYR;t;;f;8704456;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3721;Sathonay—Rillieux;sathonay-rillieux;8772370;87723700;45.82013;4.875425;;f;FR;f;Europe/Paris;t;FRHFL;SYR;t;;f;8704456;f;;f;;f;;f;;;f;;f;8700371;f;;f;f;;;;;;;;;;;;;;;;;;
 3722;Les Échets;les-echets;8772371;87723718;45.874578;4.910789;;f;FR;f;Europe/Paris;t;FRHFM;ECH;t;;f;8703765;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3723;Mionnay;mionnay;8772372;87723726;45.896653994273215;4.919707775115966;;f;FR;f;Europe/Paris;t;FRHFN;MIO;t;;f;8703996;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3724;St-André-de-Corcy;st-andre-de-corcy;8772373;87723734;45.92599070295779;4.948825836181641;;f;FR;f;Europe/Paris;t;FRHFO;SAY;t;;f;8704528;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2843,7 +2843,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3733;Jully-les-Buxy;jully-les-buxy;8772523;87725234;46.687021015538406;4.681077003479004;;f;FR;f;Europe/Paris;t;FRHFZ;;t;;f;8703516;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3734;Les Filletières;les-filletieres;8772524;87725242;46.666582;4.683406;;f;FR;f;Europe/Paris;t;FRHGA;;t;;f;8703315;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3735;St-Boil;st-boil;8772525;87725259;46.6500000000;4.6833330000;;f;FR;f;Europe/Paris;t;FRHGB;;t;;f;8702853;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3737;Hagondange;hagondange;8719111;87191114;49.25381491677835;6.164124011993408;;f;FR;f;Europe/Paris;t;FRHGD;HGD;t;;f;8700283;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+3737;Hagondange;hagondange;8719111;87191114;49.25381491677835;6.164124011993408;;f;FR;f;Europe/Paris;t;FRHGD;HGD;t;;f;8700283;f;;f;;f;;f;;;f;;f;8700974;f;;f;t;;;;;;;;;;;;;;;;;;
 3738;St-Gengoux;st-gengoux;8772527;87725275;46.4666670000;4.7833330000;;f;FR;f;Europe/Paris;t;FRHGE;;t;;f;8704410;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3739;Malay;malay;8772528;87725283;46.5666670000;4.6833330000;;f;FR;f;Europe/Paris;t;FRHGF;;t;;f;8703890;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3740;Cormatin;cormatin;8772531;87725317;46.5500000000;4.6833330000;;f;FR;f;Europe/Paris;t;FRHGG;;t;;f;8703155;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2854,10 +2854,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3745;Prisse;prisse;8772538;;46.3166670000;4.7500000000;;f;FR;f;Europe/Paris;t;FRHGL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3746;Charnay—Condemine;charnay-condemine;8772539;87725390;46.310672;4.785209;;f;FR;f;Europe/Paris;t;FRHGM;;t;;f;8703048;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3747;Sennecey-le-Grand;sennecey-le-grand;8772561;87725614;46.6500000000;4.8666670000;;f;FR;f;Europe/Paris;t;FRHGP;;t;;f;8701942;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3748;Tournus;tournus;8772562;87725622;46.566738628284284;4.906511306762695;;f;FR;f;Europe/Paris;t;FRHGQ;TOS;t;;f;8702116;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Турню;;;
+3748;Tournus;tournus;8772562;87725622;46.566738628284284;4.906511306762695;;f;FR;f;Europe/Paris;t;FRHGQ;TOS;t;;f;8702116;f;;f;;f;;f;;;f;;f;8700349;f;;f;f;;;;;;;;;;;;;;;Турню;;;
 3749;Fleurville—Pont-de-Vaux;fleurville-pont-de-vaux;8772566;87725663;46.448575;4.882068;;f;FR;f;Europe/Paris;t;FRHGS;;t;;f;8701135;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3750;Senozan;senozan;8772567;87725671;46.392055996145196;4.871234893798828;;f;FR;f;Europe/Paris;t;FRHGT;;t;;f;8702083;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3751;Mâcon Ville;macon-ville;8772568;87725689;46.302941;4.824807;5041;f;FR;t;Europe/Paris;t;FRHGU;MAC;t;;f;8700032;t;;f;;f;8772568;f;;;f;;f;;f;;f;t;;;;;;;;;;;マコン;마콩;;;Макон;;;马孔
+3751;Mâcon Ville;macon-ville;8772568;87725689;46.302941;4.824807;5041;f;FR;t;Europe/Paris;t;FRHGU;MAC;t;;f;8700032;t;;f;;f;8772568;f;;;f;;f;8700037;f;;f;t;;;;;;;;;;;マコン;마콩;;;Макон;;;马孔
 3752;Crêches-sur-Saône;creches-sur-saone;8772571;87725713;46.246187290105524;4.78405237197876;;f;FR;f;Europe/Paris;t;FRHGV;KSA;t;;f;8700964;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3753;Pontanevaux;pontanevaux;8772572;87725721;46.213615;4.773074;;f;FR;f;Europe/Paris;t;FRHGW;PNX;t;;f;8701818;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3754;Romanèche-Thorins;romaneche-thorins;8772573;87725739;46.1833330000;4.7333330000;;f;FR;f;Europe/Paris;t;FRHGX;RHR;t;;f;8701873;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2867,16 +2867,16 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3758;Mézériat;mezeriat;8772583;87725838;46.2333330000;5.0333330000;;f;FR;f;Europe/Paris;t;FRHHB;;t;;f;8702409;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3759;Polliat;polliat;8772584;87725846;46.2500000000;5.1333330000;;f;FR;f;Europe/Paris;t;FRHHC;;t;;f;8702412;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3760;Pouilly-sous-Charlieu;pouilly-sous-charlieu;8772604;87726042;46.1433326536921;4.1083985567092896;;f;FR;f;Europe/Paris;t;FRHHE;;t;;f;8704993;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3761;Veauche—St-Galmier;veauche-st-galmier;8772620;87726208;45.56587;4.293382;;f;FR;f;Europe/Paris;t;FRHHJ;SGL;t;;f;8704565;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3761;Veauche—St-Galmier;veauche-st-galmier;8772620;87726208;45.56587;4.293382;;f;FR;f;Europe/Paris;t;FRHHJ;SGL;t;;f;8704565;f;;f;;f;;f;;;f;;f;8700149;f;;f;f;;;;;;;;;;;;;;;;;;
 3762;Bouthéon;boutheon;8772621;87726216;45.5262540000;4.2602060000;;f;FR;f;Europe/Paris;t;FRHHK;BOH;t;;f;8702900;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3763;La Fouillouse;la-fouillouse;8772623;87726232;45.5000000000;4.3166670000;;f;FR;f;Europe/Paris;t;FRHHL;LFI;t;;f;8703573;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3764;St-Chamond;st-chamond;8772630;87726307;45.47244062517769;4.516968727111816;;f;FR;f;Europe/Paris;t;FRHHO;SCM;t;;f;8704538;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-3766;Rive-de-Gier;rive-de-gier;8772633;87726331;45.524427414831166;4.6064794063568115;;f;FR;f;Europe/Paris;t;FRHHQ;RGR;t;;f;8704370;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;里夫德比耶
+3764;St-Chamond;st-chamond;8772630;87726307;45.47244062517769;4.516968727111816;;f;FR;f;Europe/Paris;t;FRHHO;SCM;t;;f;8704538;f;;f;;f;;f;;;f;;f;8700155;f;;f;t;;;;;;;;;;;;;;;;;;
+3766;Rive-de-Gier;rive-de-gier;8772633;87726331;45.524427414831166;4.6064794063568115;;f;FR;f;Europe/Paris;t;FRHHQ;RGR;t;;f;8704370;f;;f;;f;;f;;;f;;f;8700128;f;;f;f;;;;;;;;;;;;;;;;;;里夫德比耶
 3768;Andrézieux;andrezieux;8772640;87726406;45.521706311801275;4.254852533340453;;f;FR;f;Europe/Paris;t;FRHHS;ANZ;t;;f;8702659;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;昂德雷齐厄布泰翁
 3769;Bonson;bonson;8772641;87726414;45.5166670000;4.2333330000;;f;FR;f;Europe/Paris;t;FRHHT;BSN;t;;f;8702869;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3770;Sury-le-Comtal;sury-le-comtal;8772642;87726422;45.529302;4.182608;;f;FR;f;Europe/Paris;t;FRHHU;;t;;f;8704684;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3771;St-Romain-le-Puy;st-romain-le-puy;8772643;87726430;45.5500000000;4.1166670000;;f;FR;f;Europe/Paris;t;FRHHV;SRP;t;;f;8704649;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3772;Montbrison;montbrison;8772644;87726448;45.604453096955964;4.0783631801605225;;f;FR;f;Europe/Paris;t;FRHHW;MOB;t;;f;8704024;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3772;Montbrison;montbrison;8772644;87726448;45.604453096955964;4.0783631801605225;;f;FR;f;Europe/Paris;t;FRHHW;MOB;t;;f;8704024;f;;f;;f;;f;;;f;;f;8700382;f;;f;f;;;;;;;;;;;;;;;;;;
 3773;Boën;boen;8772647;87726471;45.74134108021757;4.005149602890015;;f;FR;f;Europe/Paris;t;FRHHX;;t;;f;8702850;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3774;Toulouse Barrière de Paris;toulouse-barriere-de-paris;8746287;87462879;43.65453;1.451757;5306;f;FR;f;Europe/Paris;t;FRHIB;;t;;f;8706268;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 3776;Tarsac;tarsac;8746273;87462739;43.666234;-0.118711;;f;FR;f;Europe/Paris;t;FRHID;;t;;f;8706269;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2890,15 +2890,15 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3785;Hirson Écoles;hirson-ecoles;8732433;87324335;49.929558;4.085696;4013;f;FR;f;Europe/Paris;t;FRHIO;;t;;f;8704104;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3786;Blagnac Mairie;blagnac-mairie;8746277;87462770;43.6333330000;1.4000000000;;f;FR;f;Europe/Paris;f;FRHIP;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3787;Aurec;aurec;8772676;87726760;45.3666670000;4.2000000000;;f;FR;f;Europe/Paris;t;FRHIQ;AEC;t;;f;8702722;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3788;Hirson;hirson;8729506;87295063;49.91442477286673;4.084467887878418;4013;f;FR;t;Europe/Paris;t;FRHIR;HIQ;t;;f;8700241;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3788;Hirson;hirson;8729506;87295063;49.91442477286673;4.084467887878418;4013;f;FR;t;Europe/Paris;t;FRHIR;HIQ;t;;f;8700241;f;;f;;f;;f;;;f;;f;8700854;f;;f;f;;;;;;;;;;;;;;;;;;
 3789;His;his;8761882;87618827;43.0666670000;0.9666670000;;f;FR;f;Europe/Paris;t;FRHIS;;t;;f;8703471;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3790;Bas-Monistrol;bas-monistrol;8772677;87726778;45.297614;4.139496;;f;FR;f;Europe/Paris;t;FRHIT;BMO;t;;f;8702778;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3791;Pont-de-Lignon;pont-de-lignon;8772678;87726786;45.259833;4.13724;;f;FR;f;Europe/Paris;t;FRHIU;;t;;f;8704265;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3793;St-Jean-de-Monts Avenue de la Forêt;st-jean-de-monts-avenue-de-la-foret;8746315;87463158;46.7833330000;-2.0666670000;;f;FR;f;Europe/Paris;t;FRHIW;;t;;f;8706328;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3796;St-Jodard;st-jodard;8772685;87726851;45.8833330000;4.1333330000;;f;FR;f;Europe/Paris;t;FRHIZ;SNJ;t;;f;8704414;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3797;Balbigny;balbigny;8772686;87726869;45.8166670000;4.1833330000;;f;FR;f;Europe/Paris;t;FRHJA;BBY;t;;f;8702761;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3798;Feurs;feurs;8772687;87726877;45.743957949341635;4.23072338104248;;f;FR;f;Europe/Paris;t;FRHJB;FEU;t;;f;8703313;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3799;Montrond-les-Bains;montrond-les-bains;8772688;87726885;45.64435568424734;4.248983860015869;;f;FR;f;Europe/Paris;t;FRHJC;MRB;t;;f;8704054;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3797;Balbigny;balbigny;8772686;87726869;45.8166670000;4.1833330000;;f;FR;f;Europe/Paris;t;FRHJA;BBY;t;;f;8702761;f;;f;;f;;f;;;f;;f;8700145;f;;f;f;;;;;;;;;;;;;;;;;;
+3798;Feurs;feurs;8772687;87726877;45.743957949341635;4.23072338104248;;f;FR;f;Europe/Paris;t;FRHJB;FEU;t;;f;8703313;f;;f;;f;;f;;;f;;f;8700125;f;;f;f;;;;;;;;;;;;;;;;;;
+3799;Montrond-les-Bains;montrond-les-bains;8772688;87726885;45.64435568424734;4.248983860015869;;f;FR;f;Europe/Paris;t;FRHJC;MRB;t;;f;8704054;f;;f;;f;;f;;;f;;f;8700148;f;;f;f;;;;;;;;;;;;;;;;;;
 3800;St-Fons;st-fons;8772850;87728501;45.705748473262176;4.852507710456848;;f;FR;f;Europe/Paris;t;FRHJE;SFS;t;;f;8701957;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3802;Celles-sur-Durolle;celles-sur-durolle;8773160;87731604;45.8500000000;3.6333330000;;f;FR;f;Europe/Paris;t;FRHJL;;t;;f;8702996;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3803;Ste-Pazanne Rue du Vigneau;ste-pazanne-rue-du-vigneau;8746312;87463125;47.1000000000;-1.8166670000;5230;f;FR;f;Europe/Paris;t;FRHJM;;t;;f;8706288;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2912,7 +2912,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3819;Ris—Châteldon;ris-chateldon;8773231;87732313;45.988993;3.489252;;f;FR;f;Europe/Paris;t;FRHKE;;t;;f;8704366;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3820;Puy-Guillaume;puy-guillaume;8773232;87732321;45.9500000000;3.4833330000;10738;f;FR;f;Europe/Paris;t;FRHKF;;t;;f;8704330;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3821;Lapalisse—St-Prix;lapalisse-st-prix;8773261;87732610;46.227189;3.63299;;f;FR;f;Europe/Paris;t;FRHKK;;t;;f;8703649;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3823;Royat—Chamalières;royat-chamalieres;8773403;87734038;45.767813;3.06151;;f;FR;f;Europe/Paris;t;FRHKO;RYA;t;;f;8701885;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3823;Royat—Chamalières;royat-chamalieres;8773403;87734038;45.767813;3.06151;;f;FR;f;Europe/Paris;t;FRHKO;RYA;t;;f;8701885;f;;f;;f;;f;;;f;;f;8700984;f;;f;f;;;;;;;;;;;;;;;;;;
 3824;Gerzat;gerzat;8773404;87734046;45.8333330000;3.1500000000;;f;FR;f;Europe/Paris;t;FRHKP;;t;;f;8703390;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3825;Dréfféac Église;dreffeac-eglise;8746297;87462978;47.4666670000;-2.0666670000;;f;FR;f;Europe/Paris;t;FRHKQ;;t;;f;8706365;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3826;Pont-du-Château;pont-du-chateau;8773408;87734087;45.8000000000;3.2500000000;;f;FR;f;Europe/Paris;t;FRHKR;;t;;f;8704270;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2924,16 +2924,16 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3833;Les Martres-de-Veyre;les-martres-de-veyre;8773417;87734178;45.6840610000;3.1898650000;;f;FR;f;Europe/Paris;t;FRHKY;;t;;f;8703773;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3834;Vic-le-Comte;vic-le-comte;8773418;87734186;45.66495;3.206937;;f;FR;f;Europe/Paris;t;FRHKZ;;t;;f;8704831;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3835;Parent—Coudes—Champeix;parent-coudes-champeix;8773419;87734194;45.613972;3.217814;;f;FR;f;Europe/Paris;t;FRHLA;;t;;f;8704181;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3836;Issoire;issoire;8773420;87734202;45.54403500801298;3.2541418075561523;10683;f;FR;f;Europe/Paris;t;FRHLB;ISS;t;;f;8703484;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;イソワール;;;;Иссуар;;;伊苏瓦尔
+3836;Issoire;issoire;8773420;87734202;45.54403500801298;3.2541418075561523;10683;f;FR;f;Europe/Paris;t;FRHLB;ISS;t;;f;8703484;f;;f;;f;;f;;;f;;f;8700115;f;;f;f;;;;;;;;;;;イソワール;;;;Иссуар;;;伊苏瓦尔
 3837;Le Breuil-sur-Couze;le-breuil-sur-couze;8773422;87734228;45.46707602845702;3.262134790420532;10719;f;FR;f;Europe/Paris;t;FRHLC;;t;;f;8703689;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3838;Le Saut-du-Loup;le-saut-du-loup;8773423;87734236;45.45186;3.303086;;f;FR;f;Europe/Paris;t;FRHLD;;t;;f;8703731;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3839;Brassac-les-Mines—Ste-Florine;brassac-les-mines-ste-florine;8773424;87734244;45.414088;3.330161;;f;FR;f;Europe/Paris;t;FRHLE;BLM;t;;f;8702903;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3840;Brioude;brioude;8773426;87734269;45.300633467428604;3.3786284923553462;10675;f;FR;f;Europe/Paris;t;FRHLF;BRD;t;;f;8702928;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ブリウド;;;;Бриуд;;;布里乌德
-3841;Paulhaguet;paulhaguet;8773429;87734293;45.2000000000;3.5333330000;10583;f;FR;f;Europe/Paris;t;FRHLH;;t;;f;8704192;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3842;Langeac;langeac;8773431;87734319;45.101255930103974;3.490632176399231;;f;FR;f;Europe/Paris;t;FRHLI;LNG;t;;f;8703643;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3839;Brassac-les-Mines—Ste-Florine;brassac-les-mines-ste-florine;8773424;87734244;45.414088;3.330161;;f;FR;f;Europe/Paris;t;FRHLE;BLM;t;;f;8702903;f;;f;;f;;f;;;f;;f;8700116;f;;f;f;;;;;;;;;;;;;;;;;;
+3840;Brioude;brioude;8773426;87734269;45.300633467428604;3.3786284923553462;10675;f;FR;f;Europe/Paris;t;FRHLF;BRD;t;;f;8702928;f;;f;;f;;f;;;f;;f;8700222;f;;f;f;;;;;;;;;;;ブリウド;;;;Бриуд;;;布里乌德
+3841;Paulhaguet;paulhaguet;8773429;87734293;45.2000000000;3.5333330000;10583;f;FR;f;Europe/Paris;t;FRHLH;;t;;f;8704192;f;;f;;f;;f;;;f;;f;8700223;f;;f;f;;;;;;;;;;;;;;;;;;
+3842;Langeac;langeac;8773431;87734319;45.101255930103974;3.490632176399231;;f;FR;f;Europe/Paris;t;FRHLI;LNG;t;;f;8703643;f;;f;;f;;f;;;f;;f;8700225;f;;f;f;;;;;;;;;;;;;;;;;;
 3843;Monistrol-d’Allier;monistrol-dallier;8773433;87734335;44.9500000000;3.6333330000;;f;FR;f;Europe/Paris;t;FRHLK;;t;;f;8704011;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3844;Chapeauroux;chapeauroux;8773434;87734343;44.8384340000;3.7369820000;;f;FR;f;Europe/Paris;t;FRHLL;;t;;f;8703041;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3845;Langogne;langogne;8773435;87734350;44.73274904526125;3.857327699661255;;f;FR;f;Europe/Paris;t;FRHLM;LGG;t;;f;8703645;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3844;Chapeauroux;chapeauroux;8773434;87734343;44.8384340000;3.7369820000;;f;FR;f;Europe/Paris;t;FRHLL;;t;;f;8703041;f;;f;;f;;f;;;f;;f;8700226;f;;f;f;;;;;;;;;;;;;;;;;;
+3845;Langogne;langogne;8773435;87734350;44.73274904526125;3.857327699661255;;f;FR;f;Europe/Paris;t;FRHLM;LGG;t;;f;8703645;f;;f;;f;;f;;;f;;f;8700227;f;;f;f;;;;;;;;;;;;;;;;;;
 3846;Luc;luc;8773436;87734368;44.6501430000;3.8909520000;;f;FR;f;Europe/Paris;t;FRHLN;;t;;f;8703849;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Люк-сюр-Мер;;;吕克阿尔莫
 3847;Séverac Rue de la Gare;severac-rue-de-la-gare;8746311;87463117;47.5333330000;-2.0833330000;;f;FR;f;Europe/Paris;t;FRHLO;;t;;f;8706368;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3848;Vertaizon;vertaizon;8773442;87734426;45.784704;3.28846;;f;FR;f;Europe/Paris;t;FRHLQ;VTZ;t;;f;8704819;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2964,7 +2964,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3876;Lagraulière;lagrauliere;8773476;87734764;45.3500000000;1.6333330000;;f;FR;f;Europe/Paris;t;FRHMU;;t;;f;8703628;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3878;Riom-es-Montagnes;riom-es-montagnes;8764566;87645663;45.28479487906906;2.6582300662994385;;f;FR;f;Europe/Paris;t;FRHMW;;t;;f;8704365;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3879;Cerans Église;cerans-eglise;8746293;87462937;47.838811;0.086476;;f;FR;f;Europe/Paris;t;FRHMX;;t;;f;8706376;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3880;Massiac-Blesle;massiac-blesle;8773487;87734871;45.253765;3.196555;;f;FR;f;Europe/Paris;t;FRHMY;MIA;t;;f;8703935;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3880;Massiac-Blesle;massiac-blesle;8773487;87734871;45.253765;3.196555;;f;FR;f;Europe/Paris;t;FRHMY;MIA;t;;f;8703935;f;;f;;f;;f;;;f;;f;8700109;f;;f;f;;;;;;;;;;;;;;;;;;
 3881;Guécélard Belle Étoile;guecelard-belle-etoile;8746299;87462994;47.8833330000;0.1333330000;;f;FR;f;Europe/Paris;t;FRHMZ;;t;;f;8706377;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3882;Le Mans Pontlieue;le-mans-pontlieue;8746305;87463059;48.0000000000;0.2000000000;4661;f;FR;f;Europe/Paris;t;FRHNA;;t;;f;8706378;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3883;Amazy;amazy;8773490;87734905;47.3755120000;3.5779380000;;f;FR;f;Europe/Paris;t;FRHNB;;t;;f;8704990;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2988,7 +2988,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3907;Argentine;argentine;8774127;87741272;45.5000000000;6.3166670000;;f;FR;f;Europe/Paris;t;FRHOG;;t;;f;8702389;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3908;Épierre—St-Léger;epierre-st-leger;8774128;87741280;45.457056;6.292377;;f;FR;f;Europe/Paris;t;FRHOH;MEE;t;;f;8702401;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3909;Les Chavannes—St-Rémy;les-chavannes-st-remy;8774129;87741298;45.383165;6.278794;;f;FR;f;Europe/Paris;t;FRHOI;;t;;f;8702408;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3910;St-Avre—La Chambre;st-avre-la-chambre;8774130;87741306;45.352844;6.303065;;f;FR;f;Europe/Paris;t;FRHOJ;SVB;t;;f;8702380;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3910;St-Avre—La Chambre;st-avre-la-chambre;8774130;87741306;45.352844;6.303065;;f;FR;f;Europe/Paris;t;FRHOJ;SVB;t;;f;8702380;f;;f;;f;;f;;;f;;f;8700990;f;;f;f;;;;;;;;;;;;;;;;;;
 3912;Aiguebelette-le-Lac;aiguebelette-le-lac;8774142;87741421;45.5333330000;5.8166670000;;f;FR;f;Europe/Paris;t;FRHOL;AGQ;t;;f;8702467;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3913;Lépin-le-Lac—La Bauche;lepin-le-lac-la-bauche;8774143;87741439;45.541555314480306;5.765054225921631;;f;FR;f;Europe/Paris;t;FRHOM;LPL;t;;f;8702530;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3914;La Bridoire;la-bridoire;8774144;87741447;45.5250360000;5.7407270000;;f;FR;f;Europe/Paris;t;FRHON;;t;;f;8702478;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -2996,20 +2996,20 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3916;Domessin—Le-Bonnard;domessin-le-bonnard;8774146;87741462;45.524322;5.696509;;f;FR;f;Europe/Paris;t;FRHOP;;t;;f;8702501;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3917;Pont-de-Beauvoisin;pont-de-beauvoisin;8774147;87741470;45.524630364755225;5.680704116821289;;f;FR;f;Europe/Paris;t;FRHOQ;POB;t;;f;8702558;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3918;Les Abrets—Fitilieu;les-abrets-fitilieu;8774149;87741496;45.542337;5.575271;;f;FR;f;Europe/Paris;t;FRHOS;FII;t;;f;8702466;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3919;Virieu-le-Grand—Belley;virieu-le-grand-belley;8774150;87741504;45.848276;5.653765;;f;FR;f;Europe/Paris;t;FRHOT;VRU;t;;f;8700460;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3919;Virieu-le-Grand—Belley;virieu-le-grand-belley;8774150;87741504;45.848276;5.653765;;f;FR;f;Europe/Paris;t;FRHOT;VRU;t;;f;8700460;f;;f;;f;;f;;;f;;f;8700154;f;;f;f;;;;;;;;;;;;;;;;;;
 3920;Grésy-sur-Isère;gresy-sur-isere;8774161;87741611;45.6000000000;6.2500000000;;f;FR;f;Europe/Paris;t;FRHOV;TGG;t;;f;8702403;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3921;Frontenex;frontenex;8774162;87741629;45.6333330000;6.3166670000;;f;FR;f;Europe/Paris;t;FRHOW;TFF;t;;f;8702402;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3922;Diebling Maison Forestière;diebling-maison-forestiere;8747686;87476861;49.113248;6.930098;;f;FR;f;Europe/Paris;t;FRHOX;;t;;f;8706289;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3924;La Bathie;la-bathie;8774167;87741678;45.6333330000;6.4500000000;;f;FR;f;Europe/Paris;t;FRHOZ;;t;;f;8702382;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3925;Cevins;cevins;8774168;87741686;45.5833330000;6.4666670000;;f;FR;f;Europe/Paris;t;FRHPA;;t;;f;8702394;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3926;Notre-Dame-de-Briançon;notre-dame-de-briancon;8774169;87741694;45.539577;6.468592;;f;FR;f;Europe/Paris;t;FRHPB;NAB;t;;f;8702410;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3926;Notre-Dame-de-Briançon;notre-dame-de-briancon;8774169;87741694;45.539577;6.468592;;f;FR;f;Europe/Paris;t;FRHPB;NAB;t;;f;8702410;f;;f;;f;;f;;;f;;f;8700706;f;;f;f;;;;;;;;;;;;;;;;;;
 3927;Petit-Cœur—La Léchère;petit-coeur-la-lechere;8774170;87741702;45.520888;6.484647;;f;FR;f;Europe/Paris;t;FRHPC;;t;;f;8702411;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3928;Aigueblanche;aigueblanche;8774171;87741710;45.49966955063677;6.511352062225342;;f;FR;f;Europe/Paris;t;FRHPD;;t;;f;8702386;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3930;Romelfing Église;romelfing-eglise;8747691;87476911;48.8333330000;7.0166670000;;f;FR;f;Europe/Paris;f;FRHPF;;t;;f;8706446;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3931;Landry;landry;8774177;87741777;45.57427846261418;6.733675003051758;;f;FR;f;Europe/Paris;t;FRHPG;LAY;t;HPG;t;8700444;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3931;Landry;landry;8774177;87741777;45.57427846261418;6.733675003051758;;f;FR;f;Europe/Paris;t;FRHPG;LAY;t;HPG;t;8700444;f;;f;;f;;f;;;f;;f;8700160;f;;f;f;;;;;;;;;;;;;;;;;;
 3932;Antignac (Cantal);antignac-cantal;8711022;87110221;45.3666670000;2.5500000000;;f;FR;f;Europe/Paris;t;FRHPH;;t;;f;8702668;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3933;Ambilly;ambilly;8774203;87742031;46.1952000000;6.2243000000;;f;FR;f;Europe/Paris;t;FRHPM;;t;;f;8702465;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3934;St-Jean-de-Maurienne—Arvan;st-jean-de-maurienne-arvan;8774232;87742320;45.277793;6.354573;;f;FR;f;Europe/Paris;t;FRHPN;SJM;t;;f;8702383;f;;f;;f;8774232;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3934;St-Jean-de-Maurienne—Arvan;st-jean-de-maurienne-arvan;8774232;87742320;45.277793;6.354573;;f;FR;f;Europe/Paris;t;FRHPN;SJM;t;;f;8702383;f;;f;;f;8774232;f;;;f;;f;8700262;f;;f;f;;;;;;;;;;;;;;;;;;
 3936;Romelfing Route Départementale;romelfing-route-departementale;8747688;87476887;48.8333330000;7.0166670000;;f;FR;f;Europe/Paris;f;FRHPP;;t;;f;8706447;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3938;Gérardmer Les Bas-Rupts;gerardmer-les-bas-rupts;8747680;;48.04475072986582;6.8708109855651855;;f;FR;f;Europe/Paris;t;FRHPR;;t;;f;8706425;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3939;Collonges (Ain);collonges-ain;8774260;87742601;46.1333330000;5.9000000000;;f;FR;f;Europe/Paris;t;FRHPS;;t;;f;8703131;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3038,8 +3038,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3969;Molinges;molinges;8774359;87743591;46.3500000000;5.7666670000;;f;FR;f;Europe/Paris;t;FRHQW;;t;;f;8704004;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3972;Gerbeviller Foch;gerbeviller-foch;8747678;87476788;48.5000000000;6.5166670000;;f;FR;f;Europe/Paris;t;FRHQZ;;t;;f;8706290;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3973;Lunéville Lycée Professionnel;luneville-lycee-professionnel;8747674;87476747;48.59750;6.48963;9346;f;FR;f;Europe/Paris;t;FRHRA;;t;;f;8706291;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;リュネヴィル;;;;Люневиль;;;吕内维尔
-3977;St-Rambert-en-Bugey;st-rambert-en-bugey;8774374;87743740;45.946968;5.438231;;f;FR;f;Europe/Paris;t;FRHRE;SBB;t;;f;8701930;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-3978;Tenay—Hauteville;tenay-hauteville;8774375;87743757;45.922544;5.500984;;f;FR;f;Europe/Paris;t;FRHRF;TEN;t;;f;8701291;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+3977;St-Rambert-en-Bugey;st-rambert-en-bugey;8774374;87743740;45.946968;5.438231;;f;FR;f;Europe/Paris;t;FRHRE;SBB;t;;f;8701930;f;;f;;f;;f;;;f;;f;8700363;f;;f;f;;;;;;;;;;;;;;;;;;
+3978;Tenay—Hauteville;tenay-hauteville;8774375;87743757;45.922544;5.500984;;f;FR;f;Europe/Paris;t;FRHRF;TEN;t;;f;8701291;f;;f;;f;;f;;;f;;f;8700904;f;;f;f;;;;;;;;;;;;;;;;;;
 3983;Farges;farges;8774514;87745141;46.1666670000;5.9166670000;;f;FR;f;Europe/Paris;t;FRHRL;;t;;f;8703305;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3984;Greny;greny;8774515;;49.946414932080245;1.3053828477859497;;f;FR;f;Europe/Paris;t;FRHRM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3985;Sous-Peron;sous-peron;8774516;87745166;46.187879;5.929491;;f;FR;f;Europe/Paris;t;FRHRN;;t;;f;8704520;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3052,29 +3052,29 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 3997;Pougny—Chancy;pougny-chancy;8774538;87745380;46.146088;5.961151;;f;FR;f;Europe/Paris;t;FRHRZ;;t;;f;8701758;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 3999;Valleiry;valleiry;8774541;87745414;46.109322;5.967228;;f;FR;f;Europe/Paris;t;FRHSB;VEY;t;;f;8702252;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4000;Merten République;merten-republique;8747715;87477158;49.2500000000;6.6666670000;;f;FR;f;Europe/Paris;t;FRHSC;;t;;f;8706293;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4001;St-Julien-en-Genevois;st-julien-en-genevois;8774543;87745430;46.14200574979052;6.0855889320373535;;f;FR;f;Europe/Paris;t;FRHSD;SJG;t;;f;8701982;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4004;Machilly;machilly;8774558;87745588;46.2500000000;6.3333330000;;f;FR;f;Europe/Paris;t;FRHSK;MCI;t;;f;8701479;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4005;Bons-en-Chablais;bons-en-chablais;8774559;87745596;46.270014016045366;6.366169452667236;;f;FR;f;Europe/Paris;t;FRHSL;BAB;t;;f;8700680;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4001;St-Julien-en-Genevois;st-julien-en-genevois;8774543;87745430;46.14200574979052;6.0855889320373535;;f;FR;f;Europe/Paris;t;FRHSD;SJG;t;;f;8701982;f;;f;;f;;f;;;f;;f;8700143;f;;f;f;;;;;;;;;;;;;;;;;;
+4004;Machilly;machilly;8774558;87745588;46.2500000000;6.3333330000;;f;FR;f;Europe/Paris;t;FRHSK;MCI;t;;f;8701479;f;;f;;f;;f;;;f;;f;8700780;f;;f;f;;;;;;;;;;;;;;;;;;
+4005;Bons-en-Chablais;bons-en-chablais;8774559;87745596;46.270014016045366;6.366169452667236;;f;FR;f;Europe/Paris;t;FRHSL;BAB;t;;f;8700680;f;;f;;f;;f;;;f;;f;8700124;f;;f;f;;;;;;;;;;;;;;;;;;
 4007;Perrignier;perrignier;8774562;87745620;46.3000000000;6.4500000000;;f;FR;f;Europe/Paris;t;FRHSN;PEG;t;;f;8701797;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4010;Châtillon-en-Michaille;chatillon-en-michaille;8774571;87745711;46.1432843356237;5.798410177230835;;f;FR;f;Europe/Paris;t;FRHSS;;t;;f;8703067;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4011;St-Germain-de-Joux;st-germain-de-joux;8774572;87745729;46.178073511807575;5.737706422805786;;f;FR;f;Europe/Paris;t;FRHST;;t;;f;8704571;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4012;Charix—Lalleyriat;charix-lalleyriat;8774573;87745737;46.155958;5.714973;;f;FR;f;Europe/Paris;t;FRHSU;;t;;f;8703046;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4013;Hirson;hirson;;;49.9166670000;4.0833330000;;t;FR;f;Europe/Paris;f;FRHSV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4015;Seyssel—Corbonod;seyssel-corbonod;8774582;87745828;45.963032;5.831347;;f;FR;f;Europe/Paris;t;FRHSX;SSS;t;;f;8700458;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4015;Seyssel—Corbonod;seyssel-corbonod;8774582;87745828;45.963032;5.831347;;f;FR;f;Europe/Paris;t;FRHSX;SSS;t;;f;8700458;f;;f;;f;;f;;;f;;f;8700152;f;;f;f;;;;;;;;;;;;;;;;;;
 4018;Grésy-sur-Aix;gresy-sur-aix;8774610;87746107;45.7166670000;5.9500000000;;f;FR;f;Europe/Paris;t;FRHTB;GAX;t;;f;8703436;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4021;Rumilly;rumilly;8774614;87746149;45.86293870111006;5.947980880737305;;f;FR;f;Europe/Paris;t;FRHTE;RUM;t;;f;8700440;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4021;Rumilly;rumilly;8774614;87746149;45.86293870111006;5.947980880737305;;f;FR;f;Europe/Paris;t;FRHTE;RUM;t;;f;8700440;f;;f;;f;;f;;;f;;f;8700265;f;;f;f;;;;;;;;;;;;;;;;;;
 4022;Lyon Jean Macé;lyon-jean-mace;8728262;87282624;45.745052;4.841841;4718;f;FR;f;Europe/Paris;t;FRHTF;LJC;t;;f;8706450;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
 4023;Hettange-Grande;hettange-grande;8719116;87191163;49.40767829801834;6.15659236907959;;f;FR;f;Europe/Paris;t;FRHTG;;t;;f;8701141;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4025;Pringy (Haute Savoie);pringy-haute-savoie;8774620;87746206;45.9394967961247;6.123311519622802;;f;FR;f;Europe/Paris;t;FRHTK;PGY;t;;f;8704920;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4026;St-Martin-Bellevue;st-martin-bellevue;8774622;87746222;45.9500000000;6.1333330000;;f;FR;f;Europe/Paris;t;FRHTM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4027;Groisy—Thorens-la-Caille;groisy-thorens-la-caille;8774624;87746248;46.011106;6.175499;;f;FR;f;Europe/Paris;t;FRHTO;GTC;t;;f;8703441;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4029;Chartres;chartres;9904055;;48.4468530000;1.4892480000;;t;FR;f;Europe/Paris;f;FRHTS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4030;Chartres;chartres;8739400;87394007;48.448387;1.480873;4029;f;FR;t;Europe/Paris;t;FRQTJ;CHH;t;;f;8700080;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;シャルトル;샤르트르;;;Шартр;;;沙特尔
-4031;St-Pierre-en-Faucigny;st-pierre-en-faucigny;8774631;87746313;46.05932533958489;6.375739574432373;;f;FR;f;Europe/Paris;t;FRHTT;SPE;t;;f;8704640;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4032;Bonneville;bonneville;8774633;87746339;46.07767392087253;6.41650915145874;;f;FR;f;Europe/Paris;t;FRHTV;BON;t;;f;8700137;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4033;Marignier;marignier;8774634;87746347;46.08877687387567;6.507822275161743;;f;FR;f;Europe/Paris;t;FRHTW;MRG;t;;f;8700492;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4035;Cluses;cluses;8774637;87746370;46.0611195266875;6.582773923873901;;f;FR;f;Europe/Paris;t;FRHTZ;CLU;t;HTZ;t;8700138;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4037;Magland;magland;8774641;87746412;46.0166670000;6.6166670000;;f;FR;f;Europe/Paris;t;FRHUB;MGD;t;;f;8703876;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4030;Chartres;chartres;8739400;87394007;48.448387;1.480873;4029;f;FR;t;Europe/Paris;t;FRQTJ;CHH;t;;f;8700080;f;;f;;f;;f;;;f;;f;8700095;f;;f;t;;;;;;;;;;;シャルトル;샤르트르;;;Шартр;;;沙特尔
+4031;St-Pierre-en-Faucigny;st-pierre-en-faucigny;8774631;87746313;46.05932533958489;6.375739574432373;;f;FR;f;Europe/Paris;t;FRHTT;SPE;t;;f;8704640;f;;f;;f;;f;;;f;;f;8700268;f;;f;f;;;;;;;;;;;;;;;;;;
+4032;Bonneville;bonneville;8774633;87746339;46.07767392087253;6.41650915145874;;f;FR;f;Europe/Paris;t;FRHTV;BON;t;;f;8700137;f;;f;;f;;f;;;f;;f;8700269;f;;f;f;;;;;;;;;;;;;;;;;;
+4033;Marignier;marignier;8774634;87746347;46.08877687387567;6.507822275161743;;f;FR;f;Europe/Paris;t;FRHTW;MRG;t;;f;8700492;f;;f;;f;;f;;;f;;f;8700490;f;;f;f;;;;;;;;;;;;;;;;;;
+4035;Cluses;cluses;8774637;87746370;46.0611195266875;6.582773923873901;;f;FR;f;Europe/Paris;t;FRHTZ;CLU;t;HTZ;t;8700138;f;;f;;f;;f;;;f;;f;8700272;f;;f;t;;;;;;;;;;;;;;;;;;
+4037;Magland;magland;8774641;87746412;46.0166670000;6.6166670000;;f;FR;f;Europe/Paris;t;FRHUB;MGD;t;;f;8703876;f;;f;;f;;f;;;f;;f;8700273;f;;f;f;;;;;;;;;;;;;;;;;;
 4039;Reignier;reignier;8774651;87746511;46.1333330000;6.2666670000;;f;FR;f;Europe/Paris;t;FRHUF;REI;t;;f;8704352;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4041;Le Trétien;le-tretien;8774663;;;;;f;CH;f;Europe/Zurich;f;FRHUK;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4042;Les Marécottes;les-marecottes;8774664;;;;6370;f;CH;f;Europe/Zurich;f;FRHUL;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3098,21 +3098,21 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4060;Le Buet;le-buet;8774688;87746883;46.018325;6.920804;;f;FR;f;Europe/Paris;t;FRHVF;;t;;f;8703691;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4061;Virieu-sur-Bourbre;virieu-sur-bourbre;8774720;87747204;45.491691;5.471742;;f;FR;f;Europe/Paris;t;FRHVI;VRB;t;;f;8702453;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4062;Chabons;chabons;8774721;87747212;45.4166670000;5.4333330000;;f;FR;f;Europe/Paris;t;FRHVJ;CKN;t;;f;8702488;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4063;Le Grand-Lemps;le-grand-lemps;8774722;87747220;45.396762448974705;5.423383712768555;;f;FR;f;Europe/Paris;t;FRHVK;LGL;t;;f;8702514;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4065;Rives;rives;8774724;87747246;45.35759615954167;5.491887331008911;;f;FR;f;Europe/Paris;t;FRHVM;RIV;t;;f;8702576;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4063;Le Grand-Lemps;le-grand-lemps;8774722;87747220;45.396762448974705;5.423383712768555;;f;FR;f;Europe/Paris;t;FRHVK;LGL;t;;f;8702514;f;;f;;f;;f;;;f;;f;8700253;f;;f;f;;;;;;;;;;;;;;;;;;
+4065;Rives;rives;8774724;87747246;45.35759615954167;5.491887331008911;;f;FR;f;Europe/Paris;t;FRHVM;RIV;t;;f;8702576;f;;f;;f;;f;;;f;;f;8700255;f;;f;f;;;;;;;;;;;;;;;;;;
 4066;Reaumont—St-Cassien;reaumont-st-cassien;8774727;87747279;45.369177;5.534892;;f;FR;f;Europe/Paris;t;FRHVN;RCS;t;;f;8702575;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4067;Voiron;voiron;8774728;87747287;45.36400389280961;5.594916343688965;;f;FR;f;Europe/Paris;t;FRHVO;VOR;t;;f;8700425;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+4067;Voiron;voiron;8774728;87747287;45.36400389280961;5.594916343688965;;f;FR;f;Europe/Paris;t;FRHVO;VOR;t;;f;8700425;f;;f;;f;;f;;;f;;f;8700256;f;;f;t;;;;;;;;;;;;;;;;;;
 4069;Voreppe;voreppe;8774733;87747337;45.290252;5.63211;;f;FR;f;Europe/Paris;t;FRHVQ;VPE;t;;f;8702451;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4070;St-Egrève—St-Robert;st-egreve-st-robert;8774735;87747352;45.235696232182036;5.671273469924927;;f;FR;f;Europe/Paris;t;FRHVR;SEG;t;;f;8702508;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4072;Brignoud;brignoud;8774745;87747451;45.2624654129904;5.90140700340271;;f;FR;f;Europe/Paris;t;FRHVV;BNU;t;;f;8702924;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4073;Goncelin;goncelin;8774747;87747477;45.34198840882092;5.974148511886597;;f;FR;f;Europe/Paris;t;FRHVX;GOC;t;;f;8703414;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4075;Pontcharra-sur-Breda—Allevard;pontcharra-sur-breda-allevard;8774749;87747493;45.434125;6.007652;;f;FR;f;Europe/Paris;t;FRHVZ;PCA;t;;f;8700459;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4075;Pontcharra-sur-Breda—Allevard;pontcharra-sur-breda-allevard;8774749;87747493;45.434125;6.007652;;f;FR;f;Europe/Paris;t;FRHVZ;PCA;t;;f;8700459;f;;f;;f;;f;;;f;;f;8700153;f;;f;f;;;;;;;;;;;;;;;;;;
 4076;Pont-de-Claix;pont-de-claix;8774751;87747519;45.1166670000;5.7000000000;;f;FR;f;Europe/Paris;t;FRHWA;;t;;f;8704259;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4077;Jarrie—Vizille;jarrie-vizille;8774753;87747535;45.08537;5.742399;;f;FR;f;Europe/Paris;t;FRHWB;;t;;f;8703495;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4078;St-Georges-de-Commiers;st-georges-de-commiers;8774756;87747568;45.0333330000;5.7000000000;;f;FR;f;Europe/Paris;t;FRHWC;;t;;f;8704569;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4080;Monestier-de-Clermont;monestier-de-clermont;8774759;87747592;44.912000382359004;5.633947849273682;;f;FR;f;Europe/Paris;t;FRHWE;;t;;f;8704008;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4082;Clelles—Mens;clelles-mens;8774762;87747626;44.827146;5.604954;;f;FR;f;Europe/Paris;t;FRHWG;;t;;f;8703118;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4085;Lus-la-Croix-Haute;lus-la-croix-haute;8774766;87747667;44.671010549543126;5.697387456893921;;f;FR;f;Europe/Paris;t;FRHWK;;t;;f;8703862;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4080;Monestier-de-Clermont;monestier-de-clermont;8774759;87747592;44.912000382359004;5.633947849273682;;f;FR;f;Europe/Paris;t;FRHWE;;t;;f;8704008;f;;f;;f;;f;;;f;;f;8700328;f;;f;f;;;;;;;;;;;;;;;;;;
+4082;Clelles—Mens;clelles-mens;8774762;87747626;44.827146;5.604954;;f;FR;f;Europe/Paris;t;FRHWG;;t;;f;8703118;f;;f;;f;;f;;;f;;f;8700329;f;;f;f;;;;;;;;;;;;;;;;;;
+4085;Lus-la-Croix-Haute;lus-la-croix-haute;8774766;87747667;44.671010549543126;5.697387456893921;;f;FR;f;Europe/Paris;t;FRHWK;;t;;f;8703862;f;;f;;f;;f;;;f;;f;8700376;f;;f;f;;;;;;;;;;;;;;;;;;
 4088;Moirans—La-Galifette;moirans-la-galifette;8774769;87747691;45.323939882128045;5.563716888427734;4774;f;FR;f;Europe/Paris;t;FRHWN;MFE;t;;f;8704001;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4089;Genève Voyageurs;geneve-voyageurs;8774890;87748905;46.209768;6.140756;5335;f;CH;f;Europe/Zurich;f;FRHWO;;t;;f;8587057;t;;f;;f;;f;;;f;;f;;f;;f;f;;Genf;Geneva;Ginebra;;Ginevra;;Ženeva;;Genf;ジュネーヴ;제네바;Genewa;Genebra;Женева;;Cenevre;日内瓦
 4090;Genève;geneve;8774893;87748939;;;5335;f;CH;f;Europe/Zurich;f;FRHWQ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3121,14 +3121,14 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4093;Logras;logras;8774947;87749473;46.180598;5.918237;;f;FR;f;Europe/Paris;t;FRHWT;;t;;f;8703819;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4094;Sauverny;sauverny;8774949;87749499;46.3166670000;6.1166670000;;f;FR;f;Europe/Paris;t;FRHWU;;t;;f;8704461;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4095;Villemotier;villemotier;8774952;;46.34585743182882;5.320644378662109;;f;FR;f;Europe/Paris;t;FRHWV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4100;Sisteron;sisteron;8775120;87751206;44.19023588306013;5.946521759033203;;f;FR;f;Europe/Paris;t;FRHXE;;t;;f;8704503;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;シストロン;;;;Систерон;;;西斯特龙
+4100;Sisteron;sisteron;8775120;87751206;44.19023588306013;5.946521759033203;;f;FR;f;Europe/Paris;t;FRHXE;;t;;f;8704503;f;;f;;f;;f;;;f;;f;8700333;f;;f;f;;;;;;;;;;;シストロン;;;;Систерон;;;西斯特龙
 4102;Les Mées;les-mees;8775124;87751248;44.0333330000;5.9833330000;;f;FR;f;Europe/Paris;t;FRHXH;;t;;f;8704212;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4104;La Brillanne—Oraison;la-brillanne-oraison;8775127;87751271;43.9248016048157;5.892389416694641;;f;FR;f;Europe/Paris;t;FRHXJ;;t;;f;8703546;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4104;La Brillanne—Oraison;la-brillanne-oraison;8775127;87751271;43.9248016048157;5.892389416694641;;f;FR;f;Europe/Paris;t;FRHXJ;;t;;f;8703546;f;;f;;f;;f;;;f;;f;8700339;f;;f;f;;;;;;;;;;;;;;;;;;
 4105;Volx;volx;8775131;87751313;43.871404;5.852678;;f;FR;f;Europe/Paris;t;FRHXL;;t;;f;8704901;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4106;Manosque—Gréoux-les-Bains;manosque-greoux-les-bains;8775132;87751321;43.823069;5.793394;;f;FR;f;Europe/Paris;t;FRHXM;;t;;f;8703899;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+4106;Manosque—Gréoux-les-Bains;manosque-greoux-les-bains;8775132;87751321;43.823069;5.793394;;f;FR;f;Europe/Paris;t;FRHXM;;t;;f;8703899;f;;f;;f;;f;;;f;;f;8700338;f;;f;t;;;;;;;;;;;;;;;;;;
 4107;Pertuis;pertuis;8775136;87751362;43.684562664658024;5.503715872764587;;f;FR;f;Europe/Paris;t;FRHXN;PER;t;;f;8704205;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4108;Meyrargues;meyrargues;8775137;87751370;43.644025847699496;5.53959846496582;;f;FR;f;Europe/Paris;t;FRHXO;;t;;f;8703987;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4109;Gardanne;gardanne;8775142;87751420;43.45598748024226;5.463294982910156;;f;FR;f;Europe/Paris;t;FRHXP;GDN;t;;f;8700345;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4109;Gardanne;gardanne;8775142;87751420;43.45598748024226;5.463294982910156;;f;FR;f;Europe/Paris;t;FRHXP;GDN;t;;f;8700345;f;;f;;f;;f;;;f;;f;8700336;f;;f;f;;;;;;;;;;;;;;;;;;
 4110;Simiane;simiane;8775143;87751438;43.434597593834624;5.426044464111328;;f;FR;f;Europe/Paris;t;FRHXQ;SIE;t;;f;8704500;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4111;Malijai;malijai;8775145;87751453;44.0500000000;6.0333330000;;f;FR;f;Europe/Paris;t;FRHXR;;t;;f;8703893;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4112;Mallemoisson;mallemoisson;8775146;87751461;44.0500000000;6.1333330000;;f;FR;f;Europe/Paris;t;FRHXS;;t;;f;8703894;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3138,37 +3138,37 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4120;St-Marcel;st-marcel;8775170;87751701;43.288372;5.467086;;f;FR;f;Europe/Paris;t;FRHYA;;t;;f;8704608;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4121;La Pomme;la-pomme;8775171;87751719;43.2898660000;5.4415260000;;f;FR;f;Europe/Paris;t;FRHYB;;t;;f;8703595;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4122;La Penne-sur-Huveaune;la-penne-sur-huveaune;8775174;87751743;43.2833330000;5.5166670000;;f;FR;f;Europe/Paris;t;FRHYC;;t;;f;8703592;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4123;Aubagne;aubagne;8775175;87751750;43.29601149887667;5.566506385803223;;f;FR;f;Europe/Paris;t;FRHYD;;t;;f;8700491;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;オーバーニュ;;;;Обань;;;欧巴涅
-4124;Cassis;cassis;8775177;87751776;43.234139318691895;5.553165078163147;;f;FR;f;Europe/Paris;t;FRHYE;;t;;f;8702304;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4123;Aubagne;aubagne;8775175;87751750;43.29601149887667;5.566506385803223;;f;FR;f;Europe/Paris;t;FRHYD;;t;;f;8700491;f;;f;;f;;f;;;f;;f;8700477;f;;f;t;;;;;;;;;;;オーバーニュ;;;;Обань;;;欧巴涅
+4124;Cassis;cassis;8775177;87751776;43.234139318691895;5.553165078163147;;f;FR;f;Europe/Paris;t;FRHYE;;t;;f;8702304;f;;f;;f;;f;;;f;;f;8700478;f;;f;f;;;;;;;;;;;;;;;;;;
 4125;Septèmes;septemes;8775180;87751800;43.4000000000;5.3666670000;;f;FR;f;Europe/Paris;t;FRHYF;SEP;t;;f;8704480;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4127;Ste-Marthe-en-Provence;ste-marthe-en-provence;8775184;87751842;43.338991;5.391738;;f;FR;f;Europe/Paris;t;FRHYH;SAH;t;;f;8704676;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4128;St-Chamas;st-chamas;8775320;87753202;43.5500000000;5.0333330000;;f;FR;f;Europe/Paris;t;FRHYK;;t;;f;8701936;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4129;Berre;berre;8775322;87753228;43.4666670000;5.1833330000;;f;FR;f;Europe/Paris;t;FRHYL;;t;;f;8700769;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4130;Rognac;rognac;8775325;87753251;43.48703063650691;5.230897665023804;;f;FR;f;Europe/Paris;t;FRHYM;;t;;f;8701883;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4131;Pas-des-Lanciers;pas-des-lanciers;8775328;87753285;43.40964615745079;5.254061222076416;;f;FR;f;Europe/Paris;t;FRHYO;;t;;f;8701791;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4132;Istres;istres;8775341;87753418;43.51539310595615;4.980272054672241;;f;FR;f;Europe/Paris;t;FRHYP;;t;;f;8700554;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;イストル;;;;Истр;;;伊斯特爾
+4132;Istres;istres;8775341;87753418;43.51539310595615;4.980272054672241;;f;FR;f;Europe/Paris;t;FRHYP;;t;;f;8700554;f;;f;;f;;f;;;f;;f;8700161;f;;f;f;;;;;;;;;;;イストル;;;;Истр;;;伊斯特爾
 4133;Rassuen;rassuen;8775342;87753426;43.496662;4.972823;;f;FR;f;Europe/Paris;t;FRHYQ;;t;;f;8701899;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4134;Fos-sur-Mer;fos-sur-mer;8775344;87753442;43.4377380000;4.9445670000;;f;FR;f;Europe/Paris;t;FRHYR;;t;;f;8701150;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;フォス＝シュル＝メール;;;;;;;濱海福斯
 4135;Croix-Sainte;croix-sainte;8775349;87753491;43.409071;5.019486;;f;FR;f;Europe/Paris;t;FRHYS;;t;;f;8700988;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4136;Martigues;martigues;8775350;87753509;43.39282424202957;5.0255584716796875;;f;FR;f;Europe/Paris;t;FRHYT;;t;;f;8701583;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;マルティーグ;;;;Мартиг;;;马尔蒂盖
+4136;Martigues;martigues;8775350;87753509;43.39282424202957;5.0255584716796875;;f;FR;f;Europe/Paris;t;FRHYT;;t;;f;8701583;f;;f;;f;;f;;;f;;f;8700181;f;;f;f;;;;;;;;;;;マルティーグ;;;;Мартиг;;;马尔蒂盖
 4138;La Couronne—Carro;la-couronne-carro;8775354;87753541;43.339971;5.051712;;f;FR;f;Europe/Paris;t;FRHYV;;t;;f;8700845;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4139;Sausset-les-Pins;sausset-les-pins;8775355;87753558;43.33291966770801;5.110112428665161;;f;FR;f;Europe/Paris;t;FRHYW;;t;;f;8702065;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4140;Carry-le-Rouet;carry-le-rouet;8775356;87753566;43.33663422274022;5.153660774230957;;f;FR;f;Europe/Paris;t;FRHYX;;t;;f;8700953;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Карри-ле-Руэ;;;卡里勒鲁埃
 4141;La Redonne—Ensuès;la-redonne-ensues;8775357;87753574;43.3500000000;5.2000000000;;f;FR;f;Europe/Paris;t;FRHYY;;t;;f;8701858;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4142;Niolon;niolon;8775358;87753582;43.340123;5.256891;;f;FR;f;Europe/Paris;t;FRHYZ;;t;;f;8701668;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4143;Arles;arles;8775365;87753657;43.68486524901543;4.632432460784912;;f;FR;f;Europe/Paris;t;FRHZA;ARS;t;;f;8700139;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アルル;아를;;;Арль;;;阿爾勒
+4143;Arles;arles;8775365;87753657;43.68486524901543;4.632432460784912;;f;FR;f;Europe/Paris;t;FRHZA;ARS;t;;f;8700139;f;;f;;f;;f;;;f;;f;8700274;f;;f;t;;;;;;;;;;;アルル;아를;;;Арль;;;阿爾勒
 4144;Orgon;orgon;8775370;87753707;43.7833330000;5.0333330000;;f;FR;f;Europe/Paris;t;FRHZC;;t;;f;8701718;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4145;Sénas;senas;8775371;87753715;43.7408093440164;5.073237419128417;;f;FR;f;Europe/Paris;t;FRHZD;;t;;f;8702009;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4146;Lamanon;lamanon;8775373;87753731;43.7000000000;5.0833330000;;f;FR;f;Europe/Paris;t;FRHZE;;t;;f;8701414;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4147;Salon;salon;8775376;87753764;43.63901020178748;5.088493824005127;;f;FR;f;Europe/Paris;t;FRHZF;;t;;f;8700544;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4149;St-Cyr—Les Lecques—La Cadière;st-cyr-les-lecques-la-cadiere;8775521;87755215;43.185428;5.7037;;f;FR;f;Europe/Paris;t;FRHZI;;t;;f;8704544;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4150;Ollioules—Sanary-sur-Mer;ollioules-sanary-sur-mer;8775523;87755231;43.122539;5.824992;;f;FR;f;Europe/Paris;t;FRHZJ;;t;;f;8704147;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4151;Hazebrouck;hazebrouck;8728630;87286302;50.725005535347094;2.5423479080200195;;f;FR;f;Europe/Paris;t;FRHZK;HZK;t;;f;8700076;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;Hazebroek;;;;アーズブルック;;;;Азбрук;;;阿兹布鲁克
+4147;Salon;salon;8775376;87753764;43.63901020178748;5.088493824005127;;f;FR;f;Europe/Paris;t;FRHZF;;t;;f;8700544;f;;f;;f;;f;;;f;;f;8700151;f;;f;t;;;;;;;;;;;;;;;;;;
+4149;St-Cyr—Les Lecques—La Cadière;st-cyr-les-lecques-la-cadiere;8775521;87755215;43.185428;5.7037;;f;FR;f;Europe/Paris;t;FRHZI;;t;;f;8704544;f;;f;;f;;f;;;f;;f;8700481;f;;f;f;;;;;;;;;;;;;;;;;;
+4150;Ollioules—Sanary-sur-Mer;ollioules-sanary-sur-mer;8775523;87755231;43.122539;5.824992;;f;FR;f;Europe/Paris;t;FRHZJ;;t;;f;8704147;f;;f;;f;;f;;;f;;f;8700482;f;;f;f;;;;;;;;;;;;;;;;;;
+4151;Hazebrouck;hazebrouck;8728630;87286302;50.725005535347094;2.5423479080200195;;f;FR;f;Europe/Paris;t;FRHZK;HZK;t;;f;8700076;f;;f;;f;;f;;;f;;f;8700091;f;;f;t;;;;;;;Hazebroek;;;;アーズブルック;;;;Азбрук;;;阿兹布鲁克
 4153;La Garde;la-garde;8775530;87755306;43.11874705192281;6.010036468505859;;f;FR;f;Europe/Paris;t;FRHZM;;t;;f;8703577;f;;f;;f;8775530;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4154;Solliès-Pont;sollies-pont;8775533;87755330;43.190777;6.046414;;f;FR;f;Europe/Paris;t;FRHZN;;t;;f;8702040;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4155;Cuers—Pierrefeu;cuers-pierrefeu;8775535;87755355;43.236451;6.085706;;f;FR;f;Europe/Paris;t;FRHZO;;t;;f;8700934;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4156;Puget-Ville;puget-ville;8775536;87755363;43.2833330000;6.1333330000;;f;FR;f;Europe/Paris;t;FRHZP;;t;;f;8701821;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4157;Carnoules;carnoules;8775537;87755371;43.297456085075;6.186257600784302;;f;FR;f;Europe/Paris;t;FRHZQ;;t;;f;8700915;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4157;Carnoules;carnoules;8775537;87755371;43.297456085075;6.186257600784302;;f;FR;f;Europe/Paris;t;FRHZQ;;t;;f;8700915;f;;f;;f;;f;;;f;;f;8700282;f;;f;f;;;;;;;;;;;;;;;;;;
 4158;Pignans;pignans;8775538;87755389;43.3000000000;6.2166670000;;f;FR;f;Europe/Paris;t;FRHZR;;t;;f;8701762;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4159;Gonfaron;gonfaron;8775539;87755397;43.31715369186969;6.2818729877471915;;f;FR;f;Europe/Paris;t;FRHZS;;t;;f;8701190;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4160;Le Luc-et-le-Cannet;le-luc-et-le-cannet;8775540;87755405;43.39022;6.343103;;f;FR;f;Europe/Paris;t;FRHZT;;t;;f;8701364;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3176,8 +3176,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4163;Villeneuve-Loubet Plage;villeneuve-loubet-plage;8775630;87756304;43.629792;7.13436;;f;FR;f;Europe/Paris;t;FRHZZ;;t;;f;8702188;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4165;Cros-de-Cagnes;cros-de-cagnes;8775633;87756338;43.66044411171091;7.167157530784606;;f;FR;f;Europe/Paris;t;FRIAB;;t;;f;8700847;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4166;St-Laurent-du-Var;st-laurent-du-var;8775634;87756346;43.66239226968641;7.194596529006958;;f;FR;f;Europe/Paris;t;FRIAC;;t;;f;8701995;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4167;Cap-d’Ail;cap-dail;8775639;87756395;43.72056724116208;7.394367456436157;;f;FR;f;Europe/Paris;t;FRIAD;;t;;f;8700829;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Capo d’Aglio;;;;;;;;;;;;
-4168;Cap-Martin—Roquebrune;cap-martin-roquebrune;8775646;87756460;43.76061842574356;7.457351088523865;;f;FR;f;Europe/Paris;t;FRIAE;;t;;f;8700484;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Roccabruna;;;;;;;;;;;;
+4167;Cap-d’Ail;cap-dail;8775639;87756395;43.72056724116208;7.394367456436157;;f;FR;f;Europe/Paris;t;FRIAD;;t;;f;8700829;f;;f;;f;;f;;;f;;f;8700251;f;;f;f;;;;;;Capo d’Aglio;;;;;;;;;;;;
+4168;Cap-Martin—Roquebrune;cap-martin-roquebrune;8775646;87756460;43.76061842574356;7.457351088523865;;f;FR;f;Europe/Paris;t;FRIAE;;t;;f;8700484;f;;f;;f;;f;;;f;;f;8700428;f;;f;f;;;;;;Roccabruna;;;;;;;;;;;;
 4169;Carnoles;carnoles;8775647;87756478;43.76196;7.481551;;f;FR;f;Europe/Paris;t;FRIAF;;t;;f;8700830;f;;f;;f;8775647;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4171;La Trinité-Victor;la-trinite-victor;8775676;87756767;43.742867;7.311484;;f;FR;f;Europe/Paris;t;FRIAI;;t;;f;8703607;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4172;Drap—Cantaron;drap-cantaron;8775677;87756775;43.760297;7.317003;;f;FR;f;Europe/Paris;t;FRIAJ;;t;;f;8703245;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3200,13 +3200,13 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4189;Anthéor—Cap-Roux;antheor-cap-roux;8775756;87757567;43.435076;6.892056;;f;FR;f;Europe/Paris;t;FRIBD;;t;;f;8700636;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4190;Le Trayas;le-trayas;8775757;87757575;43.4666670000;6.9166670000;;f;FR;f;Europe/Paris;t;FRIBE;;t;;f;8702122;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4191;Théoule-sur-Mer;theoule-sur-mer;8775758;87757583;43.513417;6.936831;;f;FR;f;Europe/Paris;t;FRIBF;;t;;f;8702103;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4193;Golfe-Juan—Vallauris;golfe-juan-vallauris;8775764;87757641;43.566238;7.073288;;f;FR;f;Europe/Paris;t;FRIBJ;;t;;f;8700536;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4193;Golfe-Juan—Vallauris;golfe-juan-vallauris;8775764;87757641;43.566238;7.073288;;f;FR;f;Europe/Paris;t;FRIBJ;;t;;f;8700536;f;;f;;f;;f;;;f;;f;8700421;f;;f;f;;;;;;;;;;;;;;;;;;
 4194;Biot;biot;8775769;87757690;43.61088843518391;7.1262967586517325;;f;FR;f;Europe/Paris;t;FRIBK;;t;;f;8700723;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4195;Grasse;grasse;8775772;87757724;43.653861819593324;6.926482915878296;;f;FR;f;Europe/Paris;t;FRIBL;GRA;t;;f;8705486;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;グラース;그라스;;;Грас;;;格拉斯
 4196;Ranguin;ranguin;8775773;87757732;43.569168;6.969309;;f;FR;f;Europe/Paris;t;FRIBM;RGN;t;;f;8704345;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4269;St-Rambert-d’Albon;st-rambert-dalbon;8776110;87761106;45.29780345100183;4.8108744621276855;;f;FR;f;Europe/Paris;t;FRIEO;SRA;t;;f;8700503;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4271;St-Vallier-sur-Rhône;st-vallier-sur-rhone;8776113;87761130;45.186382;4.81455;;f;FR;f;Europe/Paris;t;FRIEQ;SUO;t;;f;8702136;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4272;Tain-L'Hermitage—Tournon;tain-lhermitage-tournon;8776116;87761163;45.072327;4.839756;;f;FR;f;Europe/Paris;t;FRIER;TAI;t;;f;8702111;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4269;St-Rambert-d’Albon;st-rambert-dalbon;8776110;87761106;45.29780345100183;4.8108744621276855;;f;FR;f;Europe/Paris;t;FRIEO;SRA;t;;f;8700503;f;;f;;f;;f;;;f;;f;8700905;f;;f;f;;;;;;;;;;;;;;;;;;
+4271;St-Vallier-sur-Rhône;st-vallier-sur-rhone;8776113;87761130;45.186382;4.81455;;f;FR;f;Europe/Paris;t;FRIEQ;SUO;t;;f;8702136;f;;f;;f;;f;;;f;;f;8700346;f;;f;f;;;;;;;;;;;;;;;;;;
+4272;Tain-L'Hermitage—Tournon;tain-lhermitage-tournon;8776116;87761163;45.072327;4.839756;;f;FR;f;Europe/Paris;t;FRIER;TAI;t;;f;8702111;f;;f;;f;;f;;;f;;f;8700141;f;;f;f;;;;;;;;;;;;;;;;;;
 4273;Étoile;etoile;8776122;87761221;44.8333330000;4.9000000000;;f;FR;f;Europe/Paris;t;FRIEU;;t;;f;8705244;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4274;L’Isle-d’Abeau;lisle-dabeau;8776123;87761239;45.60760551892236;5.219578742980957;;f;FR;f;Europe/Paris;t;FRIEV;ISA;t;;f;8702518;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4275;Loriol;loriol;8776126;87761262;44.75445929546451;4.817150831222533;;f;FR;f;Europe/Paris;t;FRIEW;LOL;t;;f;8701442;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3214,25 +3214,25 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4277;La Voulte Mairie;la-voulte-mairie;8733697;87336974;44.79942362439995;4.781134128570557;5667;f;FR;f;Europe/Paris;t;FRIFA;;t;;f;8705246;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4278;St-Péray;st-peray;8776149;87761494;44.9500000000;4.8333330000;5611;f;FR;f;Europe/Paris;t;FRIFB;;t;;f;8702028;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4279;La Voulte;la-voulte;8776154;;44.799362720814585;4.781134128570557;5667;f;FR;t;Europe/Paris;t;FRIFC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4281;Romans—Bourg-de-Péage;romans-bourg-de-peage;8776165;87761650;45.048875893555234;5.049591064453125;;f;FR;f;Europe/Paris;t;FRIFE;ROM;t;;f;8700414;f;;f;;f;8776165;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+4281;Romans—Bourg-de-Péage;romans-bourg-de-peage;8776165;87761650;45.048875893555234;5.049591064453125;;f;FR;f;Europe/Paris;t;FRIFE;ROM;t;;f;8700414;f;;f;;f;8776165;f;;;f;;f;8700264;f;;f;t;;;;;;;;;;;;;;;;;;
 4282;St-Hilaire—St-Nazaire;st-hilaire-st-nazaire;8776168;87761684;45.071402882128005;5.243820548057556;;f;FR;f;Europe/Paris;t;FRIFF;SHN;t;;f;8704587;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4283;St-Marcellin;st-marcellin;8776171;87761718;45.15087923796671;5.323594808578491;;f;FR;f;Europe/Paris;t;FRIFG;SCI;t;;f;8700482;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4283;St-Marcellin;st-marcellin;8776171;87761718;45.15087923796671;5.323594808578491;;f;FR;f;Europe/Paris;t;FRIFG;SCI;t;;f;8700482;f;;f;;f;;f;;;f;;f;8700405;f;;f;f;;;;;;;;;;;;;;;;;;
 4284;Vinay;vinay;8776172;87761726;45.207924234281286;5.410155057907104;;f;FR;f;Europe/Paris;t;FRIFH;VNA;t;;f;8704882;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4285;Poliénas;polienas;8776174;87761742;45.2500000000;5.4666670000;;f;FR;f;Europe/Paris;t;FRIFI;POS;t;;f;8704249;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4286;Tullins—Fures;tullins-fures;8776175;87761759;45.301408;5.492579;;f;FR;f;Europe/Paris;t;FRIFJ;TLE;t;;f;8704750;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4287;Aouste-sur-Sye;aouste-sur-sye;8776179;87761791;44.7166670000;5.0500000000;;f;FR;f;Europe/Paris;t;FRIFK;;t;;f;8702472;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4288;Saillans;saillans;8776181;87761817;44.69437612444637;5.19402801990509;;f;FR;f;Europe/Paris;t;FRIFL;;t;;f;8702577;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4289;Vercheny;vercheny;8776182;;44.70541866585089;5.2591681480407715;;f;FR;f;Europe/Paris;t;FRIFM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4292;Luc-en-Diois;luc-en-diois;8776187;87761874;44.613720100315994;5.454668998718262;;f;FR;f;Europe/Paris;t;FRIFP;LDE;t;;f;8702527;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4292;Luc-en-Diois;luc-en-diois;8776187;87761874;44.613720100315994;5.454668998718262;;f;FR;f;Europe/Paris;t;FRIFP;LDE;t;;f;8702527;f;;f;;f;;f;;;f;;f;8700195;f;;f;f;;;;;;;;;;;;;;;;;;
 4318;Chorges;chorges;8776342;87763425;44.54584503648685;6.271862983703612;;f;FR;f;Europe/Paris;t;FRIGS;CHO;t;;f;8702494;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4321;Embrun;embrun;8776346;87763466;44.567052084935284;6.496717929840088;;f;FR;f;Europe/Paris;t;FRIGV;EMB;t;;f;8702506;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4325;Montdauphin—Guillestre;montdauphin-guillestre;8776350;87763508;44.67459;6.615512;;f;FR;f;Europe/Paris;t;FRIGZ;MOG;t;;f;8702549;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4328;L’Argentière—Les-Ecrins;largentiere-les-ecrins;8776355;87763557;44.790946;6.556192;;f;FR;f;Europe/Paris;t;FRIHC;LEE;t;;f;8702473;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4334;Serres;serres;8776372;87763722;44.42467016760475;5.718458890914917;5239;f;FR;t;Europe/Paris;t;FRIHI;;t;;f;8704486;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4337;Laragne;laragne;8776375;87763755;44.316513740268704;5.81898808479309;;f;FR;f;Europe/Paris;t;FRIHL;;t;;f;8703653;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4321;Embrun;embrun;8776346;87763466;44.567052084935284;6.496717929840088;;f;FR;f;Europe/Paris;t;FRIGV;EMB;t;;f;8702506;f;;f;;f;;f;;;f;;f;8700198;f;;f;f;;;;;;;;;;;;;;;;;;
+4325;Montdauphin—Guillestre;montdauphin-guillestre;8776350;87763508;44.67459;6.615512;;f;FR;f;Europe/Paris;t;FRIGZ;MOG;t;;f;8702549;f;;f;;f;;f;;;f;;f;8700199;f;;f;f;;;;;;;;;;;;;;;;;;
+4328;L’Argentière—Les-Ecrins;largentiere-les-ecrins;8776355;87763557;44.790946;6.556192;;f;FR;f;Europe/Paris;t;FRIHC;LEE;t;;f;8702473;f;;f;;f;;f;;;f;;f;8700341;f;;f;f;;;;;;;;;;;;;;;;;;
+4334;Serres;serres;8776372;87763722;44.42467016760475;5.718458890914917;5239;f;FR;t;Europe/Paris;t;FRIHI;;t;;f;8704486;f;;f;;f;;f;;;f;;f;8700331;f;;f;f;;;;;;;;;;;;;;;;;;
+4337;Laragne;laragne;8776375;87763755;44.316513740268704;5.81898808479309;;f;FR;f;Europe/Paris;t;FRIHL;;t;;f;8703653;f;;f;;f;;f;;;f;;f;8700332;f;;f;f;;;;;;;;;;;;;;;;;;
 4338;Donzère;donzere;8776429;87764290;44.4500000000;4.7166670000;;f;FR;f;Europe/Paris;t;FRIHM;DOE;t;;f;8701036;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4339;Pierrelatte;pierrelatte;8776430;87764308;44.374733276848254;4.703827500343323;;f;FR;f;Europe/Paris;t;FRIHN;PRL;t;;f;8701764;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4340;Bollène-la-Croisière;bollene-la-croisiere;8776435;87764357;44.271855;4.707884;;f;FR;f;Europe/Paris;t;FRIHO;;t;;f;8700750;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4339;Pierrelatte;pierrelatte;8776430;87764308;44.374733276848254;4.703827500343323;;f;FR;f;Europe/Paris;t;FRIHN;PRL;t;;f;8701764;f;;f;;f;;f;;;f;;f;8700165;f;;f;f;;;;;;;;;;;;;;;;;;
+4340;Bollène-la-Croisière;bollene-la-croisiere;8776435;87764357;44.271855;4.707884;;f;FR;f;Europe/Paris;t;FRIHO;;t;;f;8700750;f;;f;;f;;f;;;f;;f;8700441;f;;f;f;;;;;;;;;;;;;;;;;;
 4341;Le Teil Sablons;le-teil-sablons;8742080;87420802;44.5500000000;4.6833330000;;f;FR;f;Europe/Paris;t;FRIHP;;t;;f;8705643;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4343;Le Teil Melas;le-teil-melas;8742081;87420810;44.5500000000;4.6833330000;;f;FR;f;Europe/Paris;t;FRIHT;;t;;f;8705644;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4344;Vals-les-Bains—Labegude;vals-les-bains-labegude;8776477;;;;;f;FR;f;Europe/Paris;f;FRIHV;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3245,7 +3245,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4354;Gadagne;gadagne;8776544;87765446;43.9333330000;4.9333330000;;f;FR;f;Europe/Paris;t;FRIIH;;t;;f;8701182;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4355;Le Thor;le-thor;8776545;87765453;43.92642821158812;4.996311664581299;;f;FR;f;Europe/Paris;t;FRIII;;t;;f;8702126;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4356;L’Isle-sur-Sorgue—Fontaine-de-Vaucluse;lisle-sur-sorgue-fontaine-de-vaucluse;8776547;87765479;43.917276;5.047335;;f;FR;f;Europe/Paris;t;FRIIJ;;t;;f;8701311;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4357;Cavaillon;cavaillon;8776550;87765503;43.83474347862773;5.043904781341553;;f;FR;f;Europe/Paris;t;FRIIK;;t;;f;8700888;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;カヴァイヨン;;;;Кавайон;;;卡瓦永
+4357;Cavaillon;cavaillon;8776550;87765503;43.83474347862773;5.043904781341553;;f;FR;f;Europe/Paris;t;FRIIK;;t;;f;8700888;f;;f;;f;;f;;;f;;f;8700142;f;;f;f;;;;;;;;;;;カヴァイヨン;;;;Кавайон;;;卡瓦永
 4359;Montoison;montoison;8776952;87769521;44.7833330000;4.9166670000;;f;FR;f;Europe/Paris;t;FRIIT;;t;;f;8705247;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4360;Allex;allex;8776955;87769554;44.7666670000;4.9166670000;;f;FR;f;Europe/Paris;t;FRIIU;;t;;f;8705323;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4361;Grane;grane;8776957;87769570;44.7333330000;4.9166670000;;f;FR;f;Europe/Paris;t;FRIIV;;t;;f;8705248;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3256,10 +3256,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4367;Baillargues;baillargues;8777345;87773457;43.65331067513575;4.007112979888916;;f;FR;f;Europe/Paris;t;FRIJF;BGU;t;;f;8700735;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4368;St-Aunès;st-aunes;8777346;87773465;43.6333330000;3.9666670000;;f;FR;f;Europe/Paris;t;FRIJG;;t;;f;8700644;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4369;Les Mazes-le-Crès;les-mazes-le-cres;8777347;;43.63918102014533;3.9388400316238403;;f;FR;f;Europe/Paris;t;FRIJH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4370;Villeneuve-lès-Maguelonne;villeneuve-les-maguelonne;8777351;87773515;43.543729;3.849819;;f;FR;f;Europe/Paris;t;FRIJI;VLM;t;;f;8702197;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4371;Vic-la-Gardiole—Mireval;vic-la-gardiole-mireval;8777353;87773531;43.500599;3.799335;;f;FR;f;Europe/Paris;t;FRIJJ;VIC;t;;f;8702159;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4372;Frontignan;frontignan;8777355;87773556;43.447279764862536;3.7594485282897945;;f;FR;f;Europe/Paris;t;FRIJK;FRN;t;;f;8701164;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4373;Beaucaire;beaucaire;8777502;87775023;43.8070310000;4.6438690000;;f;FR;f;Europe/Paris;t;FRIJL;;t;;f;8700696;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ボーケール;;;;Бокер;;;博凯尔
+4370;Villeneuve-lès-Maguelonne;villeneuve-les-maguelonne;8777351;87773515;43.543729;3.849819;;f;FR;f;Europe/Paris;t;FRIJI;VLM;t;;f;8702197;f;;f;;f;;f;;;f;;f;8700560;f;;f;f;;;;;;;;;;;;;;;;;;
+4371;Vic-la-Gardiole—Mireval;vic-la-gardiole-mireval;8777353;87773531;43.500599;3.799335;;f;FR;f;Europe/Paris;t;FRIJJ;VIC;t;;f;8702159;f;;f;;f;;f;;;f;;f;8700570;f;;f;f;;;;;;;;;;;;;;;;;;
+4372;Frontignan;frontignan;8777355;87773556;43.447279764862536;3.7594485282897945;;f;FR;f;Europe/Paris;t;FRIJK;FRN;t;;f;8701164;f;;f;;f;;f;;;f;;f;8700286;f;;f;f;;;;;;;;;;;;;;;;;;
+4373;Beaucaire;beaucaire;8777502;87775023;43.8070310000;4.6438690000;;f;FR;f;Europe/Paris;t;FRIJL;;t;;f;8700696;f;;f;;f;;f;;;f;;f;8700530;f;;f;f;;;;;;;;;;;ボーケール;;;;Бокер;;;博凯尔
 4374;Jonquières-et-St-Vincent;jonquieres-et-st-vincent;8777504;87775049;43.79658117994277;4.53311026096344;;f;FR;f;Europe/Paris;t;FRIJN;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4375;Manduel—Redessan;manduel-redessan;8777506;87775064;43.826602;4.478947;;f;FR;f;Europe/Paris;t;FRIJP;;t;;f;8701501;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4376;Milhaud;milhaud;8777509;87775098;43.7833330000;4.3000000000;;f;FR;f;Europe/Paris;t;FRIJQ;;t;;f;8701520;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3267,12 +3267,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4378;Vergèze-Codognan;vergeze-codognan;8777511;87775114;43.739793;4.218961;;f;FR;f;Europe/Paris;t;FRIJS;VZC;t;;f;8702590;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4379;Gallargues;gallargues;8777513;87775130;43.7166670000;4.1666670000;;f;FR;f;Europe/Paris;t;FRIJT;;t;;f;8701195;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4380;Chasseradès;chasserades;8777514;87775148;44.5500000000;3.8166670000;;f;FR;f;Europe/Paris;t;FRIJU;;t;;f;8703055;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4381;Villefort;villefort;8777519;87775197;44.439369;3.924061;;f;FR;f;Europe/Paris;t;FRIJW;VLF;t;;f;8704854;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4383;Génolhac;genolhac;8777521;87775213;44.347146051276496;3.951687812805176;;f;FR;f;Europe/Paris;t;FRIJY;GNC;t;;f;8703383;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4384;Chamborigaud;chamborigaud;8777522;87775221;44.3000000000;3.9833330000;;f;FR;f;Europe/Paris;t;FRIJZ;;t;;f;8703020;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4385;Ste-Cécile-d’Andorge;ste-cecile-dandorge;8777523;87775239;44.255432;3.975856;;f;FR;f;Europe/Paris;t;FRIKA;;t;;f;8704669;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4381;Villefort;villefort;8777519;87775197;44.439369;3.924061;;f;FR;f;Europe/Paris;t;FRIJW;VLF;t;;f;8704854;f;;f;;f;;f;;;f;;f;8700229;f;;f;f;;;;;;;;;;;;;;;;;;
+4383;Génolhac;genolhac;8777521;87775213;44.347146051276496;3.951687812805176;;f;FR;f;Europe/Paris;t;FRIJY;GNC;t;;f;8703383;f;;f;;f;;f;;;f;;f;8700233;f;;f;f;;;;;;;;;;;;;;;;;;
+4384;Chamborigaud;chamborigaud;8777522;87775221;44.3000000000;3.9833330000;;f;FR;f;Europe/Paris;t;FRIJZ;;t;;f;8703020;f;;f;;f;;f;;;f;;f;8700235;f;;f;f;;;;;;;;;;;;;;;;;;
+4385;Ste-Cécile-d’Andorge;ste-cecile-dandorge;8777523;87775239;44.255432;3.975856;;f;FR;f;Europe/Paris;t;FRIKA;;t;;f;8704669;f;;f;;f;;f;;;f;;f;8700236;f;;f;f;;;;;;;;;;;;;;;;;;
 4386;La Levade;la-levade;8777524;87775247;44.238209;3.991462;;f;FR;f;Europe/Paris;t;FRIKB;;t;;f;8703584;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4387;La Grand-Combe La Pise;la-grand-combe-la-pise;8777525;87775254;44.209821;4.032956;;f;FR;f;Europe/Paris;t;FRIKC;LGC;t;;f;8703428;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4387;La Grand-Combe La Pise;la-grand-combe-la-pise;8777525;87775254;44.209821;4.032956;;f;FR;f;Europe/Paris;t;FRIKC;LGC;t;;f;8703428;f;;f;;f;;f;;;f;;f;8700238;f;;f;f;;;;;;;;;;;;;;;;;;
 4389;Agen Payou;agen-payou;8746554;87465542;44.2000000000;0.6333330000;17433;f;FR;f;Europe/Paris;t;FRIKH;;t;;f;8706315;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4390;Boucoiran;boucoiran;8777534;87775346;43.9833330000;4.1833330000;;f;FR;f;Europe/Paris;t;FRIKI;;t;;f;8702878;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4391;Nozières—Brignon;nozieres-brignon;8777535;87775353;43.975948;4.20732;;f;FR;f;Europe/Paris;t;FRIKJ;;t;;f;8704135;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3298,8 +3298,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4411;Villedieu-les-Poêles Centre;villedieu-les-poeles-centre;8777968;87779686;48.837171;-1.223521;5658;f;FR;f;Europe/Paris;t;FRILI;;t;;f;8704853;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4412;Lamontjoie;lamontjoie;8746471;87464719;44.0666670000;0.5333330000;5006;f;FR;f;Europe/Paris;t;FRILJ;;t;;f;8706388;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4413;Ligardes;ligardes;8746472;87464727;44.0333330000;0.5000000000;5006;f;FR;f;Europe/Paris;t;FRILK;;t;;f;8706389;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4415;Port-la-Nouvelle;port-la-nouvelle;8778106;87781062;43.01992919644896;3.0388355255126953;;f;FR;f;Europe/Paris;t;FRILP;PLN;t;;f;8700490;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4416;Leucate—La-Franqui;leucate-la-franqui;8778108;87781088;42.932777;3.01286;;f;FR;f;Europe/Paris;t;FRILQ;LEU;t;;f;8701462;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4415;Port-la-Nouvelle;port-la-nouvelle;8778106;87781062;43.01992919644896;3.0388355255126953;;f;FR;f;Europe/Paris;t;FRILP;PLN;t;;f;8700490;f;;f;;f;;f;;;f;;f;8700454;f;;f;f;;;;;;;;;;;;;;;;;;
+4416;Leucate—La-Franqui;leucate-la-franqui;8778108;87781088;42.932777;3.01286;;f;FR;f;Europe/Paris;t;FRILQ;LEU;t;;f;8701462;f;;f;;f;;f;;;f;;f;8700453;f;;f;f;;;;;;;;;;;;;;;;;;
 4417;Coursan;coursan;8778116;87781161;43.2333330000;3.0666670000;;f;FR;f;Europe/Paris;t;FRILR;;t;;f;8700916;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4418;Nissan;nissan;8778117;87781179;43.2833330000;3.1333330000;;f;FR;f;Europe/Paris;t;FRILS;;t;;f;8701655;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4419;Vias;vias;8778126;87781260;43.315686155295666;3.425363302230835;;f;FR;f;Europe/Paris;t;FRILU;;t;;f;8702176;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3310,8 +3310,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4424;Ceilhes—Roqueredonde;ceilhes-roqueredonde;8778154;87781542;43.812219;3.155114;;f;FR;f;Europe/Paris;t;FRIMC;COQ;t;;f;8702994;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4425;Les Cabrils;les-cabrils;8778155;87781559;43.779705;3.186082;;f;FR;f;Europe/Paris;t;FRIMD;;t;;f;8703760;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4427;Lunas;lunas;8778157;87781575;43.7000000000;3.2000000000;;f;FR;f;Europe/Paris;t;FRIMF;;t;;f;8703859;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4428;Le Bousquet-d’Orb;le-bousquet-dorb;8778158;87781583;43.7000000000;3.1666670000;;f;FR;f;Europe/Paris;t;FRIMG;LBD;t;;f;8703686;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4429;Bédarieux;bedarieux;8778160;87781609;43.60868613426842;3.1495678424835205;;f;FR;f;Europe/Paris;t;FRIMH;BED;t;;f;8700410;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;Bedarius;Бедарье;;;贝达里约
+4428;Le Bousquet-d’Orb;le-bousquet-dorb;8778158;87781583;43.7000000000;3.1666670000;;f;FR;f;Europe/Paris;t;FRIMG;LBD;t;;f;8703686;f;;f;;f;;f;;;f;;f;8700137;f;;f;f;;;;;;;;;;;;;;;;;;
+4429;Bédarieux;bedarieux;8778160;87781609;43.60868613426842;3.1495678424835205;;f;FR;f;Europe/Paris;t;FRIMH;BED;t;;f;8700410;f;;f;;f;;f;;;f;;f;8700138;f;;f;f;;;;;;;;;;;;;;Bedarius;Бедарье;;;贝达里约
 4430;Magalas;magalas;8778166;87781666;43.4666670000;3.2166670000;;f;FR;f;Europe/Paris;t;FRIMK;MGA;t;;f;8703875;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4431;St-Pons;st-pons;8778170;87781708;43.5166670000;3.5166670000;;f;FR;f;Europe/Paris;t;FRIMM;;t;;f;8706005;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4432;Gondrin;gondrin;8746475;87464750;43.8833330000;0.2500000000;5006;f;FR;f;Europe/Paris;t;FRIMO;;t;;f;8706392;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3320,21 +3320,21 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4435;Segos;segos;8746485;87464859;43.6333330000;-0.2500000000;5006;f;FR;f;Europe/Paris;t;FRIMT;;t;;f;8706395;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4436;Talizat;talizat;8778315;87783159;45.110774;3.027315;;f;FR;f;Europe/Paris;t;FRIMU;;t;;f;8704691;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4437;Andelat;andelat;8778316;87783167;45.0666670000;3.0666670000;;f;FR;f;Europe/Paris;t;FRIMV;;t;;f;8702656;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4438;St-Flour—Chaudes-Aigues;st-flour-chaudes-aigues;8778317;87783175;45.035219;3.105044;;f;FR;f;Europe/Paris;t;FRIMW;SFC;t;;f;8704563;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4438;St-Flour—Chaudes-Aigues;st-flour-chaudes-aigues;8778317;87783175;45.035219;3.105044;;f;FR;f;Europe/Paris;t;FRIMW;SFC;t;;f;8704563;f;;f;;f;;f;;;f;;f;8700126;f;;f;f;;;;;;;;;;;;;;;;;;
 4439;St-Agnet;st-agnet;8746478;87464784;43.6166670000;-0.2666670000;5006;f;FR;f;Europe/Paris;t;FRIMX;;t;;f;8706396;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4440;Sarron;sarron;8746486;87464867;43.59183023057016;-0.2738642692565918;5006;f;FR;f;Europe/Paris;t;FRIMY;;t;;f;8706397;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4441;Garlin;garlin;8746487;87464875;43.5666670000;-0.2500000000;5006;f;FR;f;Europe/Paris;t;FRIMZ;;t;;f;8706398;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4443;St-Chély-d’Apcher;st-chely-dapcher;8778324;87783241;44.80178358882254;3.270707130432129;;f;FR;f;Europe/Paris;t;FRINB;SYH;t;;f;8704539;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4444;Aumont-Aubrac;aumont-aubrac;8778326;87783266;44.7181935085656;3.283490538597107;;f;FR;f;Europe/Paris;t;FRINC;AAU;t;;f;8702720;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4445;Marvejols;marvejols;8778328;87783282;44.544667490121476;3.281092643737793;;f;FR;f;Europe/Paris;t;FRINE;MVJ;t;;f;8703932;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4443;St-Chély-d’Apcher;st-chely-dapcher;8778324;87783241;44.80178358882254;3.270707130432129;;f;FR;f;Europe/Paris;t;FRINB;SYH;t;;f;8704539;f;;f;;f;;f;;;f;;f;8700127;f;;f;f;;;;;;;;;;;;;;;;;;
+4444;Aumont-Aubrac;aumont-aubrac;8778326;87783266;44.7181935085656;3.283490538597107;;f;FR;f;Europe/Paris;t;FRINC;AAU;t;;f;8702720;f;;f;;f;;f;;;f;;f;8700120;f;;f;f;;;;;;;;;;;;;;;;;;
+4445;Marvejols;marvejols;8778328;87783282;44.544667490121476;3.281092643737793;;f;FR;f;Europe/Paris;t;FRINE;MVJ;t;;f;8703932;f;;f;;f;;f;;;f;;f;8700401;f;;f;f;;;;;;;;;;;;;;;;;;
 4446;Chirac;chirac;8778329;87783290;44.5333330000;3.2666670000;;f;FR;f;Europe/Paris;t;FRINF;;t;;f;8703100;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4447;Banassac—La Canourgue;banassac-la-canourgue;8778332;87783324;44.447585;3.196132;;f;FR;f;Europe/Paris;t;FRINH;BAA;t;;f;8702766;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4447;Banassac—La Canourgue;banassac-la-canourgue;8778332;87783324;44.447585;3.196132;;f;FR;f;Europe/Paris;t;FRINH;BAA;t;;f;8702766;f;;f;;f;;f;;;f;;f;8700133;f;;f;f;;;;;;;;;;;;;;;;;;
 4448;Campagnac—St-Geniez;campagnac-st-geniez;8778334;87783340;44.421957;3.0664;;f;FR;f;Europe/Paris;t;FRINJ;CNT;t;;f;8702960;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4449;Engayresque;engayresque;8778338;87783381;44.250587;3.064746;;f;FR;f;Europe/Paris;t;FRINK;;t;;f;8703263;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4450;Aguessac;aguessac;8778339;87783399;44.1500000000;3.1000000000;;f;FR;f;Europe/Paris;t;FRINL;;t;;f;8702623;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4451;St-Georges-de-Luzençon;st-georges-de-luzencon;8778342;87783423;44.0666670000;2.9833330000;;f;FR;f;Europe/Paris;t;FRINM;SDU;t;;f;8704570;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4452;St-Rome-de-Cernon;st-rome-de-cernon;8778343;87783431;44.0166670000;2.9666670000;;f;FR;f;Europe/Paris;t;FRINN;SDO;t;;f;8704650;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4453;Tournemire—Roquefort;tournemire-roquefort;8778345;87783456;43.969899;3.016501;;f;FR;f;Europe/Paris;t;FRINO;TEO;t;;f;8704735;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4453;Tournemire—Roquefort;tournemire-roquefort;8778345;87783456;43.969899;3.016501;;f;FR;f;Europe/Paris;t;FRINO;TEO;t;;f;8704735;f;;f;;f;;f;;;f;;f;8700136;f;;f;f;;;;;;;;;;;;;;;;;;
 4454;St-Affrique;st-affrique;8778348;87783480;43.956765352566826;2.881792187690735;;f;FR;f;Europe/Paris;t;FRINP;;t;;f;8704965;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4455;Les Salèlles;les-salelles;8778351;87783514;44.4833330000;3.2833330000;;f;FR;f;Europe/Paris;t;FRINQ;;t;;f;8703784;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4456;Chanac;chanac;8778353;87783530;44.4666670000;3.3333330000;;f;FR;f;Europe/Paris;t;FRINR;;t;;f;8703034;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3347,9 +3347,9 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4466;Bertholène;bertholene;8778375;87783753;44.3833330000;2.7833330000;;f;FR;f;Europe/Paris;t;FRIOB;;t;;f;8702819;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4467;Laissac;laissac;8778376;87783761;44.3833330000;2.8333330000;;f;FR;f;Europe/Paris;t;FRIOC;;t;;f;8703630;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4468;Recoules;recoules;8778379;87783795;44.3333330000;2.9666670000;;f;FR;f;Europe/Paris;t;FRIOD;;t;;f;8704348;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4469;Salses;salses;8778415;87784157;42.83551848686106;2.9174870252609253;;f;FR;f;Europe/Paris;t;FRIOE;SAL;t;;f;8701991;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4470;Rivesaltes;rivesaltes;8778417;87784173;42.76639100482349;2.8677964210510254;;f;FR;f;Europe/Paris;t;FRIOF;RVT;t;;f;8700489;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;リヴサルト;;;;;;;里韦萨尔泰
-4471;Elne;elne;8778420;87784207;42.597213117611076;2.963411808013916;;f;FR;f;Europe/Paris;t;FRIOG;ELN;t;;f;8701064;f;;f;;f;;f;;;f;;f;;f;;f;f;;Elna;Elna;Elna;;Elna;;;;;エルヌ;;Elna;;;;;埃尔恩
+4469;Salses;salses;8778415;87784157;42.83551848686106;2.9174870252609253;;f;FR;f;Europe/Paris;t;FRIOE;SAL;t;;f;8701991;f;;f;;f;;f;;;f;;f;8700452;f;;f;f;;;;;;;;;;;;;;;;;;
+4470;Rivesaltes;rivesaltes;8778417;87784173;42.76639100482349;2.8677964210510254;;f;FR;f;Europe/Paris;t;FRIOF;RVT;t;;f;8700489;f;;f;;f;;f;;;f;;f;8700451;f;;f;f;;;;;;;;;;;リヴサルト;;;;;;;里韦萨尔泰
+4471;Elne;elne;8778420;87784207;42.597213117611076;2.963411808013916;;f;FR;f;Europe/Paris;t;FRIOG;ELN;t;;f;8701064;f;;f;;f;;f;;;f;;f;8700449;f;;f;f;;Elna;Elna;Elna;;Elna;;;;;エルヌ;;Elna;;;;;埃尔恩
 4472;Port-Vendres;port-vendres;8778427;;42.51356654935007;3.1025648117065425;;f;FR;f;Europe/Paris;f;FRIOH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4473;Lalonquette;lalonquette;8746489;87464891;43.4833330000;-0.3166670000;5006;f;FR;f;Europe/Paris;t;FRIOI;;t;;f;8706400;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4474;Auriac;auriac;8746490;87464909;43.474036;-0.323638;5006;f;FR;f;Europe/Paris;t;FRIOK;;t;;f;8706401;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3389,8 +3389,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4519;Truyes;truyes;8793095;87930958;47.269371;0.831753;;f;FR;f;Europe/Paris;t;FRIRK;;t;;f;8704749;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4522;Villefranche-de-Rouergue Liberté;villefranche-de-rouergue-liberte;8713877;87138776;44.354322;2.038339;;f;FR;f;Europe/Paris;t;FRIRX;;t;;f;8706491;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4523;St-Nic—Pentrez;st-nic-pentrez;8798848;87988485;48.2000000000;-4.2833330000;;f;FR;f;Europe/Paris;t;FRIRY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4526;Laroche-Migennes;laroche-migennes;8768326;87683268;47.961012484989375;3.513007164001465;9150;f;FR;t;Europe/Paris;t;FRISI;LAR;t;;f;8700092;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4528;St-Florentin—Vergigny;st-florentin-vergigny;8768331;87683318;47.980625;3.731152;5193;f;FR;t;Europe/Paris;t;FRISK;;t;;f;8701958;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4526;Laroche-Migennes;laroche-migennes;8768326;87683268;47.961012484989375;3.513007164001465;9150;f;FR;t;Europe/Paris;t;FRISI;LAR;t;;f;8700092;f;;f;;f;;f;;;f;;f;8700131;f;;f;t;;;;;;;;;;;;;;;;;;
+4528;St-Florentin—Vergigny;st-florentin-vergigny;8768331;87683318;47.980625;3.731152;5193;f;FR;t;Europe/Paris;t;FRISK;;t;;f;8701958;f;;f;;f;;f;;;f;;f;8700358;f;;f;f;;;;;;;;;;;;;;;;;;
 4529;Neuvy-Sautour;neuvy-sautour;;;48.0333330000;3.8000000000;;t;FR;f;Europe/Paris;f;FRISL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4532;La Pouge;la-pouge;8715784;87157842;45.9833330000;1.9500000000;;f;FR;f;Europe/Paris;t;FRJAB;;t;;f;8703596;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4533;Le Verdeau;le-verdeau;8715794;87157941;45.846577;1.387871;;f;FR;f;Europe/Paris;t;FRJAC;;t;;f;8703743;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3398,7 +3398,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4535;Montboucher;montboucher;8715786;87157867;45.9500000000;1.6833330000;;f;FR;f;Europe/Paris;t;FRJAE;;t;;f;8704023;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4536;Panazol;panazol;8715797;87157974;45.8333330000;1.3000000000;;f;FR;f;Europe/Paris;t;FRJAF;;t;;f;8704173;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4537;Pontarion;pontarion;8715785;87157859;46.0000000000;1.8500000000;;f;FR;f;Europe/Paris;t;FRJAG;;t;;f;8704276;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4538;La Bernerie-en-Retz Centre;la-bernerie-en-retz-centre;8711026;87110262;47.080438930425245;-2.0375454425811768;4608;f;FR;t;Europe/Paris;t;FRJAI;;t;;f;8703540;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4538;La Bernerie-en-Retz Centre;la-bernerie-en-retz-centre;8711026;87110262;47.080438930425245;-2.0375454425811768;4608;f;FR;t;Europe/Paris;t;FRJAI;;t;;f;8703540;f;;f;;f;;f;;;f;;f;8700822;f;;f;f;;;;;;;;;;;;;;;;;;
 4539;Le Pas-de-la-Case;le-pas-de-la-case;8745501;87455014;42.543504574141124;1.7340534925460815;;f;AD;f;Europe/Paris;t;FRJAL;;t;;f;8703720;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4540;Jarville-la-Malgrange;jarville-la-malgrange;8714101;87141010;48.6666670000;6.2166670000;;f;FR;f;Europe/Paris;t;FRJAM;JAR;t;;f;8701331;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4541;Montgaillard (Haute Garonne);montgaillard-haute-garonne;8745500;87455006;42.9333330000;1.6333330000;;f;FR;f;Europe/Paris;t;FRJAQ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3419,10 +3419,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4558;Lyon St-Exupéry TGV;lyon-st-exupery-tgv;8776290;87762906;45.720907;5.075822;10799;f;FR;f;Europe/Paris;t;FRJDQ;SXA;t;JDQ;t;8702384;f;;f;JDQ;t;8776290;f;S76290;;f;;f;;f;;f;t;;Flughafen;Airport;Aeropuerto;Aéroport;Lione Aeroporto;;;;;リヨン;리옹;;;Лион;;;里昂
 4561;Noailles Bourg;noailles-bourg;8744499;87444992;45.1000000000;1.5333330000;;f;FR;f;Europe/Paris;f;FRJEA;;t;;f;8701683;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4562;Meymac Bourg;meymac-bourg;8745006;87450064;45.527325;2.138309;4720;f;FR;f;Europe/Paris;t;FRJEB;;t;;f;8703986;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4564;La Baule-Escoublac;la-baule-escoublac;8748175;87481754;47.28866138517192;-2.3892045021057124;4613;f;FR;t;Europe/Paris;t;FRJEE;LBE;t;;f;8700084;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;Ла-Боль;;;
+4564;La Baule-Escoublac;la-baule-escoublac;8748175;87481754;47.28866138517192;-2.3892045021057124;4613;f;FR;t;Europe/Paris;t;FRJEE;LBE;t;;f;8700084;f;;f;;f;;f;;;f;;f;8700103;f;;f;t;;;;;;;;;;;;;;;Ла-Боль;;;
 4568;Jussey;jussey;;;47.8166670000;5.9000000000;;t;FR;f;Europe/Paris;f;FRJLO;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4569;Jussey Centre;jussey-centre;8732040;87320408;47.827646;5.934786;4568;f;FR;f;Europe/Paris;t;FRJSS;;t;;f;8701288;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4570;Juan-les-Pins;juan-les-pins;8775766;87757666;43.57098205049144;7.111421227455139;;f;FR;f;Europe/Paris;t;FRJLP;;t;;f;8700313;f;;f;;f;8775766;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4570;Juan-les-Pins;juan-les-pins;8775766;87757666;43.57098205049144;7.111421227455139;;f;FR;f;Europe/Paris;t;FRJLP;;t;;f;8700313;f;;f;;f;8775766;f;;;f;;f;8700288;f;;f;f;;;;;;;;;;;;;;;;;;
 4571;Joué-lès-Tours;joue-les-tours;8757188;87571885;47.35418306790452;0.6677412986755371;4580;f;FR;t;Europe/Paris;t;FRJLT;;t;;f;8703509;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;Жу-ле-Тур;;;
 4572;Job;job;8773169;87731695;45.6166670000;3.7500000000;;f;FR;f;Europe/Paris;t;FRJOB;;t;;f;8703502;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4573;Josselin;josselin;8732200;87322008;47.9500000000;-2.5500000000;;f;FR;f;Europe/Paris;t;FRJOS;;t;;f;8701207;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3439,45 +3439,45 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4589;Barbâtre La Fosse;barbatre-la-fosse;8732075;;46.9500000000;-2.1833330000;;f;FR;f;Europe/Paris;f;FRKLM;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4591;Beauvoir-sur-Mer St-Nicolas;beauvoir-sur-mer-st-nicolas;8732073;87320739;46.91685869713174;-2.046251893043518;;f;FR;f;Europe/Paris;t;FRKML;;t;;f;8701447;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4593;Krimmeri—Meinau;krimmeri-meinau;8733852;87338525;48.5636200000;7.7526290000;;f;FR;f;Europe/Paris;t;FRKRI;KRI;t;;f;8733852;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4594;Les Aubrais;les-aubrais;8754301;87543017;47.926630803480734;1.9066965579986572;;f;FR;f;Europe/Paris;t;FRLAB;LAB;t;;f;8700003;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4595;Langres;langres;8714209;87142091;47.87695838214019;5.344414114952087;5032;f;FR;t;Europe/Paris;t;FRLAG;LAG;t;;f;8700272;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ラングル;;;;Лангр;;;朗格勒
-4596;Lannion;lannion;8747322;87473223;48.72753437053021;-3.460264205932617;;f;FR;f;Europe/Paris;t;FRLAI;LNI;t;;f;8703647;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ランニオン;;;;Ланьон;;;拉尼翁
+4594;Les Aubrais;les-aubrais;8754301;87543017;47.926630803480734;1.9066965579986572;;f;FR;f;Europe/Paris;t;FRLAB;LAB;t;;f;8700003;f;;f;;f;;f;;;f;;f;87004;f;;f;t;;;;;;;;;;;;;;;;;;
+4595;Langres;langres;8714209;87142091;47.87695838214019;5.344414114952087;5032;f;FR;t;Europe/Paris;t;FRLAG;LAG;t;;f;8700272;f;;f;;f;;f;;;f;;f;8700932;f;;f;f;;;;;;;;;;;ラングル;;;;Лангр;;;朗格勒
+4596;Lannion;lannion;8747322;87473223;48.72753437053021;-3.460264205932617;;f;FR;f;Europe/Paris;t;FRLAI;LNI;t;;f;8703647;f;;f;;f;;f;;;f;;f;8700776;f;;f;t;;;;;;;;;;;ランニオン;;;;Ланьон;;;拉尼翁
 4597;La Frayère;la-frayere;8740509;;43.558103;6.972087;;f;FR;f;Europe/Paris;t;FRLAJ;FYS;t;;f;8706480;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4598;Lamballe;lamballe;8747310;87473108;48.46587541754351;-2.511454224586487;;f;FR;f;Europe/Paris;t;FRLAM;LAM;t;;f;8701413;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ランバル;;;;Ламбаль;;;朗巴尔
-4600;Laqueuille;laqueuille;8764127;87641274;45.646809;2.704683;;f;FR;f;Europe/Paris;t;FRLAQ;LAQ;t;;f;8700101;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4598;Lamballe;lamballe;8747310;87473108;48.46587541754351;-2.511454224586487;;f;FR;f;Europe/Paris;t;FRLAM;LAM;t;;f;8701413;f;;f;;f;;f;;;f;;f;8700729;f;;f;t;;;;;;;;;;;ランバル;;;;Ламбаль;;;朗巴尔
+4600;Laqueuille;laqueuille;8764127;87641274;45.646809;2.704683;;f;FR;f;Europe/Paris;t;FRLAQ;LAQ;t;;f;8700101;f;;f;;f;;f;;;f;;f;8700177;f;;f;f;;;;;;;;;;;;;;;;;;
 4602;Troyes Lombards;troyes-lombards;8713966;87139667;48.27824;4.067241;5342;f;FR;f;Europe/Paris;t;FRLBD;;t;;f;8705068;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4604;Albi;albi;;;43.9333330000;2.1500000000;;t;FR;f;Europe/Paris;f;FRLBI;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4605;Albi Montplaisir;albi-montplaisir;8744283;87442830;43.934427;2.202545;4604;f;FR;f;Europe/Paris;t;FRUGZ;;t;;f;8706041;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4606;Albi Halte Routière;albi-halte-routiere;8744035;87440354;43.92215102913589;2.1383482217788696;4604;f;FR;f;Europe/Paris;t;FRUAQ;;t;;f;8705874;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4607;L’Arbresle;larbresle;8772143;87721431;45.83316500806204;4.6183401346206665;;f;FR;f;Europe/Paris;t;FRLBL;LBL;t;;f;8703527;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4607;L’Arbresle;larbresle;8772143;87721431;45.83316500806204;4.6183401346206665;;f;FR;f;Europe/Paris;t;FRLBL;LBL;t;;f;8703527;f;;f;;f;;f;;;f;;f;8700442;f;;f;f;;;;;;;;;;;;;;;;;;
 4608;La Bernerie-en-Retz;la-bernerie-en-retz;;;;;;t;FR;f;Europe/Paris;f;FRLBN;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4609;Le Bosquet;;8740507;;43.551532;6.981669;;f;FR;f;Europe/Paris;f;FRLBO;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4610;Le Bois-Plage-en-Ré Marché;le-bois-plage-en-re-marche;8732188;87321885;46.1833330000;-1.3833330000;;f;FR;f;Europe/Paris;t;FRLBP;;t;;f;8704239;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4611;La Bastide—St-Laurent-les-Bains;la-bastide-st-laurent-les-bains;8777517;87775171;44.592698;3.903979;;f;FR;f;Europe/Paris;t;FRLBS;LBS;t;;f;8700123;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4612;Le Buisson;le-buisson;8759575;87595751;44.84720549941009;0.9081637859344482;;f;FR;f;Europe/Paris;t;FRLBU;;t;;f;8703693;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4611;La Bastide—St-Laurent-les-Bains;la-bastide-st-laurent-les-bains;8777517;87775171;44.592698;3.903979;;f;FR;f;Europe/Paris;t;FRLBS;LBS;t;;f;8700123;f;;f;;f;;f;;;f;;f;8700228;f;;f;f;;;;;;;;;;;;;;;;;;
+4612;Le Buisson;le-buisson;8759575;87595751;44.84720549941009;0.9081637859344482;;f;FR;f;Europe/Paris;t;FRLBU;;t;;f;8703693;f;;f;;f;;f;;;f;;f;8700595;f;;f;f;;;;;;;;;;;;;;;;;;
 4613;La Baule;la-baule;;;47.28255163476108;-2.395046353340149;;t;FR;f;Europe/Paris;t;FRLBY;;t;;f;;f;gbqm18;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Ла-Боль;;;
-4614;La Baule-les-Pins;la-baule-les-pins;8748169;87481697;47.283619;-2.364729;4613;f;FR;f;Europe/Paris;t;FRXBP;;t;;f;8700695;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Ла-Боль;;;
+4614;La Baule-les-Pins;la-baule-les-pins;8748169;87481697;47.283619;-2.364729;4613;f;FR;f;Europe/Paris;t;FRXBP;;t;;f;8700695;f;;f;;f;;f;;;f;;f;8700106;f;;f;f;;;;;;;;;;;;;;;Ла-Боль;;;
 4615;Mareuil-sur-Lay;mareuil-sur-lay;8733402;87334029;46.5333330000;-1.2333330000;;f;FR;f;Europe/Paris;t;FRLCE;;t;;f;8702442;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4616;Lille CHR;lille-chr;8710930;87109306;50.61456297580039;3.0343508720397945;4652;f;FR;f;Europe/Paris;t;FRLCH;;t;;f;8700088;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Lilla;Rijsel;;;;リール;릴;;;Лилль;;;里尔
 4617;La Couarde Marché;la-couarde-marche;8732187;87321877;46.19224593742895;-1.4226704835891724;;f;FR;f;Europe/Paris;t;FRLCM;;t;;f;8704321;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4618;Luçon;lucon;8748625;87486258;46.463780360992594;-1.167447566986084;;f;FR;f;Europe/Paris;t;FRLCN;LRK;t;;f;8702439;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4618;Luçon;lucon;8748625;87486258;46.463780360992594;-1.167447566986084;;f;FR;f;Europe/Paris;t;FRLCN;LRK;t;;f;8702439;f;;f;;f;;f;;;f;;f;8700671;f;;f;f;;;;;;;;;;;;;;;;;;
 4619;Lacanau Océan;lacanau-ocean;8732406;87324061;44.977853123297315;-1.0909724235534668;;f;FR;f;Europe/Paris;t;FRLCO;;t;;f;8703316;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4620;La Chapelle-St-Mesmin;la-chapelle-st-mesmin;8754337;87543371;47.8833330000;1.8333330000;;f;FR;f;Europe/Paris;t;FRLCS;;t;;f;8700895;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4621;Le Châtelard;le-chatelard;8501382;;45.6833330000;6.1500000000;;t;FR;f;Europe/Paris;t;FRLCT;;t;;f;8501382;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4622;Le Châtelard—Giétroz;le-chatelard-gietroz;8501566;;;;4621;f;CH;f;Europe/Zurich;f;CHABE;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4623;Le Côteau;le-coteau;8772682;87726828;46.02387633510588;4.086356163024902;;f;FR;f;Europe/Paris;t;FRLCU;LCU;t;;f;8703702;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4626;Lourdes;lourdes;8767133;87671339;43.10051285444798;-0.04214286804199219;;f;FR;f;Europe/Paris;t;FRLDE;LDS;t;;f;8700105;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;Lurdy;;;ルルド;루르드;;;Лурд;;;盧爾德
+4626;Lourdes;lourdes;8767133;87671339;43.10051285444798;-0.04214286804199219;;f;FR;f;Europe/Paris;t;FRLDE;LDS;t;;f;8700105;f;;f;;f;;f;;;f;;f;8700184;f;;f;t;;;;;;;;Lurdy;;;ルルド;루르드;;;Лурд;;;盧爾德
 4628;La Douzillère;la-douzillere;8700969;87009696;47.338723;0.652976;;f;FR;f;Europe/Paris;t;FRLDZ;;t;;f;8705012;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4629;Lesseux—Frapelle;lesseux-frapelle;8714432;87144329;48.28998;7.076775;;f;FR;f;Europe/Paris;t;FRLEF;;t;;f;8701380;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4630;Le Havre;le-havre;;;49.4938040000;0.1076750000;;t;FR;f;Europe/Paris;f;FRLEH;;t;;f;;f;u0b1e4;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4631;Le Havre Graville;le-havre-graville;8741320;87413203;49.49982;0.160879;4630;f;FR;f;Europe/Paris;t;FRLHG;;t;;f;8703709;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4631;Le Havre Graville;le-havre-graville;8741320;87413203;49.49982;0.160879;4630;f;FR;f;Europe/Paris;t;FRLHG;;t;;f;8703709;f;;f;;f;;f;;;f;;f;8700202;f;;f;f;;;;;;;;;;;;;;;;;;
 4633;L’Estaque;lestaque;8775160;87751602;43.363846;5.321506;;f;FR;f;Europe/Paris;t;FRLES;;t;;f;8701085;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4636;Lentilly—Charpenay;lentilly-charpenay;8756691;87566919;45.8164;4.682391;;f;FR;f;Europe/Paris;t;FRLFJ;CNJ;t;;f;8706456;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4638;La Flotte Port;la-flotte-port;8732194;87321943;46.1833330000;-1.3333330000;;f;FR;f;Europe/Paris;t;FRLFP;;t;;f;8704442;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4640;Bologne;bologne;;;48.2000000000;5.1333330000;;t;FR;f;Europe/Paris;f;FRLGE;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;;;;;;;;
 4641;Bologne Salle des Fêtes;bologne-salle-des-fetes;8710742;87107425;48.198254;5.133074;4640;f;FR;f;Europe/Paris;t;FRLGM;;t;;f;8705025;f;;f;;f;;f;;;f;;f;;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;;;;;;;;
 4642;Langres Gendarmerie;langres-gendarmerie;8733812;87338129;47.8666670000;5.3333330000;5032;f;FR;f;Europe/Paris;t;FRLGG;;t;;f;8705250;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ラングル;;;;Лангр;;;朗格勒
-4643;Longuyon;longuyon;8719427;87194274;49.44422047673474;5.604684948921203;5693;f;FR;t;Europe/Paris;t;FRLGN;LGN;t;;f;8700070;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4643;Longuyon;longuyon;8719427;87194274;49.44422047673474;5.604684948921203;5693;f;FR;t;Europe/Paris;t;FRLGN;LGN;t;;f;8700070;f;;f;;f;;f;;;f;;f;8700085;f;;f;f;;;;;;;;;;;;;;;;;;
 4644;St-Léger;st-leger;8713977;;48.23628;4.07810;;f;FR;f;Europe/Paris;t;FRLGR;;t;;f;8705075;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4646;St-Hilaire-la-Gravelle;st-hilaire-la-gravelle;8730976;87309765;47.9166670000;1.2000000000;;f;FR;f;Europe/Paris;t;FRLGV;;t;;f;8705210;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4647;Gex;gex;;;46.3333330000;6.0666670000;;t;FR;f;Europe/Paris;f;FRLGX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3486,8 +3486,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4650;Libercourt;libercourt;8734525;87345256;50.48021003841322;3.0087625980377193;;f;FR;f;Europe/Paris;t;FRLIB;;t;;f;8701358;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4651;Limoges;limoges;;;45.83572150763156;1.2651658058166504;;t;FR;f;Europe/Paris;t;FRLIG;;t;;f;;f;u00usx;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4652;Lille;lille;9901001;;50.63040208723645;3.0709308385849;;t;FR;f;Europe/Paris;t;FRLIL;;t;;f;8796003;f;u140jc;t;AD1;t;;f;;;f;;f;;f;;f;f;;;;;;Lilla;Rijsel;;;;リール;릴;;;Лилль;;;里尔
-4653;Lille-Europe;lille-europe;8722326;87223263;50.63927904928819;3.0763649940490723;4652;f;FR;f;Europe/Paris;t;FRLLE;LEW;t;LLE;f;8704949;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;Lilla;Rijsel;;;;リール;릴;;;Лилль;;;里尔
-4654;Livron;livron;8776124;87761247;44.77960372778421;4.830545783042908;;f;FR;f;Europe/Paris;t;FRLIV;LIV;t;;f;8701404;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4653;Lille-Europe;lille-europe;8722326;87223263;50.63927904928819;3.0763649940490723;4652;f;FR;f;Europe/Paris;t;FRLLE;LEW;t;LLE;f;8704949;f;;f;;f;;f;;;f;;f;8700077;f;;f;t;;;;;;Lilla;Rijsel;;;;リール;릴;;;Лилль;;;里尔
+4654;Livron;livron;8776124;87761247;44.77960372778421;4.830545783042908;;f;FR;f;Europe/Paris;t;FRLIV;LIV;t;;f;8701404;f;;f;;f;;f;;;f;;f;8700191;f;;f;f;;;;;;;;;;;;;;;;;;
 4655;Le Locle;le-locle;;;;;;t;CH;f;Europe/Zurich;f;FRLLC;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4656;Le Locle;le-locle;8705982;;;;4655;f;CH;f;Europe/Zurich;f;FRZJA;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4657;St-Laurent—Fouras;st-laurent-fouras;8748513;87485136;45.9929590593958;-1.0274523496627808;;f;FR;f;Europe/Paris;t;FRLLD;;t;;f;8705752;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3497,66 +3497,66 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4663;Locminé;locmine;8700348;87003483;47.8833330000;-2.8333330000;;f;FR;f;Europe/Paris;t;FRLMN;;t;;f;8705013;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;洛克米内
 4664;Le Monastier;le-monastier;8778330;87783308;44.5166670000;3.2500000000;;f;FR;f;Europe/Paris;t;FRLMR;;t;;f;8703718;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4665;Limoux;limoux;;;43.0666670000;2.2333330000;;t;FR;f;Europe/Paris;f;FRLMX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4666;Lunéville;luneville;8714115;87141150;48.587835540483226;6.497061252593994;9346;f;FR;t;Europe/Paris;t;FRLNE;LNE;t;;f;8700264;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;リュネヴィル;;;;Люневиль;;;吕内维尔
+4666;Lunéville;luneville;8714115;87141150;48.587835540483226;6.497061252593994;9346;f;FR;t;Europe/Paris;t;FRLNE;LNE;t;;f;8700264;f;;f;;f;;f;;;f;;f;8700922;f;;f;t;;;;;;;;;;;リュネヴィル;;;;Люневиль;;;吕内维尔
 4667;Lanuejouls;lanuejouls;8715702;87157024;44.4333330000;2.1666670000;;f;FR;f;Europe/Paris;t;FRLNJ;;t;;f;8705850;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4668;Longages—Noé;longages-noe;8761105;87611053;43.356322;1.251954;;f;FR;f;Europe/Paris;t;FRLNN;;t;;f;8701425;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4670;Lannemezan;lannemezan;8767112;87671123;43.11411069201349;0.3873753547668457;;f;FR;f;Europe/Paris;t;FRLNZ;LNZ;t;;f;8700475;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4670;Lannemezan;lannemezan;8767112;87671123;43.11411069201349;0.3873753547668457;;f;FR;f;Europe/Paris;t;FRLNZ;LNZ;t;;f;8700475;f;;f;;f;;f;;;f;;f;8700314;f;;f;f;;;;;;;;;;;;;;;;;;
 4671;Montluçon;montlucon;;;46.3333330000;2.6000000000;;t;FR;f;Europe/Paris;f;FRLOM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4672;Montluçon;montlucon;8764100;87641001;46.337909;2.59639;4671;f;FR;t;Europe/Paris;t;FRMCU;MLN;t;;f;8700028;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モンリュソン;;;;Монлюсон;;;蒙吕松
-4673;Longueville;longueville;8711613;87116137;48.513573202492374;3.250059485435486;;f;FR;f;Europe/Paris;t;FRLON;LON;t;;f;8700275;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4672;Montluçon;montlucon;8764100;87641001;46.337909;2.59639;4671;f;FR;t;Europe/Paris;t;FRMCU;MLN;t;;f;8700028;f;;f;;f;;f;;;f;;f;8700032;f;;f;t;;;;;;;;;;;モンリュソン;;;;Монлюсон;;;蒙吕松
+4673;Longueville;longueville;8711613;87116137;48.513573202492374;3.250059485435486;;f;FR;f;Europe/Paris;t;FRLON;LON;t;;f;8700275;f;;f;;f;;f;;;f;;f;8700945;f;;f;f;;;;;;;;;;;;;;;;;;
 4674;Lourches;lourches;8734347;87343475;50.3166670000;3.3500000000;;f;FR;f;Europe/Paris;t;FRLOU;;t;;f;8700356;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4675;Lozanne;lozanne;8772142;87721423;45.85408448617136;4.68142032623291;;f;FR;f;Europe/Paris;t;FRLOZ;LOZ;t;;f;8703846;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4676;Lyon Part-Dieu;lyon-part-dieu;8772319;87723197;45.760568;4.859991;4718;f;FR;t;Europe/Paris;t;FRLPD;LYD;t;LPD;f;8700152;t;;f;LPD;t;8772319;f;;;f;;f;;f;;f;t;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
+4676;Lyon Part-Dieu;lyon-part-dieu;8772319;87723197;45.760568;4.859991;4718;f;FR;t;Europe/Paris;t;FRLPD;LYD;t;LPD;f;8700152;t;;f;LPD;t;8772319;f;;;f;;f;8700303;f;;f;t;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
 4677;Lyon Perrache;lyon-perrache;8772202;87722025;45.74836;4.825301;4718;f;FR;f;Europe/Paris;t;FRLPE;LPR;t;LPE;f;8700040;f;;f;LPE;t;;f;;;f;;f;;f;;f;t;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
 4678;Toulouse Gallieni Canceropôle;toulouse-gallieni-canceropole;8749746;87497461;43.574337;1.419216;5306;f;FR;f;Europe/Paris;t;FRLPF;;t;;f;8706432;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 4679;La Pauline—Hyères;la-pauline-hyeres;8775531;87755314;43.136293;6.034971;;f;FR;f;Europe/Paris;t;FRLPH;;t;;f;8701738;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4680;La Possonnière;la-possonniere;8748433;87484337;47.3833330000;-0.6833330000;;f;FR;f;Europe/Paris;t;FRLPO;LPO;t;;f;8701785;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4681;Le Palais;le-palais;8759203;;45.8666670000;1.3166670000;;f;FR;f;Europe/Paris;t;FRLPS;;t;;f;8702316;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ル・パレ;;;;Ле-Пале;;;勒帕莱
 4682;La Poterie;la-poterie;8733450;87334508;48.092289;-1.630724;;f;FR;f;Europe/Paris;t;FRLPT;;t;;f;8704982;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4683;Le Puy-en-Velay;le-puy-en-velay;8773469;87734699;45.04275854003349;3.8925504684448238;5009;f;FR;t;Europe/Paris;t;FRLPY;LPU;t;;f;8703725;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4686;La Roche-sur-Foron;la-roche-sur-foron;8774630;87746305;46.067536432395585;6.303851008415222;;f;FR;f;Europe/Paris;t;FRLRF;LRF;t;;f;8700136;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4687;La Rochelle Ville;la-rochelle-ville;8748500;87485003;46.152426;-1.145117;5085;f;FR;t;Europe/Paris;t;FRLRH;LRE;t;LRH;t;8700202;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ラ・ロシェル;라로셸;;;Ла-Рошель;;;拉罗歇尔
+4683;Le Puy-en-Velay;le-puy-en-velay;8773469;87734699;45.04275854003349;3.8925504684448238;5009;f;FR;t;Europe/Paris;t;FRLPY;LPU;t;;f;8703725;f;;f;;f;;f;;;f;;f;8700486;f;;f;t;;;;;;;;;;;;;;;;;;
+4686;La Roche-sur-Foron;la-roche-sur-foron;8774630;87746305;46.067536432395585;6.303851008415222;;f;FR;f;Europe/Paris;t;FRLRF;LRF;t;;f;8700136;f;;f;;f;;f;;;f;;f;8700267;f;;f;f;;;;;;;;;;;;;;;;;;
+4687;La Rochelle Ville;la-rochelle-ville;8748500;87485003;46.152426;-1.145117;5085;f;FR;t;Europe/Paris;t;FRLRH;LRE;t;LRH;t;8700202;f;;f;;f;;f;;;f;;f;8700631;f;;f;t;;;;;;;;;;;ラ・ロシェル;라로셸;;;Ла-Рошель;;;拉罗歇尔
 4688;La Membrolle-sur-Choisille;la-membrolle-sur-choisille;8757151;87571513;47.4333330000;0.6333330000;;f;FR;f;Europe/Paris;t;FRLRL;;t;;f;8701547;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4690;Lorient;lorient;8747600;87476002;47.75539632962103;-3.3661508560180664;;f;FR;f;Europe/Paris;t;FRLRT;LRT;t;LRT;t;8700207;f;gbmxek;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ロリアン;로리앙;;;Лорьян;;;洛里昂
+4690;Lorient;lorient;8747600;87476002;47.75539632962103;-3.3661508560180664;;f;FR;f;Europe/Paris;t;FRLRT;LRT;t;LRT;t;8700207;f;gbmxek;t;;f;;f;;;f;;f;8700678;f;;f;t;;;;;;;;;;;ロリアン;로리앙;;;Лорьян;;;洛里昂
 4691;Lirey La Chapelle;lirey-la-chapelle;8713986;;48.153838;4.047015;;f;FR;f;Europe/Paris;t;FRLRY;;t;;f;8705070;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4692;Lury-sur-Arnon;lury-sur-arnon;8731770;87317701;47.1166670000;2.0500000000;;f;FR;f;Europe/Paris;t;FRLSA;;t;;f;8701474;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4694;Lusigny-sur-Barse;lusigny-sur-barse;;;48.2500000000;4.2666670000;;t;FR;f;Europe/Paris;f;FRLSL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4695;Lusigny-sur-Barse RN19;lusigny-sur-barse-rn19;8727995;87279950;48.240224;4.280546;4694;f;FR;f;Europe/Paris;t;FRPAP;;t;;f;8705178;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4696;Lusigny-sur-Barse Centre;lusigny-sur-barse-centre;8721598;87215988;48.254562;4.254864;4694;f;FR;t;Europe/Paris;t;FRYSC;;t;;f;8705179;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4697;Lison;lison;8744721;87447219;49.22701488963452;-1.0503315925598145;;f;FR;f;Europe/Paris;t;FRLSN;LSN;t;;f;8700027;f;;f;;f;;f;;;f;;f;;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;;;;;;;;
-4698;Les Sables-d’Olonne;les-sables-dolonne;8748644;87486449;46.49976593713438;-1.7812657356262205;;f;FR;f;Europe/Paris;t;FRLSO;LSO;t;;f;8700200;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;レ・サーブル＝ドロンヌ;;;;Ле-Сабль-д’Олон;;;莱萨布勒多洛讷
+4697;Lison;lison;8744721;87447219;49.22701488963452;-1.0503315925598145;;f;FR;f;Europe/Paris;t;FRLSN;LSN;t;;f;8700027;f;;f;;f;;f;;;f;;f;8700031;f;;f;f;;Frankreich;France;Francia;France;Francia;;;;;;;;;;;;
+4698;Les Sables-d’Olonne;les-sables-dolonne;8748644;87486449;46.49976593713438;-1.7812657356262205;;f;FR;f;Europe/Paris;t;FRLSO;LSO;t;;f;8700200;f;;f;;f;;f;;;f;;f;8700624;f;;f;t;;;;;;;;;;;レ・サーブル＝ドロンヌ;;;;Ле-Сабль-д’Олон;;;莱萨布勒多洛讷
 4699;Lyon St-Paul;lyon-st-paul;8772115;87721159;45.765997;4.826937;4718;f;FR;f;Europe/Paris;t;FRLSP;LSP;t;;f;8703872;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
-4701;La Souterraine;la-souterraine;8759237;87592378;46.23969471575138;1.4924025535583496;;f;FR;f;Europe/Paris;t;FRLST;LST;t;;f;8701994;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4701;La Souterraine;la-souterraine;8759237;87592378;46.23969471575138;1.4924025535583496;;f;FR;f;Europe/Paris;t;FRLST;LST;t;;f;8701994;f;;f;;f;;f;;;f;;f;8700511;f;;f;f;;;;;;;;;;;;;;;;;;
 4702;La Source Université;la-source-universite;8713745;87137455;47.838317;1.944285;4894;f;FR;f;Europe/Paris;t;FRLSU;;t;;f;8705044;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4703;Lichtenberg;lichtenberg;8711064;87110643;48.9166670000;7.4833330000;;f;FR;f;Europe/Paris;t;FRLTB;;t;;f;8705026;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4704;Les Fontinettes;les-fontinettes;8731730;87317305;50.94088;1.849476;;f;FR;f;Europe/Paris;t;FRLTS;;t;;f;8701144;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4704;Les Fontinettes;les-fontinettes;8731730;87317305;50.94088;1.849476;;f;FR;f;Europe/Paris;t;FRLTS;;t;;f;8701144;f;;f;;f;;f;;;f;;f;8700841;f;;f;f;;;;;;;;;;;;;;;;;;
 4706;La Chapelle-St-Luc;la-chapelle-st-luc;8713951;87139519;48.323671;4.031635;;f;FR;f;Europe/Paris;t;FRLUC;;t;;f;8705065;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4707;Lucé;luce;8739401;87394015;48.4333330000;1.4666670000;;f;FR;f;Europe/Paris;t;FRLUE;;t;;f;8703386;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4708;Ludon;ludon;;;44.9833330000;-0.6000000000;;t;FR;f;Europe/Paris;f;FRLUN;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4710;Lure;lure;8718524;87185249;47.68315889627395;6.49264097213745;;f;FR;f;Europe/Paris;t;FRLUR;LUR;t;;f;8700279;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4710;Lure;lure;8718524;87185249;47.68315889627395;6.49264097213745;;f;FR;f;Europe/Paris;t;FRLUR;LUR;t;;f;8700279;f;;f;;f;;f;;;f;;f;8700962;f;;f;f;;;;;;;;;;;;;;;;;;
 4711;Lutterbach;lutterbach;8718266;87182667;47.7666670000;7.2833330000;;f;FR;f;Europe/Paris;t;FRLUT;;t;;f;8701439;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4713;Lalevade-d’Ardèche;lalevade-dardeche;8776479;;44.64962008274752;4.322905540466309;;f;FR;f;Europe/Paris;t;FRLVD;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4714;Laval;laval;;;48.0666670000;-0.7666670000;;t;FR;f;Europe/Paris;f;FRLVR;;t;;f;;f;gbx3qq;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4715;Longwy;longwy;8719400;87194001;49.51320053249328;5.769281387329102;5702;f;FR;t;Europe/Paris;t;FRLWY;LWY;t;;f;8700162;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ロンウィ;롱위;;;Лонгви;;;隆格维
+4715;Longwy;longwy;8719400;87194001;49.51320053249328;5.769281387329102;5702;f;FR;t;Europe/Paris;t;FRLWY;LWY;t;;f;8700162;f;;f;;f;;f;;;f;;f;8700954;f;;f;f;;;;;;;;;;;ロンウィ;롱위;;;Лонгви;;;隆格维
 4716;St-Lyé-la-Forêt Mairie;st-lye-la-foret-mairie;8720853;;48.0500000000;1.9833330000;;f;FR;f;Europe/Paris;t;FRLYE;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4717;Lyon Gorge de Loup;lyon-gorge-de-loup;8772117;87721175;45.766051;4.804743;4718;f;FR;f;Europe/Paris;t;FRLYL;LYL;t;;f;8703871;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
-4718;Lyon;lyon;9919001;;45.76765767630457;4.834907054901123;;t;FR;f;Europe/Paris;t;FRLYS;;t;;f;8796002;t;u05kq2;t;LY1;t;;f;;;f;;f;;f;;f;f;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
-4719;Millau;millau;8778300;87783001;44.10248709022126;3.074476718902588;;f;FR;f;Europe/Paris;t;FRMAU;MAU;t;;f;8700093;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ミヨー;;;;Мийо;;;米约
+4718;Lyon;lyon;9919001;;45.76765767630457;4.834907054901123;;t;FR;f;Europe/Paris;t;FRLYS;;t;;f;8796002;t;u05kq2;t;LY1;t;;f;;;f;;f;87303;f;;f;f;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
+4719;Millau;millau;8778300;87783001;44.10248709022126;3.074476718902588;;f;FR;f;Europe/Paris;t;FRMAU;MAU;t;;f;8700093;f;;f;;f;;f;;;f;;f;8700134;f;;f;f;;;;;;;;;;;ミヨー;;;;Мийо;;;米约
 4720;Meymac;meymac;;;45.5333330000;2.1666670000;;t;FR;f;Europe/Paris;f;FRMAY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4721;Meymac;meymac;8759427;87594275;45.530237;2.164099;4720;f;FR;t;Europe/Paris;t;FRMYC;MYC;t;;f;8701641;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4722;Miramas;miramas;8775300;87753004;43.58090380891586;4.999444484710693;;f;FR;f;Europe/Paris;t;FRMAZ;MAS;t;;f;8700362;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ミラマ;;;;Мирамас;;;米拉马
+4721;Meymac;meymac;8759427;87594275;45.530237;2.164099;4720;f;FR;t;Europe/Paris;t;FRMYC;MYC;t;;f;8701641;f;;f;;f;;f;;;f;;f;8700986;f;;f;f;;;;;;;;;;;;;;;;;;
+4722;Miramas;miramas;8775300;87753004;43.58090380891586;4.999444484710693;;f;FR;f;Europe/Paris;t;FRMAZ;MAS;t;;f;8700362;f;;f;;f;;f;;;f;;f;8700590;f;;f;t;;;;;;;;;;;ミラマ;;;;Мирамас;;;米拉马
 4723;Marseille Blancarde;marseille-blancarde;8775108;87751081;43.29630041886183;5.406861305236816;4790;f;FR;f;Europe/Paris;t;FRMBC;MBC;t;;f;8700464;f;;f;;f;8775108;f;;;f;;f;;f;;f;f;;;;Marsella;;Marsiglia;;;;;マルセイユ;마르세유;Marsylia;Marselha;Марсель;;Marsilya;马赛
 4725;Monbalen;monbalen;8713441;87134411;44.3166670000;0.7166670000;;f;FR;f;Europe/Paris;t;FRMBL;;t;;f;8706316;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4728;Mouchard;mouchard;8771883;87718833;46.97685588214904;5.79978883266449;;f;FR;f;Europe/Paris;t;FRMCD;MCD;t;;f;8700049;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4729;Montchanin;montchanin;8769430;87694307;46.75927531640082;4.481499195098877;;f;FR;f;Europe/Paris;t;FRMCH;MCH;t;;f;8700166;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4728;Mouchard;mouchard;8771883;87718833;46.97685588214904;5.79978883266449;;f;FR;f;Europe/Paris;t;FRMCD;MCD;t;;f;8700049;f;;f;;f;;f;;;f;;f;8700060;f;;f;t;;;;;;;;;;;;;;;;;;
+4729;Montchanin;montchanin;8769430;87694307;46.75927531640082;4.481499195098877;;f;FR;f;Europe/Paris;t;FRMCH;MCH;t;;f;8700166;f;;f;;f;;f;;;f;;f;8700383;f;;f;f;;;;;;;;;;;;;;;;;;
 4730;St-Martin-de-Crau;st-martin-de-crau;8775368;87753681;43.62225988029058;4.800333380699158;;f;FR;f;Europe/Paris;t;FRMCR;;t;;f;8705491;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4731;Morcenx;morcenx;8767310;87673103;44.03235149663633;-0.9081959724426268;;f;FR;f;Europe/Paris;t;FRMCX;MCX;t;;f;8700196;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4731;Morcenx;morcenx;8767310;87673103;44.03235149663633;-0.9081959724426268;;f;FR;f;Europe/Paris;t;FRMCX;MCX;t;;f;8700196;f;;f;;f;;f;;;f;;f;8700574;f;;f;f;;;;;;;;;;;;;;;;;;
 4732;Machy;machy;8713987;87139873;48.1333330000;4.0500000000;;f;FR;f;Europe/Paris;t;FRMCY;;t;;f;8705071;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4733;Montoir-de-Bretagne;montoir-de-bretagne;8748171;87481713;47.3333330000;-2.1500000000;;f;FR;f;Europe/Paris;t;FRMDB;;t;;f;8701526;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;蒙图瓦德布雷塔尼
+4733;Montoir-de-Bretagne;montoir-de-bretagne;8748171;87481713;47.3333330000;-2.1500000000;;f;FR;f;Europe/Paris;t;FRMDB;;t;;f;8701526;f;;f;;f;;f;;;f;;f;8700756;f;;f;f;;;;;;;;;;;;;;;;;;蒙图瓦德布雷塔尼
 4735;Montaigut-en-Combraille;montaigut-en-combraille;8732760;87327601;46.1833330000;2.8000000000;;f;FR;f;Europe/Paris;t;FRMEC;;t;;f;8705720;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4737;Melun;melun;8768200;87682005;48.527647132358496;2.6554512977600098;;f;FR;f;Europe/Paris;t;FRMEL;MEL;t;;f;8700540;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ムラン;;;;Мелён;;;默伦
-4738;Mende;mende;8778360;87783605;44.52233547993275;3.502192497253418;;f;FR;f;Europe/Paris;t;FRMEN;MDE;t;;f;8703965;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;マンド;;;;;;;
-4740;Mézidon;mezidon;8744420;87444208;49.070794437034735;-0.07488727569580078;;f;FR;f;Europe/Paris;t;FRMEZ;MEZ;t;;f;8700397;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4737;Melun;melun;8768200;87682005;48.527647132358496;2.6554512977600098;;f;FR;f;Europe/Paris;t;FRMEL;MEL;t;;f;8700540;f;;f;;f;;f;;;f;;f;8700467;f;;f;t;;;;;;;;;;;ムラン;;;;Мелён;;;默伦
+4738;Mende;mende;8778360;87783605;44.52233547993275;3.502192497253418;;f;FR;f;Europe/Paris;t;FRMEN;MDE;t;;f;8703965;f;;f;;f;;f;;;f;;f;8700994;f;;f;f;;;;;;;;;;;マンド;;;;;;;
+4740;Mézidon;mezidon;8744420;87444208;49.070794437034735;-0.07488727569580078;;f;FR;f;Europe/Paris;t;FRMEZ;MEZ;t;;f;8700397;f;;f;;f;;f;;;f;;f;8700769;f;;f;f;;;;;;;;;;;;;;;;;;
 4741;Font-Romeu;font-romeu;;;42.5055150000;2.0401100000;;t;FR;f;Europe/Paris;f;FRMFL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4742;Font-Romeu Ville;font-romeu-ville;8700226;87002261;42.49677473721934;2.0333772897720332;4741;f;FR;f;Europe/Paris;t;FRMFV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;フォン＝ロムー＝オデイヨ＝ヴィア;;;;;;;丰罗默-奥代洛维阿
 4743;Font-Romeu-Odeillo-Via;font-romeu-odeillo-via;8778481;87784819;42.491236;2.038375;4741;f;FR;t;Europe/Paris;t;FRQZF;;t;;f;8700388;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3570,17 +3570,17 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4752;Chaumont Hôpital;chaumont-hopital;8710741;87107417;48.1166670000;5.1333330000;4767;f;FR;f;Europe/Paris;t;FRMHT;;t;;f;8705027;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4753;Mulhouse;mulhouse;;;47.7500000000;7.3333330000;;t;FR;f;Europe/Paris;f;FRMLH;;t;;f;;f;u0mpwu;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 4754;Montluçon Rimard;montlucon-rimard;8732367;87323675;46.33559;2.61151;4671;f;FR;f;Europe/Paris;t;FRMLR;;t;;f;8704443;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4755;Monsempron-Libos;monsempron-libos;8758645;87586453;44.48647163960303;0.9414982795715332;;f;FR;f;Europe/Paris;t;FRMLS;MLS;t;;f;8704014;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4756;Mâcon—Loché TGV;macon-loche-tgv;8772570;87725705;46.282787;4.778593;5041;f;FR;f;Europe/Paris;t;FRMLT;MLH;t;;f;8700253;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;マコン;마콩;;;Макон;;;马孔
-4757;Marne-la-Vallée—Chessy;marne-la-vallee-chessy;8711184;87111849;48.870269;2.782871;4819;f;FR;t;Europe/Paris;t;FRMLV;MLV;t;MLV;f;8704948;f;;f;MLV;t;;f;;;f;;f;;f;;f;t;;Disneyland Paris;Disneyland Paris;Disneyland Paris;Disneyland Paris;Disneyland Paris;;;;;;;;;;;;
-4759;Montmélian;montmelian;8774118;87741181;45.50303840300411;6.043113470077514;;f;FR;f;Europe/Paris;t;FRMML;MML;t;;f;8700159;f;;f;;f;8774118;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4755;Monsempron-Libos;monsempron-libos;8758645;87586453;44.48647163960303;0.9414982795715332;;f;FR;f;Europe/Paris;t;FRMLS;MLS;t;;f;8704014;f;;f;;f;;f;;;f;;f;8700658;f;;f;f;;;;;;;;;;;;;;;;;;
+4756;Mâcon—Loché TGV;macon-loche-tgv;8772570;87725705;46.282787;4.778593;5041;f;FR;f;Europe/Paris;t;FRMLT;MLH;t;;f;8700253;f;;f;;f;;f;;;f;;f;8700891;f;;f;t;;;;;;;;;;;マコン;마콩;;;Макон;;;马孔
+4757;Marne-la-Vallée—Chessy;marne-la-vallee-chessy;8711184;87111849;48.870269;2.782871;4819;f;FR;t;Europe/Paris;t;FRMLV;MLV;t;MLV;f;8704948;f;;f;MLV;t;;f;;;f;;f;8700635;f;;f;t;;Disneyland Paris;Disneyland Paris;Disneyland Paris;Disneyland Paris;Disneyland Paris;;;;;;;;;;;;
+4759;Montmélian;montmelian;8774118;87741181;45.50303840300411;6.043113470077514;;f;FR;f;Europe/Paris;t;FRMML;MML;t;;f;8700159;f;;f;;f;8774118;f;;;f;;f;8700243;f;;f;f;;;;;;;;;;;;;;;;;;
 4760;Mont-sur-Meurthe;mont-sur-meurthe;8714114;87141143;48.5500000000;6.4500000000;4812;f;FR;t;Europe/Paris;t;FRMMT;;t;;f;8702344;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4762;Monnaie;monnaie;;;47.5000000000;0.7833330000;;t;FR;f;Europe/Paris;f;FRMNA;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4764;Le Ménilot;le-menilot;8721494;87214940;48.222947;4.295324;;f;FR;f;Europe/Paris;t;FRMNL;;t;;f;8705177;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4766;Mennessis;mennessis;8729643;87296434;49.7000000000;3.2666670000;;f;FR;f;Europe/Paris;t;FRMNS;;t;;f;8701533;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4767;Chaumont;chaumont;;;48.1166670000;5.1333330000;;t;FR;f;Europe/Paris;f;FRMNT;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 4768;Chaumont Quartier Foch;chaumont-quartier-foch;8721506;87215061;48.090698;5.141506;4767;f;FR;f;Europe/Paris;t;FRTQF;;t;;f;8705144;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4769;Chaumont;chaumont;8714200;87142000;48.109449;5.134764;4767;f;FR;t;Europe/Paris;t;FRXCW;CHM;t;;f;8700051;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+4769;Chaumont;chaumont;8714200;87142000;48.109449;5.134764;4767;f;FR;t;Europe/Paris;t;FRXCW;CHM;t;;f;8700051;f;;f;;f;;f;;;f;;f;8700062;f;;f;t;;;;;;;;;;;;;;;;;;
 4770;Chaumont Gendarmerie;chaumont-gendarmerie;8721704;87217042;48.098123;5.142836;4767;f;FR;f;Europe/Paris;t;FRTGD;;t;;f;8705145;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4771;Marnaval Église;marnaval-eglise;8710750;87107508;48.624729;4.9781;;f;FR;f;Europe/Paris;t;FRMNV;;t;;f;8705028;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4773;Marnay-sur-Marne;marnay-sur-marne;8721503;87215038;48.0000000000;5.2333330000;;f;FR;f;Europe/Paris;t;FRMNY;;t;;f;8705142;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3589,17 +3589,17 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4776;Mondoubleau;mondoubleau;;;47.9833330000;0.9000000000;;t;FR;f;Europe/Paris;f;FRMOC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4778;Mommenheim;mommenheim;8721214;87212142;48.7500000000;7.6500000000;;f;FR;f;Europe/Paris;t;FRMOH;MOH;t;;f;8700395;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4779;Molsheim;molsheim;8721457;87214577;48.537156634790605;7.500293254852295;;f;FR;f;Europe/Paris;t;FRMOL;MOL;t;;f;8700394;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モルスアイム;;;;Мольсайм;;;莫尔塞姆
-4782;Moret—Veneux-les-Sablons;moret-veneux-les-sablons;8768227;87682278;48.378326;2.799501;;f;FR;f;Europe/Paris;t;FRMOR;MOR;t;;f;8701643;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4784;Motteville;motteville;8741128;87411280;49.6333330000;0.8500000000;;f;FR;f;Europe/Paris;t;FRMOT;;t;;f;8704063;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4782;Moret—Veneux-les-Sablons;moret-veneux-les-sablons;8768227;87682278;48.378326;2.799501;;f;FR;f;Europe/Paris;t;FRMOR;MOR;t;;f;8701643;f;;f;;f;;f;;;f;;f;8700390;f;;f;f;;;;;;;;;;;;;;;;;;
+4784;Motteville;motteville;8741128;87411280;49.6333330000;0.8500000000;;f;FR;f;Europe/Paris;t;FRMOT;;t;;f;8704063;f;;f;;f;;f;;;f;;f;8700836;f;;f;f;;;;;;;;;;;;;;;;;;
 4785;Aéroport Marseille-Provence Bus;aeroport-marseille-provence-bus;8733749;87337493;43.44129735202746;5.237088203430176;;f;FR;f;Europe/Paris;t;FRMPA;;t;;f;8705262;f;;f;;f;8733749;f;;;f;;f;;f;;f;f;;Flughafen;Airport;Aeropuerto;;Aeroporto;;;;;;;;;;;;
-4786;Montpellier St-Roch;montpellier-st-roch;8777300;87773002;43.60423079220492;3.880383968353271;22598;f;FR;f;Europe/Paris;t;FRMPL;MPL;t;MPL;t;8700097;f;;f;MPL;t;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モンペリエ;몽펠리에;;;Монпелье;;;蒙彼利埃
-4787;Paris-Gare-Montparnasse-3-Vaugirard;paris-gare-montparnasse-3-vaugirard;8739110;;48.838384;2.315953;4916;f;FR;f;Europe/Paris;f;FRMPV;;t;;f;8704045;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+4786;Montpellier St-Roch;montpellier-st-roch;8777300;87773002;43.60423079220492;3.880383968353271;22598;f;FR;f;Europe/Paris;t;FRMPL;MPL;t;MPL;t;8700097;f;;f;MPL;t;;f;;;f;;f;8700173;f;;f;t;;;;;;;;;;;モンペリエ;몽펠리에;;;Монпелье;;;蒙彼利埃
+4787;Paris-Gare-Montparnasse-3-Vaugirard;paris-gare-montparnasse-3-vaugirard;8739110;;48.838384;2.315953;4916;f;FR;f;Europe/Paris;f;FRMPV;;t;;f;8704045;f;;f;;f;;f;;;f;;f;8700019;f;;f;t;;;;;;;;;;;;;;;;;;
 4788;Morée Salle des Fêtes;moree-salle-des-fetes;8745339;87453399;47.9000000000;1.2333330000;;f;FR;f;Europe/Paris;t;FRMRD;;t;;f;8706412;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4789;Margut;margut;;;49.5833330000;5.2666670000;;t;FR;f;Europe/Paris;f;FRMRG;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4790;Marseille;marseille;;;43.29640973957932;5.371000170707703;;t;FR;f;Europe/Paris;t;FRMRS;;t;;f;;f;spey63;t;;f;;f;;;f;;f;;f;;f;f;;;;Marsella;;Marsiglia;;;;;マルセイユ;마르세유;Marsylia;Marselha;Марсель;;Marsilya;马赛
-4791;Marseille St-Charles;marseille-st-charles;8775100;87751008;43.303816;5.381949;4790;f;FR;t;Europe/Paris;t;FRMSC;MSC;t;MSC;t;8700074;t;;f;MSC;t;8775100;t;;;f;;f;;f;;f;t;;;;Marsella;;Marsiglia;;;;;マルセイユ;마르세유;Marsylia;Marselha;Марсель;;Marsilya;马赛
+4791;Marseille St-Charles;marseille-st-charles;8775100;87751008;43.303816;5.381949;4790;f;FR;t;Europe/Paris;t;FRMSC;MSC;t;MSC;t;8700074;t;;f;MSC;t;8775100;t;;;f;;f;8700089;f;;f;t;;;;Marsella;;Marsiglia;;;;;マルセイユ;마르세유;Marsylia;Marselha;Марсель;;Marsilya;马赛
 4793;Méreau;mereau;8730977;87309773;47.1666670000;2.0500000000;;f;FR;f;Europe/Paris;t;FRMRU;;t;;f;8705216;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4794;Merrey;merrey;8714240;87142406;48.0500000000;5.6000000000;;f;FR;f;Europe/Paris;t;FRMRY;;t;;f;8701596;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4794;Merrey;merrey;8714240;87142406;48.0500000000;5.6000000000;;f;FR;f;Europe/Paris;t;FRMRY;;t;;f;8701596;f;;f;;f;;f;;;f;;f;8700992;f;;f;f;;;;;;;;;;;;;;;;;;
 4795;Mouans-Sartoux;mouans-sartoux;8740132;87401323;43.62045799139486;6.974247694015503;;f;FR;f;Europe/Paris;t;FRMSE;MUU;t;;f;8705360;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4796;Moulis—Listrac;moulis-listrac;;;;;;t;FR;f;Europe/Paris;f;FRMSL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4797;Mont-St-Michel;mont-st-michel;8732199;87321992;48.6360280000;-1.5120790000;;f;FR;f;Europe/Paris;t;FRMSM;;t;;f;8700363;f;gbwut9;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3607,10 +3607,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4800;Moussey;moussey;8713982;87139824;48.2166670000;4.1000000000;;f;FR;f;Europe/Paris;t;FRMSY;;t;;f;8705076;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4802;Gudmont Centre;gudmont-centre;8710745;87107458;48.3500000000;5.1333330000;5551;f;FR;f;Europe/Paris;t;FRMTC;;t;;f;8705029;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4803;Montdidier;montdidier;8731334;87313346;49.641720092197914;2.5627756118774414;17476;f;FR;t;Europe/Paris;t;FRMTD;;t;;f;8701564;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4804;Mantes-la-Jolie;mantes-la-jolie;8738150;87381509;48.989327911890285;1.703031063079834;;f;FR;f;Europe/Paris;t;FRMTE;MTE;t;;f;8703900;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;マント＝ラ＝ジョリー;;;;Мант-ла-Жоли;;;
-4805;Montréjeau—Gourdan-Polignan;montrejeau-gourdan-polignan;8761115;87611152;43.077962;0.57343;;f;FR;f;Europe/Paris;t;FRMTJ;MTJ;t;;f;8700103;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4804;Mantes-la-Jolie;mantes-la-jolie;8738150;87381509;48.989327911890285;1.703031063079834;;f;FR;f;Europe/Paris;t;FRMTE;MTE;t;;f;8703900;f;;f;;f;;f;;;f;;f;8700764;f;;f;f;;;;;;;;;;;マント＝ラ＝ジョリー;;;;Мант-ла-Жоли;;;
+4805;Montréjeau—Gourdan-Polignan;montrejeau-gourdan-polignan;8761115;87611152;43.077962;0.57343;;f;FR;f;Europe/Paris;t;FRMTJ;MTJ;t;;f;8700103;f;;f;;f;;f;;;f;;f;8700182;f;;f;f;;;;;;;;;;;;;;;;;;
 4806;Montélimar;montelimar;9919006;;44.5666670000;4.7500000000;;t;FR;f;Europe/Paris;f;FRMTL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4807;Montélimar;montelimar;8776400;87764001;44.559366;4.744704;4806;f;FR;t;Europe/Paris;t;FRXMK;MTR;t;;f;8700096;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モンテリマール;;;;Монтелимар;;;蒙特利馬爾
+4807;Montélimar;montelimar;8776400;87764001;44.559366;4.744704;4806;f;FR;t;Europe/Paris;t;FRXMK;MTR;t;;f;8700096;f;;f;;f;;f;;;f;;f;8700164;f;;f;t;;;;;;;;;;;モンテリマール;;;;Монтелимар;;;蒙特利馬爾
 4810;Morteau;morteau;8771861;87718619;47.053666583148356;6.60478949546814;;f;FR;f;Europe/Paris;t;FRMTO;;t;;f;8704060;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4811;Montereau;montereau;8768230;87682302;48.3793854161093;2.9426193237304688;;f;FR;f;Europe/Paris;t;FRMTU;MTU;t;;f;8701535;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4812;Mont-sur-Meurthe;mont-sur-meurthe;;;48.5500000000;6.4500000000;;t;FR;f;Europe/Paris;f;FRMTV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3621,7 +3621,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4817;Munster;munster;8718239;87182394;48.0500000000;7.1333330000;4816;f;FR;t;Europe/Paris;t;FRMUS;MUT;t;;f;8700563;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4819;Marne-la-Vallée;marne-la-vallee;9903145;;;;;t;FR;f;Europe/Paris;f;FRMVL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4821;Minversheim;minversheim;8700624;87006247;48.7833330000;7.6166670000;;f;FR;f;Europe/Paris;t;FRMVM;;t;;f;8705190;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4822;Morlaix;morlaix;8747433;87474338;48.57812261581351;-3.8327908515930176;;f;FR;f;Europe/Paris;t;FRMXN;MXR;t;MXN;t;8700213;f;gbtk35;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モルレー;;;;Морле;;;莫尔莱
+4822;Morlaix;morlaix;8747433;87474338;48.57812261581351;-3.8327908515930176;;f;FR;f;Europe/Paris;t;FRMXN;MXR;t;MXN;t;8700213;f;gbtk35;t;;f;;f;;;f;;f;8700734;f;;f;t;;;;;;;;;;;モルレー;;;;Морле;;;莫尔莱
 4823;Montieramey;montieramey;8727994;87279943;48.2333330000;4.3000000000;;f;FR;f;Europe/Paris;t;FRMYE;;t;;f;8705176;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4824;Magny-Fouchard;magny-fouchard;8721593;87215939;48.241466924589304;4.535132646560669;;f;FR;f;Europe/Paris;t;FRMYF;;t;;f;8705173;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4825;Méry-sur-Cher;mery-sur-cher;8731254;87312546;47.2333330000;1.9833330000;;f;FR;f;Europe/Paris;t;FRMYH;;t;;f;8700468;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3635,34 +3635,34 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4834;Benet;benet;;;46.3666670000;-0.6000000000;;t;FR;f;Europe/Paris;f;FRNBT;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4836;Nice;nice;9921017;;43.69664545590452;7.2719407081603995;;t;FR;f;Europe/Paris;t;FRNCE;;f;;f;;f;spv0t7;t;;f;;f;;;f;;f;;f;;f;f;;Nizza;;Niza;;Nizza;;;;Nizza;ニース;니스;Nicea;;Ницца;;;尼斯
 4837;Nice St-Augustin;nice-st-augustin;8775625;87756254;43.670675;7.216351;4836;f;FR;f;Europe/Paris;t;FRNSA;;t;;f;8701667;f;;f;;f;8775625;f;;;f;;f;;f;;f;f;;Nizza;;Niza;;Nizza;;;;Nizza;ニース;니스;Nicea;;Ницца;;;尼斯
-4838;Nice Riquier;nice-riquier;8775635;87756353;43.705832;7.290485;4836;f;FR;f;Europe/Paris;t;FRNRI;;t;;f;8700481;f;;f;;f;8775635;f;;;f;;f;;f;;f;f;;Nizza;;Niza;;Nizza;;;;Nizza;ニース;니스;Nicea;;Ницца;;;尼斯
-4839;Nice Ville;nice-ville;8775605;87756056;43.704825;7.261764;4836;f;FR;t;Europe/Paris;t;FRNIC;NIC;t;NIC;t;8700171;f;;f;;f;8775605;t;;;f;;f;;f;;f;t;;Nizza;;Niza;;Nizza;;;;Nizza;ニース;니스;Nicea;;Ницца;;;尼斯
+4838;Nice Riquier;nice-riquier;8775635;87756353;43.705832;7.290485;4836;f;FR;f;Europe/Paris;t;FRNRI;;t;;f;8700481;f;;f;;f;8775635;f;;;f;;f;8700404;f;;f;f;;Nizza;;Niza;;Nizza;;;;Nizza;ニース;니스;Nicea;;Ницца;;;尼斯
+4839;Nice Ville;nice-ville;8775605;87756056;43.704825;7.261764;4836;f;FR;t;Europe/Paris;t;FRNIC;NIC;t;NIC;t;8700171;f;;f;;f;8775605;t;;;f;;f;8700400;f;;f;t;;Nizza;;Niza;;Nizza;;;;Nizza;ニース;니스;Nicea;;Ницца;;;尼斯
 4840;Nice St-Roch;nice-st-roch;8775600;87756007;43.715243;7.286673;4836;f;FR;f;Europe/Paris;t;FRNSR;;t;;f;8704112;f;;f;;f;;f;;;f;;f;;f;;f;f;;Nizza;;Niza;;Nizza;;;;Nizza;ニース;니스;Nicea;;Ницца;;;尼斯
-4842;Neufchâteau;neufchateau;8714129;87141291;48.35824518876885;5.690317153930664;;f;FR;f;Europe/Paris;t;FRNCH;NCH;t;;f;8700285;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4843;Annecy;annecy;8774600;87746008;45.90201488655895;6.121830940246581;;f;FR;f;Europe/Paris;t;FRNCY;ANY;t;NCY;f;8700135;f;u0hm55;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アヌシー;안시;;;Анси;;;阿讷西
+4842;Neufchâteau;neufchateau;8714129;87141291;48.35824518876885;5.690317153930664;;f;FR;f;Europe/Paris;t;FRNCH;NCH;t;;f;8700285;f;;f;;f;;f;;;f;;f;8700978;f;;f;f;;;;;;;;;;;;;;;;;;
+4843;Annecy;annecy;8774600;87746008;45.90201488655895;6.121830940246581;;f;FR;f;Europe/Paris;t;FRNCY;ANY;t;NCY;f;8700135;f;u0hm55;t;;f;;f;;;f;;f;8700266;f;;f;t;;;;;;;;;;;アヌシー;안시;;;Анси;;;阿讷西
 4845;Cenon;cenon;8742059;87420596;44.856313726970996;-0.5336630344390869;;f;FR;f;Europe/Paris;t;FRNEA;CBX;t;;f;8705754;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;スノン;;;;Сенон;;;瑟农
 4846;Niversac;niversac;8759551;87595512;45.138272;0.808265;;f;FR;f;Europe/Paris;t;FRNEC;NEC;t;;f;8701687;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4847;Novéant;noveant;8719242;87192427;49.0333330000;6.0500000000;;f;FR;f;Europe/Paris;t;FRNEN;;t;;f;8701695;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4848;Neussargues;neussargues;8764550;87645507;45.1333330000;2.9833330000;;f;FR;f;Europe/Paris;t;FRNEU;NEU;t;;f;8700233;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4848;Neussargues;neussargues;8764550;87645507;45.1333330000;2.9833330000;;f;FR;f;Europe/Paris;t;FRNEU;NEU;t;;f;8700233;f;;f;;f;;f;;;f;;f;8700800;f;;f;f;;;;;;;;;;;;;;;;;;
 4849;Ferney;ferney;;;46.2585770000;6.1106300000;;t;FR;f;Europe/Paris;f;FRNEY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4850;Ingersheim;ingersheim;8730387;87303875;48.0980310000;7.3030760000;;f;FR;f;Europe/Paris;t;FRNGE;;t;;f;8704458;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4851;Niherne—Surins;niherne-surins;8721666;87216663;46.833862;1.567449;;f;FR;f;Europe/Paris;t;FRNHR;;t;;f;8705195;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4853;Niort;niort;8748530;87485300;46.319429593412906;-0.4546236991882324;;f;FR;f;Europe/Paris;t;FRNIT;NRT;t;NIT;t;8700201;f;gbpxt8;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ニオール;;;;Ньор;;;尼奥尔
+4853;Niort;niort;8748530;87485300;46.319429593412906;-0.4546236991882324;;f;FR;f;Europe/Paris;t;FRNIT;NRT;t;NIT;t;8700201;f;gbpxt8;t;;f;;f;;;f;;f;8700627;f;;f;t;;;;;;;;;;;ニオール;;;;Ньор;;;尼奥尔
 4854;Naves Lycée Agricole;naves-lycee-agricole;8731140;87311407;45.3139520000;1.7670820000;4870;f;FR;f;Europe/Paris;t;FRNLA;;t;;f;8705744;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4855;Nevers Le Banlay;nevers-le-banlay;8755907;87559070;46.9895620000;3.1589980000;4857;f;FR;f;Europe/Paris;t;FRNLB;NVB;t;;f;8704941;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4856;Fromentine—La Barre-de-Monts;fromentine-la-barre-de-monts;8732074;87320747;46.89257045221978;-2.137441635131836;;f;FR;f;Europe/Paris;t;FRNLE;;t;;f;8701576;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4857;Nevers;nevers;;;46.9895620000;3.1589980000;;t;FR;f;Europe/Paris;f;FRNLO;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-4858;Nevers;nevers;8769600;87696005;46.98733374682313;3.1505119800567627;4857;f;FR;t;Europe/Paris;t;FRNVS;NVS;t;;f;8700399;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ヌヴェール;느베르;;;Невер;;;讷韦尔
+4858;Nevers;nevers;8769600;87696005;46.98733374682313;3.1505119800567627;4857;f;FR;t;Europe/Paris;t;FRNVS;NVS;t;;f;8700399;f;;f;;f;;f;;;f;;f;8700054;f;;f;t;;;;;;;;;;;ヌヴェール;느베르;;;Невер;;;讷韦尔
 4859;Noirmoutier-en-l’Île;noirmoutier-en-lile;8732076;87320762;47.00058276116161;-2.2490859031677246;;f;FR;f;Europe/Paris;t;FRNML;;t;;f;8701749;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Нуармутье-ан-л’Иль;;;利勒地区努瓦尔穆蒂耶
 4862;Charbonnières-les-Bains;charbonnieres-les-bains;;;45.7833330000;4.7333330000;;t;FR;f;Europe/Paris;f;FRNRS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4863;Nogent-sur-Seine De Gaulle;nogent-sur-seine-de-gaulle;8721615;87216150;48.4925;3.5114;4864;f;FR;f;Europe/Paris;t;FRNSG;;t;;f;8705132;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4864;Nogent-sur-Seine;nogent-sur-seine;;;48.5333330000;3.5000000000;;t;FR;f;Europe/Paris;f;FRNSL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4865;Nogent-sur-Seine Théâtre;nogent-sur-seine-theatre;8721616;87216168;48.49167;3.506278;4864;f;FR;f;Europe/Paris;t;FRNST;;t;;f;8705133;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4866;Nantes;nantes;8748100;87481002;47.217207095916486;-1.5423345565795898;5317;f;FR;t;Europe/Paris;t;FRNTE;NTS;t;;f;8700020;f;;f;NTE;t;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ナント;;;;Нант;;;南特
+4866;Nantes;nantes;8748100;87481002;47.217207095916486;-1.5423345565795898;5317;f;FR;t;Europe/Paris;t;FRNTE;NTS;t;;f;8700020;f;;f;NTE;t;;f;;;f;;f;8700024;f;;f;t;;;;;;;;;;;ナント;;;;Нант;;;南特
 4868;Fronville;fronville;;;48.4000000000;5.1500000000;;t;FR;f;Europe/Paris;f;FRNVI;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4869;Fronville Mairie;fronville-mairie;8710749;;48.398138;5.156706;4868;f;FR;f;Europe/Paris;t;FRVIL;;t;;f;8705037;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4870;Naves;naves;;;45.3139520000;1.7670820000;;t;FR;f;Europe/Paris;f;FRNVL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4873;Nexon;nexon;8759272;87592725;45.6833330000;1.1833330000;;f;FR;f;Europe/Paris;t;FRNXN;;t;;f;8704108;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4873;Nexon;nexon;8759272;87592725;45.6833330000;1.1833330000;;f;FR;f;Europe/Paris;t;FRNXN;;t;;f;8704108;f;;f;;f;;f;;;f;;f;8700562;f;;f;f;;;;;;;;;;;;;;;;;;
 4874;Neuvy-Pailloux Bourg;neuvy-pailloux-bourg;8731086;87310862;46.8833330000;1.8500000000;;f;FR;f;Europe/Paris;t;FRNYP;;t;;f;8700467;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4875;Montaulin Mairie;montaulin-mairie;8727996;;48.2500000000;4.2000000000;;f;FR;f;Europe/Paris;t;FROAP;;t;;f;8705180;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4876;Aubenas;aubenas;;;44.6166670000;4.3833330000;;t;FR;f;Europe/Paris;f;FROBA;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3676,15 +3676,15 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4888;Orléans Gare Routière;orleans-gare-routiere;8713744;87137448;47.9166670000;1.9000000000;4894;f;FR;f;Europe/Paris;f;FROGR;;f;;f;8705045;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4889;Orges;orges;8721553;87215533;48.0833330000;4.9333330000;;f;FR;f;Europe/Paris;t;FROGS;;t;;f;8705157;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4890;Ostricourt;ostricourt;8734524;87345249;50.4500000000;3.0333330000;;f;FR;f;Europe/Paris;t;FROIC;;t;;f;8701725;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4891;Oissel;oissel;8741120;87411207;49.34299206229827;1.1023235321044922;;f;FR;f;Europe/Paris;t;FROIL;OSL;t;;f;8700402;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+4891;Oissel;oissel;8741120;87411207;49.34299206229827;1.1023235321044922;;f;FR;f;Europe/Paris;t;FROIL;OSL;t;;f;8700402;f;;f;;f;;f;;;f;;f;8700793;f;;f;t;;;;;;;;;;;;;;;;;;
 4893;Houlgate;houlgate;;;49.3000000000;-0.0666670000;;t;FR;f;Europe/Paris;f;FROLG;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4894;Orléans;orleans;9904003;;47.9166670000;1.9000000000;;t;FR;f;Europe/Paris;t;FROLS;;f;;f;;f;u092e2;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+4894;Orléans;orleans;9904003;;47.9166670000;1.9000000000;;t;FR;f;Europe/Paris;t;FROLS;;f;;f;;f;u092e2;t;;f;;f;;;f;;f;8700685;f;;f;t;;;;;;;;;;;;;;;;;;
 4895;Le Caoulet;le-caoulet;8712404;87124040;44.236689;0.644427;;f;FR;f;Europe/Paris;t;FROLT;;t;;f;8706318;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4896;Le Caoulet Station;le-caoulet-station;8746557;87465575;44.235835;0.643528;;f;FR;f;Europe/Paris;t;FROLU;;t;;f;8706319;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4897;Le Caoulet Pharmacie;le-caoulet-pharmacie;8746556;87465567;44.234361;0.638629;;f;FR;f;Europe/Paris;t;FROLV;;t;;f;8706320;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4898;Bajamont;bajamont;8746558;87465583;44.2656000000;0.7073000000;;f;FR;f;Europe/Paris;t;FROLW;;t;;f;8706321;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4900;Fromy;fromy;8711234;87112342;49.59655351972755;5.249125957489013;;f;FR;f;Europe/Paris;t;FROMY;;t;;f;8705149;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4901;Onville;onville;8719243;87192435;49.0166670000;5.9666670000;;f;FR;f;Europe/Paris;t;FRONV;;t;;f;8700267;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4901;Onville;onville;8719243;87192435;49.0166670000;5.9666670000;;f;FR;f;Europe/Paris;t;FRONV;;t;;f;8700267;f;;f;;f;;f;;;f;;f;8700926;f;;f;f;;;;;;;;;;;;;;;;;;
 4902;Orchies;orchies;8728658;87286583;50.47717864754371;3.2490938901901245;;f;FR;f;Europe/Paris;t;FRORC;;t;;f;8700403;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4907;Ors;ors;8729566;87295667;50.1000000000;3.6333330000;;f;FR;f;Europe/Paris;t;FRORS;;t;;f;8701719;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4908;Costaros;costaros;8745365;87453654;44.9000000000;3.8333330000;;f;FR;f;Europe/Paris;t;FROSO;;t;;f;8706413;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3692,17 +3692,17 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4910;Charost;charost;8730465;87304659;46.9833330000;2.1333330000;;f;FR;f;Europe/Paris;t;FROST;;t;;f;8700389;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4911;Coursan-en-Othe;coursan-en-othe;8713990;87139907;48.0666670000;3.8333330000;;f;FR;f;Europe/Paris;t;FROTH;;t;;f;8705072;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4912;Massabrac Tuileries;massabrac-tuileries;8744684;;43.231520698955094;1.375662088394165;;f;FR;f;Europe/Paris;t;FROUN;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4913;Oyonnax;oyonnax;8774353;87743534;46.259548444849344;5.6532275676727295;;f;FR;f;Europe/Paris;t;FROYO;OYO;t;;f;8704166;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4914;Port-d’Atelier-Amance;port-datelier-amance;8718510;87185108;47.75922;6.0396;;f;FR;f;Europe/Paris;t;FRPAA;;t;;f;8700054;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4913;Oyonnax;oyonnax;8774353;87743534;46.259548444849344;5.6532275676727295;;f;FR;f;Europe/Paris;t;FROYO;OYO;t;;f;8704166;f;;f;;f;;f;;;f;;f;8700326;f;;f;f;;;;;;;;;;;;;;;;;;
+4914;Port-d’Atelier-Amance;port-datelier-amance;8718510;87185108;47.75922;6.0396;;f;FR;f;Europe/Paris;t;FRPAA;;t;;f;8700054;f;;f;;f;;f;;;f;;f;8700065;f;;f;f;;;;;;;;;;;;;;;;;;
 4915;Longchamp-sur-Aujon;longchamp-sur-aujon;8721557;87215574;48.1500000000;4.8333330000;;f;FR;f;Europe/Paris;t;FRPAJ;;t;;f;8705153;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4916;Paris;paris;9903001;;48.8534100000;2.3488000000;;t;FR;f;Europe/Paris;t;FRPAR;;t;PAR;t;8796001;t;u09tvm;t;;f;;f;;;f;;f;;f;;f;f;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4917;Paris-Gare-de-Bercy;paris-gare-de-bercy;8768666;87686667;48.839131;2.382887;4916;f;FR;f;Europe/Paris;t;FRPBE;PBY;t;;f;8702455;t;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4919;Paris-Gare-de-l’Est;paris-gare-de-lest;8711300;87113001;48.876975;2.35912;4916;f;FR;f;Europe/Paris;t;FRPST;PES;t;PST;f;8700011;t;;f;;f;8711300;f;;;f;;f;;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4920;Paris-Gare-Montparnasse;paris-gare-montparnasse;8739100;87391003;48.840488;2.319576;4916;f;FR;f;Europe/Paris;t;FRPMO;PMP;t;PMO;t;8700013;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4921;Paris-Austerlitz;paris-austerlitz;8754700;87547000;48.84091003613604;2.3665666580200195;4916;f;FR;f;Europe/Paris;t;FRPAZ;PAZ;t;;f;8700010;t;;f;;f;8754700;f;;;f;;f;;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4922;Paris-Gare-du-Nord;paris-gare-du-nord;8727100;87271007;48.880885;2.354931;4916;f;FR;f;Europe/Paris;t;FRPNO;PNO;t;;f;8700014;f;;f;;f;8727100;f;;;f;;f;;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4923;Paris-Gare-St-Lazare;paris-gare-st-lazare;8738400;87384008;48.876328;2.325338;4916;f;FR;f;Europe/Paris;t;FRPSL;PSL;t;;f;8700015;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4924;Paris-Gare-de-Lyon;paris-gare-de-lyon;8768600;87686006;48.844839;2.374069;4916;f;FR;f;Europe/Paris;t;FRPLY;PLY;t;PLY;t;8700012;f;;f;;f;8768600;t;;;f;;f;;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4917;Paris-Gare-de-Bercy;paris-gare-de-bercy;8768666;87686667;48.839131;2.382887;4916;f;FR;f;Europe/Paris;t;FRPBE;PBY;t;;f;8702455;t;;f;;f;;f;;;f;;f;8700018;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4919;Paris-Gare-de-l’Est;paris-gare-de-lest;8711300;87113001;48.876975;2.35912;4916;f;FR;f;Europe/Paris;t;FRPST;PES;t;PST;f;8700011;t;;f;;f;8711300;f;;;f;;f;8700012;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4920;Paris-Gare-Montparnasse;paris-gare-montparnasse;8739100;87391003;48.840488;2.319576;4916;f;FR;f;Europe/Paris;t;FRPMO;PMP;t;PMO;t;8700013;f;;f;;f;;f;;;f;;f;8700014;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4921;Paris-Austerlitz;paris-austerlitz;8754700;87547000;48.84091003613604;2.3665666580200195;4916;f;FR;f;Europe/Paris;t;FRPAZ;PAZ;t;;f;8700010;t;;f;;f;8754700;f;;;f;;f;87011;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4922;Paris-Gare-du-Nord;paris-gare-du-nord;8727100;87271007;48.880885;2.354931;4916;f;FR;f;Europe/Paris;t;FRPNO;PNO;t;;f;8700014;f;;f;;f;8727100;f;;;f;;f;8700015;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4923;Paris-Gare-St-Lazare;paris-gare-st-lazare;8738400;87384008;48.876328;2.325338;4916;f;FR;f;Europe/Paris;t;FRPSL;PSL;t;;f;8700015;f;;f;;f;;f;;;f;;f;8700017;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4924;Paris-Gare-de-Lyon;paris-gare-de-lyon;8768600;87686006;48.844839;2.374069;4916;f;FR;f;Europe/Paris;t;FRPLY;PLY;t;PLY;t;8700012;f;;f;;f;8768600;t;;;f;;f;8700013;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
 4926;Parthenay;parthenay;8748717;87487173;46.6482872235422;-0.24051904678344727;;f;FR;f;Europe/Paris;t;FRPAY;;t;;f;8704189;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4927;Largentière Garage des Rancs;largentiere-garage-des-rancs;8776482;87764829;44.54448;4.292178;;f;FR;f;Europe/Paris;t;FRPBI;;t;;f;8703656;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4929;Pouzauges Centre;pouzauges-centre;8733300;87333005;46.78237125977221;-0.8373051881790161;5018;f;FR;f;Europe/Paris;t;FRPBM;;t;;f;8704308;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3712,13 +3712,13 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4934;St-Martial—Le Mont;st-martial-le-mont;8744502;87445023;46.0500000000;2.0833330000;;f;FR;f;Europe/Paris;t;FRPBY;;t;;f;8704609;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4935;Fourneaux;fourneaux;8744503;87445031;46.017399;2.140358;;f;FR;f;Europe/Paris;t;FRPBZ;;t;;f;8703344;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4936;St-Quentin-la-Tour;st-quentin-la-tour;8744542;87445429;43.0333330000;1.9000000000;;f;FR;f;Europe/Paris;t;FRPCJ;;t;;f;8706171;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4938;Pontchâteau;pontchateau;8748184;87481846;47.43534860885827;-2.08840548992157;;f;FR;f;Europe/Paris;t;FRPCT;PCU;t;;f;8704279;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;蓬特沙托
-4940;Port-de-Bouc;port-de-bouc;8775345;87753459;43.40722215648971;4.984654784202575;;f;FR;f;Europe/Paris;t;FRPDB;;t;;f;8701795;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4938;Pontchâteau;pontchateau;8748184;87481846;47.43534860885827;-2.08840548992157;;f;FR;f;Europe/Paris;t;FRPCT;PCU;t;;f;8704279;f;;f;;f;;f;;;f;;f;8700673;f;;f;f;;;;;;;;;;;;;;;;;;蓬特沙托
+4940;Port-de-Bouc;port-de-bouc;8775345;87753459;43.40722215648971;4.984654784202575;;f;FR;f;Europe/Paris;t;FRPDB;;t;;f;8701795;f;;f;;f;;f;;;f;;f;8700171;f;;f;f;;;;;;;;;;;;;;;;;;
 4941;Montreuil-Bellay;montreuil-bellay;;;47.1333330000;-0.1500000000;;t;FR;f;Europe/Paris;f;FRPDC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4942;Luz-St-Sauveur;luz-st-sauveur;8766683;87666834;42.87336945723386;-0.002542734146118164;;f;FR;f;Europe/Paris;t;FRPDE;;t;;f;8700320;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;吕圣索弗
 4943;Pontivy Douric;pontivy-douric;8741422;87414227;48.0666670000;-2.9833330000;9399;f;FR;f;Europe/Paris;t;FRPDI;;t;;f;8705625;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4945;Pont-de-Dore;pont-de-dore;8773445;87734459;45.8333330000;3.5000000000;;f;FR;f;Europe/Paris;t;FRPDO;PDO;t;;f;8704262;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4946;Persan—Beaumont;persan-beaumont;8727646;;49.147919;2.278307;;f;FR;f;Europe/Paris;t;FRPEB;;t;;f;8701755;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4945;Pont-de-Dore;pont-de-dore;8773445;87734459;45.8333330000;3.5000000000;;f;FR;f;Europe/Paris;t;FRPDO;PDO;t;;f;8704262;f;;f;;f;;f;;;f;;f;8700378;f;;f;f;;;;;;;;;;;;;;;;;;
+4946;Persan—Beaumont;persan-beaumont;8727646;;49.147919;2.278307;;f;FR;f;Europe/Paris;t;FRPEB;;t;;f;8701755;f;;f;;f;;f;;;f;;f;8700882;f;;f;f;;;;;;;;;;;;;;;;;;
 4947;Picon-Busserine;picon-busserine;8775929;87759290;43.331224;5.393195;4790;f;FR;f;Europe/Paris;t;FRPEI;XPC;t;;f;8706227;f;;f;;f;;f;;;f;;f;;f;;f;f;;Marseille;Marseille;Marsella;Marseille;Marsiglia;Marseille;Marseille;Marseille;Marseille;マルセイユ;마르세유;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
 4948;Marseille St-Antoine;marseille-st-antoine;8775182;87751826;43.36968;5.357409;4790;f;FR;f;Europe/Paris;t;FRPEJ;SNT;t;;f;8706228;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Marsella;;Marsiglia;;;;;マルセイユ;마르세유;Marsylia;Marselha;Марсель;;Marsilya;马赛
 4949;St-Joseph-le-Castellas;st-joseph-le-castellas;8775931;87759316;43.351998;5.377248;4790;f;FR;f;Europe/Paris;t;FRPEK;XJC;t;;f;8706229;f;;f;;f;;f;;;f;;f;;f;;f;f;;Marseille;Marseille;Marsella;Marseille;Marsiglia;Marseille;Marseille;Marseille;Marseille;マルセイユ;마르세유;Marsylia;Marselha;Марсель;Marseille;Marsilya;马赛
@@ -3726,25 +3726,25 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4952;Le Puy-en-Velay Lafayette;le-puy-en-velay-lafayette;8702438;87024380;45.04339;3.880283;5009;f;FR;f;Europe/Paris;t;FRPFY;;t;;f;8705030;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4953;Dives;dives;;;;;;t;FR;f;Europe/Paris;f;FRPGE;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4954;Dives-sur-Mer—Port-Guillaume;dives-sur-mer-port-guillaume;8733737;87337378;49.291090802259674;-0.10087251663208008;4953;f;FR;f;Europe/Paris;t;FRPGU;;t;;f;8705264;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4955;Perpignan;perpignan;8778400;87784009;42.69607053922139;2.87940502166748;;f;FR;f;Europe/Paris;t;FRPGF;PPN;t;PGF;t;8700164;f;spd4cu;t;;f;;f;;;f;;f;;f;;f;t;;;;Perpiñán;;Perpignano;;;;;ペルピニャン;페르피냥;;Perpinhã;Перпиньян;;;佩皮尼昂
+4955;Perpignan;perpignan;8778400;87784009;42.69607053922139;2.87940502166748;;f;FR;f;Europe/Paris;t;FRPGF;PPN;t;PGF;t;8700164;f;spd4cu;t;;f;;f;;;f;;f;8700374;f;;f;t;;;;Perpiñán;;Perpignano;;;;;ペルピニャン;페르피냥;;Perpinhã;Перпиньян;;;佩皮尼昂
 4956;Poitiers Gare Routière;poitiers-gare-routiere;8720248;87202481;46.5833330000;0.3333330000;4964;f;FR;f;Europe/Paris;f;FRPGR;;f;;f;8705079;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4957;Périgueux;perigueux;;;45.1833330000;0.7166670000;;t;FR;f;Europe/Paris;f;FRPGX;;t;;f;;f;u00903;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 4958;Perrigny-sur-Loire;perrigny-sur-loire;8728233;87282335;46.5333330000;3.8333330000;;f;FR;f;Europe/Paris;t;FRPGY;;t;;f;8705220;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4959;Phalsbourg;phalsbourg;8731912;87319129;48.7666670000;7.2666670000;;f;FR;f;Europe/Paris;t;FRPHB;;t;;f;8706540;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4960;Apach;apach;;;49.4500000000;6.3666670000;;t;FR;f;Europe/Paris;f;FRPHC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4963;Privas;privas;;;44.7333330000;4.6000000000;;t;FR;f;Europe/Paris;f;FRPIB;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4964;Poitiers;poitiers;8757500;87575001;46.5822116325826;0.33311963081359863;5001;f;FR;t;Europe/Paris;t;FRPIS;PST;t;;f;8700066;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ポワチエ;푸아티에;;;Пуатье;;;普瓦捷
+4964;Poitiers;poitiers;8757500;87575001;46.5822116325826;0.33311963081359863;5001;f;FR;t;Europe/Paris;t;FRPIS;PST;t;;f;8700066;f;;f;;f;;f;;;f;;f;87081;f;;f;t;;;;;;;;;;;ポワチエ;푸아티에;;;Пуатье;;;普瓦捷
 4966;Les Vans;les-vans;8755579;87555797;44.40535433335084;4.12862241268158;;f;FR;f;Europe/Paris;t;FRPJO;;t;;f;8703789;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4967;Pleumeur-Bodou;pleumeur-bodou;8733828;;48.771969999317015;-3.5179156064987183;;f;FR;f;Europe/Paris;t;FRPLB;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Плёмёр-Боду;;;普勒默博杜
 4970;Ploërmel;ploermel;8732296;87322966;47.93101962171903;-2.3946762084960938;;f;FR;f;Europe/Paris;t;FRPLL;;t;;f;8701832;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;プロエルメル;;;;;;;普洛厄尔梅
-4971;Paray-le-Monial;paray-le-monial;8769468;87694687;46.44728302142562;4.113746881484985;;f;FR;f;Europe/Paris;t;FRPLM;PLM;t;;f;8704176;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4971;Paray-le-Monial;paray-le-monial;8769468;87694687;46.44728302142562;4.113746881484985;;f;FR;f;Europe/Paris;t;FRPLM;PLM;t;;f;8704176;f;;f;;f;;f;;;f;;f;8700385;f;;f;f;;;;;;;;;;;;;;;;;;
 4972;Pont-sur-Seine;pont-sur-seine;;;48.5166670000;3.6000000000;;t;FR;f;Europe/Paris;f;FRPLO;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4973;Pont-sur-Seine Place St-Martin;pont-sur-seine-place-st-martin;8721614;87216143;48.515015;3.600898;4972;f;FR;f;Europe/Paris;t;FRPSM;;t;;f;8705131;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4974;Pont-sur-Seine Fleming;pont-sur-seine-fleming;8721613;87216135;48.50964;3.60186;4972;f;FR;t;Europe/Paris;t;FRPSN;;t;;f;8705130;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4975;Plouaret—Trégor;plouaret-tregor;8747318;87473181;48.606202;-3.466797;;f;FR;f;Europe/Paris;t;FRPLT;PLT;t;;f;8700542;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+4975;Plouaret—Trégor;plouaret-tregor;8747318;87473181;48.606202;-3.466797;;f;FR;f;Europe/Paris;t;FRPLT;PLT;t;;f;8700542;f;;f;;f;;f;;;f;;f;8700733;f;;f;f;;;;;;;;;;;;;;;;;;
 4976;Palluau;palluau;8721667;;46.9500000000;1.3166670000;;f;FR;f;Europe/Paris;t;FRPLU;;t;;f;8705193;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4979;Plomodiern;plomodiern;8767447;;48.180430892724296;-4.235202670097351;;f;FR;f;Europe/Paris;t;FRPMD;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;普洛莫迪耶尔恩
-4980;Pamiers;pamiers;8761134;87611343;43.116209628192536;1.6196250915527342;;f;FR;f;Europe/Paris;t;FRPMS;PMS;t;;f;8700493;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;パミエ;;;;Памье;;;帕米耶
+4980;Pamiers;pamiers;8761134;87611343;43.116209628192536;1.6196250915527342;;f;FR;f;Europe/Paris;t;FRPMS;PMS;t;;f;8700493;f;;f;;f;;f;;;f;;f;8700521;f;;f;f;;;;;;;;;;;パミエ;;;;Памье;;;帕米耶
 4981;Rouilly—St-Loup La Guérade;rouilly-st-loup-la-guerade;8728001;87280016;48.2666670000;4.1500000000;5087;f;FR;t;Europe/Paris;t;FRPNA;;t;;f;8705183;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4984;St-Pierre-d’Oléron;st-pierre-doleron;8734701;87347013;45.94231699046314;-1.307373046875;;f;FR;f;Europe/Paris;t;FRPOE;;t;;f;8734701;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Сен-Пьер-д’Олерон;;;圣皮耶尔多莱龙
 4985;Port-Bou;port-bou;;;;;;t;ES;f;Europe/Madrid;f;FRPOF;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3757,31 +3757,31 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4994;Perros-Guirec;perros-guirec;8733830;87338301;48.8166670000;-3.4500000000;9273;f;FR;t;Europe/Paris;f;FRPRR;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4998;Portet—Saint-Simon;portet-saint-simon;8761140;87611400;43.527971;1.388968;;f;FR;f;Europe/Paris;t;FRPSS;PSS;t;;f;8701801;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4999;Précy-sous-Thil;precy-sous-thil;8700235;87002352;47.3833330000;4.3166670000;;f;FR;f;Europe/Paris;t;FRPTH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5000;Pontarlier;pontarlier;8771500;87715003;46.90051747821962;6.353300213813782;;f;FR;f;Europe/Paris;t;FRPTL;PTL;t;;f;8700406;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ポンタルリエ;;;;Понтарлье;;;蓬塔尔利耶
+5000;Pontarlier;pontarlier;8771500;87715003;46.90051747821962;6.353300213813782;;f;FR;f;Europe/Paris;t;FRPTL;PTL;t;;f;8700406;f;;f;;f;;f;;;f;;f;8700362;f;;f;t;;;;;;;;;;;ポンタルリエ;;;;Понтарлье;;;蓬塔尔利耶
 5001;Poitiers;poitiers;;;46.5833330000;0.3333330000;;t;FR;f;Europe/Paris;f;FRPTR;;t;;f;;f;u021p8;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5002;Futuroscope;futuroscope;8732409;87324095;46.66996566437575;0.37731170654296875;5001;f;FR;f;Europe/Paris;t;FRTGO;FTU;t;;f;8703726;f;;f;;f;;f;;;f;;f;;f;;f;t;;10 km von Poitiers entfernt;10km from Poitiers;a 10 km de Poitiers;à 11 km de Poitiers;10km da Poitiers;;;;;;;;;;;;
+5002;Futuroscope;futuroscope;8732409;87324095;46.66996566437575;0.37731170654296875;5001;f;FR;f;Europe/Paris;t;FRTGO;FTU;t;;f;8703726;f;;f;;f;;f;;;f;;f;8700471;f;;f;t;;10 km von Poitiers entfernt;10km from Poitiers;a 10 km de Poitiers;à 11 km de Poitiers;10km da Poitiers;;;;;;;;;;;;
 5006;Pau;pau;;;43.3000000000;-0.3666670000;;t;FR;f;Europe/Paris;f;FRPUF;;t;;f;;f;ezxwrd;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5007;Pau Ville;pau-ville;8744890;87448902;43.29459030491233;-0.3707617521286011;5006;f;FR;f;Europe/Paris;t;FRUJO;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ポー;;;;Пау;;;
-5008;Puyoô;puyoo;8767227;87672279;43.524530538838874;-0.9108352661132812;;f;FR;f;Europe/Paris;t;FRPUO;PUO;t;;f;8700061;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5008;Puyoô;puyoo;8767227;87672279;43.524530538838874;-0.9108352661132812;;f;FR;f;Europe/Paris;t;FRPUO;PUO;t;;f;8700061;f;;f;;f;;f;;;f;;f;8700073;f;;f;f;;;;;;;;;;;;;;;;;;
 5009;Le Puy-en-Velay;le-puy-en-velay;;;45.0333330000;3.8833330000;;t;FR;f;Europe/Paris;f;FRPUY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5010;Pont-la-Ville;pont-la-ville;8721554;87215541;48.083183;4.890167;;f;FR;f;Europe/Paris;t;FRPVL;;t;;f;8705156;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5011;Pont-l’Évêque;pont-leveque;8744434;87444349;49.28705306697374;0.1921749114990234;;f;FR;f;Europe/Paris;t;FRPVQ;PVQ;t;;f;8701782;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5011;Pont-l’Évêque;pont-leveque;8744434;87444349;49.28705306697374;0.1921749114990234;;f;FR;f;Europe/Paris;t;FRPVQ;PVQ;t;;f;8701782;f;;f;;f;;f;;;f;;f;8700824;f;;f;f;;;;;;;;;;;;;;;;;;
 5012;Capvern;capvern;;;43.1000000000;0.3166670000;;t;FR;f;Europe/Paris;f;FRPVR;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5013;Capvern-les-Bains;capvern-les-bains;8744589;87445890;43.103352514176244;0.3296327590942383;5012;f;FR;f;Europe/Paris;t;FRVLB;;t;;f;8705946;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5014;St-Privat;st-privat;8733703;87337030;44.6333330000;4.4166670000;;f;FR;f;Europe/Paris;t;FRPVT;;t;;f;8705265;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5015;Parempuyre;parempuyre;;;44.9500000000;-0.5833330000;;t;FR;f;Europe/Paris;f;FRPYE;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5016;Pagny-sur-Meuse;pagny-sur-meuse;8717582;87175828;48.6833330000;5.7166670000;;f;FR;f;Europe/Paris;t;FRPYM;;t;;f;8701806;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5016;Pagny-sur-Meuse;pagny-sur-meuse;8717582;87175828;48.6833330000;5.7166670000;;f;FR;f;Europe/Paris;t;FRPYM;;t;;f;8701806;f;;f;;f;;f;;;f;;f;8700967;f;;f;f;;;;;;;;;;;;;;;;;;
 5017;Pyrénées-2000;pyrenees-2000;8700349;87003491;42.514744891509814;2.0600008964538574;;f;FR;f;Europe/Paris;t;FRPYR;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5018;Pouzauges;pouzauges;;;46.7833330000;-0.8333330000;;t;FR;f;Europe/Paris;f;FRPZG;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5019;Le Pouzin Centre;le-pouzin-centre;8776440;87764407;44.75088212314229;4.747509956359863;;f;FR;f;Europe/Paris;t;FRPZN;;t;;f;8705266;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5021;Aime-la-Plagne;aime-la-plagne;8774176;87741769;45.554202;6.648394;23613;f;FR;t;Europe/Paris;t;FRQAI;ANJ;t;QAI;t;8700431;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5022;Amiens;amiens;8731387;87313874;49.89055645889729;2.3081427812576294;10605;f;FR;f;Europe/Paris;t;FRQAM;AMS;t;;f;8700001;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アミアン;아미앵;;;Амьен;;;亞眠
+5021;Aime-la-Plagne;aime-la-plagne;8774176;87741769;45.554202;6.648394;23613;f;FR;t;Europe/Paris;t;FRQAI;ANJ;t;QAI;t;8700431;f;;f;;f;;f;;;f;;f;8700150;f;;f;f;;;;;;;;;;;;;;;;;;
+5022;Amiens;amiens;8731387;87313874;49.89055645889729;2.3081427812576294;10605;f;FR;f;Europe/Paris;t;FRQAM;AMS;t;;f;8700001;f;;f;;f;;f;;;f;;f;8700002;f;;f;t;;;;;;;;;;;アミアン;아미앵;;;Амьен;;;亞眠
 5023;Lasseran;lasseran;8761719;87617191;43.5833330000;0.5333330000;;f;FR;f;Europe/Paris;t;FRQBB;;t;;f;8706172;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5024;St-Jean-le-Comtal;st-jean-le-comtal;8761718;87617183;43.5833330000;0.5166670000;;f;FR;f;Europe/Paris;t;FRQBC;;t;;f;8706173;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5025;Labejan;labejan;8761717;87617175;43.540133;0.447204;;f;FR;f;Europe/Paris;t;FRQBD;;t;;f;8706174;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5026;Miramont-d’Astarac;miramont-dastarac;8761716;87617167;43.532403;0.421288;;f;FR;f;Europe/Paris;t;FRQBE;;t;;f;8706175;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5027;Joyeuse;joyeuse;8755580;87555805;44.4833330000;4.2333330000;;f;FR;f;Europe/Paris;t;FRQBG;;t;;f;8703513;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5028;Bourg-St-Maurice;bourg-st-maurice;8774179;87741793;45.618765169916266;6.771526336669922;;f;FR;f;Europe/Paris;t;FRQBM;BSM;t;QBM;t;8700130;f;u0hgdr;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;Бур-Сен-Морис;;;
+5028;Bourg-St-Maurice;bourg-st-maurice;8774179;87741793;45.618765169916266;6.771526336669922;;f;FR;f;Europe/Paris;t;FRQBM;BSM;t;QBM;t;8700130;f;u0hgdr;t;;f;;f;;;f;;f;8700249;f;;f;t;;;;;;;;;;;;;;;Бур-Сен-Морис;;;
 5029;Besançon;besancon;;;47.23792;6.02432;;t;FR;f;Europe/Paris;t;FRQBQ;;t;;f;;f;u0kk9p;t;;f;;f;;;f;;f;;f;;f;f;;;;Besanzón;;;;;;;ブザンソン;브장송;;;Безансон;;;贝桑松
 5030;La Courtine;la-courtine;8744525;87445254;45.7000000000;2.2666670000;;f;FR;f;Europe/Paris;t;FRQCD;;t;;f;8704913;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5031;Moutier-Rozeille;moutier-rozeille;8744504;87445049;45.916477;2.19157;;f;FR;f;Europe/Paris;t;FRQCE;;t;;f;8704069;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3791,27 +3791,27 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5035;Langres Bel Air;langres-bel-air;8721610;87216101;47.852726;5.34859;5032;f;FR;f;Europe/Paris;t;FRWGS;;t;;f;8705134;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5036;Langres Boulière;langres-bouliere;8721607;87216077;47.845229;5.332931;5032;f;FR;f;Europe/Paris;t;FRVGS;;t;;f;8705135;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5037;Les Cauquillous;les-cauquillous;8732802;87328021;43.734013;1.754685;;f;FR;f;Europe/Paris;t;FRQLS;;t;;f;8705267;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5038;Moûtiers—Salins;moutiers-salins;8774172;87741728;45.486693;6.531454;23615;f;FR;t;Europe/Paris;t;FRQMU;MOS;t;QMU;t;8700129;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5039;Annemasse;annemasse;8774549;87745497;46.19928993718554;6.236371994018555;;f;FR;f;Europe/Paris;t;FRQNJ;ANE;t;QNJ;t;8700131;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アヌマッス;;;;;;;安纳马斯
+5038;Moûtiers—Salins;moutiers-salins;8774172;87741728;45.486693;6.531454;23615;f;FR;t;Europe/Paris;t;FRQMU;MOS;t;QMU;t;8700129;f;;f;;f;;f;;;f;;f;8700246;f;;f;t;;;;;;;;;;;;;;;;;;
+5039;Annemasse;annemasse;8774549;87745497;46.19928993718554;6.236371994018555;;f;FR;f;Europe/Paris;t;FRQNJ;ANE;t;QNJ;t;8700131;f;;f;;f;;f;;;f;;f;8700252;f;;f;t;;;;;;;;;;;アヌマッス;;;;;;;安纳马斯
 5041;Mâcon;macon;;;46.3000000000;4.8333330000;;t;FR;f;Europe/Paris;t;FRQNX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;マコン;마콩;;;Макон;;;马孔
-5042;Arras;arras;8734201;87342014;50.286933167844474;2.781364917755127;;f;FR;f;Europe/Paris;t;FRQRV;ARR;t;;f;8700071;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アラス;아라스;;;Аррас-сюр-Рон;;;罗讷河畔阿尔拉
+5042;Arras;arras;8734201;87342014;50.286933167844474;2.781364917755127;;f;FR;f;Europe/Paris;t;FRQRV;ARR;t;;f;8700071;f;;f;;f;;f;;;f;;f;8700086;f;;f;t;;;;;;;;;;;アラス;아라스;;;Аррас-сюр-Рон;;;罗讷河畔阿尔拉
 5043;Château-Renault;chateau-renault;;;47.5833330000;0.9166670000;;t;FR;f;Europe/Paris;f;FRQTV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5044;Château-Renault Place Jean Jaurès;chateau-renault-place-jean-jaures;8742240;87422402;47.60715;0.926931;5043;f;FR;f;Europe/Paris;t;FRRRC;;t;;f;8703698;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5045;Château-Renault Salle des Fêtes;chateau-renault-salle-des-fetes;8742239;87422394;47.587131;0.908117;5043;f;FR;f;Europe/Paris;t;FRTTR;;t;;f;8703735;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5046;La Valbonne;la-valbonne;8772357;87723577;45.8500000000;5.1333330000;;f;FR;f;Europe/Paris;t;FRQVI;VAO;t;;f;8702587;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5047;Aix-en-Provence Centre;aix-en-provence-centre;8775140;87751404;43.522912431040176;5.445291996002197;23614;f;FR;t;Europe/Paris;t;FRQXB;AXP;t;;f;8700157;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;エクス＝アン＝プロヴァンス;엑상프로방스;;;Экс-ан-Прованс;;;普罗旺斯地区艾克斯
-5048;Troyes;troyes;8711800;87118000;48.295912;4.064571;5342;f;FR;t;Europe/Paris;t;FRQYR;TOY;t;;f;8700273;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;トロワ;트루아;;;Труа;;;特鲁瓦
+5048;Troyes;troyes;8711800;87118000;48.295912;4.064571;5342;f;FR;t;Europe/Paris;t;FRQYR;TOY;t;;f;8700273;f;;f;;f;;f;;;f;;f;8700942;f;;f;t;;;;;;;;;;;トロワ;트루아;;;Труа;;;特鲁瓦
 5049;Montlouis;montlouis;8757127;87571273;47.39158028444776;0.8173227310180664;;f;FR;f;Europe/Paris;t;FRQZE;;t;;f;8701615;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5050;La Villeneuve-au-Chêne;la-villeneuve-au-chene;8727993;;48.2333330000;4.3833330000;;f;FR;f;Europe/Paris;t;FRRAP;;t;;f;8705175;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5053;St-André-les-Vergers Reine Blanche;st-andre-les-vergers-reine-blanche;8713968;87139683;48.279174;4.046593;5127;f;FR;t;Europe/Paris;t;FRRBH;;t;;f;8705073;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5054;Bazancourt;bazancourt;8717146;87171462;49.36086962147401;4.174364805221558;;f;FR;f;Europe/Paris;t;FRRBO;BZT;t;;f;8705947;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5055;Rennes;rennes;8746249;;48.0833330000;-1.6833330000;;f;FR;f;Europe/Paris;f;FRRBW;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5060;Rochefort;rochefort;8748514;87485144;45.94747951423195;-0.9637069702148438;;f;FR;f;Europe/Paris;t;FRRCO;RCT;t;;f;8700203;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5060;Rochefort;rochefort;8748514;87485144;45.94747951423195;-0.9637069702148438;;f;FR;f;Europe/Paris;t;FRRCO;RCT;t;;f;8700203;f;;f;;f;;f;;;f;;f;8700633;f;;f;t;;;;;;;;;;;;;;;;;;
 5063;Crancey RN;crancey-rn;8721618;87216184;48.5166670000;3.6333330000;5089;f;FR;t;Europe/Paris;t;FRRCY;;t;;f;8705129;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5066;Montrabé Mairie;montrabe-mairie;8746284;;43.6500000000;1.5166670000;;f;FR;f;Europe/Paris;t;FRRDD;;t;;f;8706415;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5067;Carignan Rue de la Paix;carignan-rue-de-la-paix;8711232;87112326;49.6333330000;5.1666670000;5076;f;FR;f;Europe/Paris;t;FRRDP;;t;;f;8705148;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5068;Bridore;bridore;8728006;87280065;47.0166670000;1.0833330000;;f;FR;f;Europe/Paris;t;FRRDR;;t;;f;8705495;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5069;Rodez;rodez;8761342;87613422;44.362749598114625;2.5806283950805664;;f;FR;f;Europe/Paris;t;FRRDZ;RDZ;t;;f;8700194;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ロデズ;;;;Родез;;;罗德兹
+5069;Rodez;rodez;8761342;87613422;44.362749598114625;2.5806283950805664;;f;FR;f;Europe/Paris;t;FRRDZ;RDZ;t;;f;8700194;f;;f;;f;;f;;;f;;f;8700555;f;;f;t;;;;;;;;;;;ロデズ;;;;Родез;;;罗德兹
 5072;Barberey;barberey;;;48.3500000000;4.0166670000;;t;FR;f;Europe/Paris;f;FRREY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5073;Barberey Centre Commercial;barberey-centre-commercial;8713952;87139527;48.333334;4.021872;5072;f;FR;f;Europe/Paris;t;FRSLP;;t;;f;8705064;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5074;Ruffec (Indre);ruffec-indre;8720159;;46.6333330000;1.1666670000;;f;FR;f;Europe/Paris;t;FRRFC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3820,7 +3820,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5079;Les Granges;les-granges;8713958;87139584;48.5000000000;3.7833330000;;f;FR;f;Europe/Paris;t;FRRGS;;t;;f;8705060;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5082;Ria;ria;8778466;87784660;42.6166670000;2.4000000000;;f;FR;f;Europe/Paris;t;FRRIA;;t;;f;8704364;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5083;Azay-le-Rideau;azay-le-rideau;;;47.2666670000;0.4666670000;;t;FR;f;Europe/Paris;f;FRRID;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5084;Riom—Châtel-Guyon;riom-chatel-guyon;8773405;87734053;45.88996335257688;3.120546340942383;10635;f;FR;t;Europe/Paris;t;FRRIO;RIO;t;;f;8701846;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5084;Riom—Châtel-Guyon;riom-chatel-guyon;8773405;87734053;45.88996335257688;3.120546340942383;10635;f;FR;t;Europe/Paris;t;FRRIO;RIO;t;;f;8701846;f;;f;;f;;f;;;f;;f;8700114;f;;f;t;;;;;;;;;;;;;;;;;;
 5085;La Rochelle;la-rochelle;;;46.15251603337616;-1.1455178260803223;;t;FR;f;Europe/Paris;t;FRRLE;;t;;f;;f;gbpntu;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ラ・ロシェル;라로셸;;;Ла-Рошель;;;拉罗歇尔
 5086;La Rochelle Porte Dauphine;la-rochelle-porte-dauphine;8743779;87437798;46.167554;-1.151787;5085;f;FR;f;Europe/Paris;t;FRXSR;;t;;f;8706252;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ラ・ロシェル;라로셸;;;Ла-Рошель;;;拉罗歇尔
 5087;Rouilly—St-Loup;rouilly-st-loup;;;48.2666670000;4.1500000000;;t;FR;f;Europe/Paris;f;FRRLP;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3830,8 +3830,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5092;Romilly-sur-Seine;romilly-sur-seine;;;48.4833330000;3.7333330000;;t;FR;f;Europe/Paris;f;FRRMY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5093;Romilly-sur-Seine Atelier SNCF;romilly-sur-seine-atelier-sncf;8721611;87216119;48.511725;3.715727;5092;f;FR;f;Europe/Paris;t;FRRSA;;t;;f;8705126;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5095;Romilly-sur-Seine Hôpital;romilly-sur-seine-hopital;8721612;87216127;48.508049;3.696598;5092;f;FR;f;Europe/Paris;t;FRRSH;;t;;f;8705127;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5096;Roanne;roanne;8772680;87726802;46.03941041592775;4.06318724155426;;f;FR;f;Europe/Paris;t;FRRNE;ROA;t;;f;8700094;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ロアンヌ;로안;;;Роанн;;;罗阿讷
-5097;Rennes;rennes;8747100;87471003;48.11122798424453;-1.680033802986145;;f;FR;f;Europe/Paris;t;FRRNS;RES;t;RNS;t;8700025;f;gbwc99;t;RNS;t;;f;;;f;;f;;f;;f;t;;;;;;;;;;;レンヌ;렌;;;Ренн;;;雷恩
+5096;Roanne;roanne;8772680;87726802;46.03941041592775;4.06318724155426;;f;FR;f;Europe/Paris;t;FRRNE;ROA;t;;f;8700094;f;;f;;f;;f;;;f;;f;8700144;f;;f;t;;;;;;;;;;;ロアンヌ;로안;;;Роанн;;;罗阿讷
+5097;Rennes;rennes;8747100;87471003;48.11122798424453;-1.680033802986145;;f;FR;f;Europe/Paris;t;FRRNS;RES;t;RNS;t;8700025;f;gbwc99;t;RNS;t;;f;;;f;;f;8700029;f;;f;t;;;;;;;;;;;レンヌ;렌;;;Ренн;;;雷恩
 5098;Remiremont;remiremont;8714445;87144451;48.016446406949434;6.599001288414001;;f;FR;f;Europe/Paris;t;FRRNT;RMT;t;;f;8701879;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;Ремирмон;;;雷米雷蒙
 5099;Roncenay;roncenay;8713985;87139857;48.2000000000;4.0500000000;;f;FR;f;Europe/Paris;t;FRRNY;;t;;f;8705077;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5100;St-Sébastien-sur-Loire Frêne Rond;st-sebastien-sur-loire-frene-rond;8735459;87354597;47.2076820000;-1.5033250000;9144;f;FR;f;Europe/Paris;t;FRROD;XTD;t;;f;8705329;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3840,37 +3840,37 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5104;Sablanceaux;sablanceaux;8732193;;;;;f;FR;f;Europe/Paris;f;FRRPS;;t;;f;8704806;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5105;Reipertswiller;reipertswiller;8711063;87110635;48.9333330000;7.4666670000;;f;FR;f;Europe/Paris;t;FRRPW;;t;;f;8705046;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5106;Serrières;serrieres;8723326;87233262;45.3166670000;4.7500000000;;f;FR;f;Europe/Paris;t;FRRRS;;t;;f;8705271;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5107;Rosporden;rosporden;8747415;87474155;47.96041617499652;-3.8327479362487793;;f;FR;f;Europe/Paris;t;FRRSP;RSP;t;RSP;t;8700500;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;罗斯波尔当
+5107;Rosporden;rosporden;8747415;87474155;47.96041617499652;-3.8327479362487793;;f;FR;f;Europe/Paris;t;FRRSP;RSP;t;RSP;t;8700500;f;;f;;f;;f;;;f;;f;8700681;f;;f;f;;;;;;;;;;;;;;;;;;罗斯波尔当
 5108;Rosières (Aube);rosieres-aube;8713973;87139733;48.2666670000;4.0666670000;;f;FR;f;Europe/Paris;t;FRRSR;;t;;f;8705074;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5110;Brion—Montréal-la-Cluse;brion-montreal-la-cluse;8713196;87131961;46.175672;5.558686;;f;FR;f;Europe/Paris;t;FRRTC;;t;;f;8700140;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5111;Bruère-Allichamps;bruere-allichamps;8745338;87453381;46.770856;2.404362;;f;FR;f;Europe/Paris;t;FRRUB;;t;;f;8706417;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5112;Rue;rue;8731740;87317404;50.27315238673158;1.6759514808654785;;f;FR;f;Europe/Paris;t;FRRUE;RUE;t;;f;8701901;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5112;Rue;rue;8731740;87317404;50.27315238673158;1.6759514808654785;;f;FR;f;Europe/Paris;t;FRRUE;RUE;t;;f;8701901;f;;f;;f;;f;;;f;;f;8700846;f;;f;f;;;;;;;;;;;;;;;;;;
 5113;Ruoms;ruoms;8776484;87764845;44.4500000000;4.3500000000;;f;FR;f;Europe/Paris;t;FRRUO;;t;;f;8704399;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5114;Dreux;dreux;9904054;;48.7333330000;1.3666670000;;t;FR;f;Europe/Paris;f;FRRUX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5115;Dreux;dreux;8739348;87393488;48.731143;1.370351;5114;f;FR;t;Europe/Paris;t;FRXDR;DRX;t;;f;8700214;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ドルー;;;;Дрё;;;德勒
+5115;Dreux;dreux;8739348;87393488;48.731143;1.370351;5114;f;FR;t;Europe/Paris;t;FRXDR;DRX;t;;f;8700214;f;;f;;f;;f;;;f;;f;8700743;f;;f;t;;;;;;;;;;;ドルー;;;;Дрё;;;德勒
 5116;Villiers-le-Sec;villiers-le-sec;;;;;;t;FR;f;Europe/Paris;f;FRRVL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5117;Villiers-le-Sec Mairie;villiers-le-sec-mairie;8721520;;48.107507;5.063443;5116;f;FR;t;Europe/Paris;t;FRVLM;;t;;f;8705160;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5118;Villiers-le-Sec La Poste;villiers-le-sec-la-poste;8721521;;48.104712;5.075453;5116;f;FR;f;Europe/Paris;t;FRVLS;;t;;f;8705161;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5119;Rouvray;rouvray;8713429;87134296;47.4166670000;4.1000000000;;f;FR;f;Europe/Paris;t;FRRVY;;t;;f;8705047;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5120;La Croix-Blanche;la-croix-blanche;8712406;87124065;44.3000000000;0.6833330000;;f;FR;f;Europe/Paris;t;FRRXB;;t;;f;8706322;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5122;Royan;royan;8749180;87491803;45.625619711831185;-1.0164982080459595;;f;FR;f;Europe/Paris;t;FRRYN;ROY;t;;f;8702345;f;gbp78f;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ロワイヤン;;;;Руайян;;;鲁瓦扬
+5122;Royan;royan;8749180;87491803;45.625619711831185;-1.0164982080459595;;f;FR;f;Europe/Paris;t;FRRYN;ROY;t;;f;8702345;f;gbp78f;t;;f;;f;;;f;;f;8700581;f;;f;t;;;;;;;;;;;ロワイヤン;;;;Руайян;;;鲁瓦扬
 5124;Les Moutiers-en-Retz;les-moutiers-en-retz;;;;;;t;FR;f;Europe/Paris;f;FRRZT;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5125;Cerizay;cerizay;;;46.8166670000;-0.6666670000;;t;FR;f;Europe/Paris;f;FRRZY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5126;Sablé-sur-Sarthe;sable-sur-sarthe;8739640;87396408;47.84187272841203;-0.34197092056274414;;f;FR;f;Europe/Paris;t;FRSAB;SAB;t;;f;8700211;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5126;Sablé-sur-Sarthe;sable-sur-sarthe;8739640;87396408;47.84187272841203;-0.34197092056274414;;f;FR;f;Europe/Paris;t;FRSAB;SAB;t;;f;8700211;f;;f;;f;;f;;;f;;f;8700727;f;;f;t;;;;;;;;;;;;;;;;;;
 5127;St-André-les-Vergers;st-andre-les-vergers;;;;;;t;FR;f;Europe/Paris;f;FRSAD;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5129;St-Antoine-de-Ficalba;st-antoine-de-ficalba;8712407;87124073;44.3333330000;0.7166670000;;f;FR;f;Europe/Paris;t;FRSAF;;t;;f;8706323;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5130;St-André-le-Gaz;st-andre-le-gaz;8772349;87723494;45.544500877623655;5.524342060089111;;f;FR;f;Europe/Paris;t;FRSAG;SAG;t;;f;8702595;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5130;St-André-le-Gaz;st-andre-le-gaz;8772349;87723494;45.544500877623655;5.524342060089111;;f;FR;f;Europe/Paris;t;FRSAG;SAG;t;;f;8702595;f;;f;;f;;f;;;f;;f;8700241;f;;f;f;;;;;;;;;;;;;;;;;;
 5131;Bar-sur-Aube Hôpital;bar-sur-aube-hopital;8721560;87215608;48.2166670000;4.7166670000;5132;f;FR;f;Europe/Paris;t;FRSAH;;t;;f;8705165;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;バール＝シュル＝オーブ;;;;Бар-сюр-Об;;;奥布河畔巴尔
 5132;Bar-sur-Aube;bar-sur-aube;;;48.2166670000;4.7166670000;;t;FR;f;Europe/Paris;f;FRSAJ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5133;Bar-sur-Aube Piscine;bar-sur-aube-piscine;8721561;87215616;48.237267;4.696935;5132;f;FR;f;Europe/Paris;t;FRSAP;;t;;f;8705166;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5134;Salbris;salbris;8754316;87543165;47.425162118186826;2.047555446624756;;f;FR;f;Europe/Paris;t;FRSAL;SAP;t;;f;8702325;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5134;Salbris;salbris;8754316;87543165;47.425162118186826;2.047555446624756;;f;FR;f;Europe/Paris;t;FRSAL;SAP;t;;f;8702325;f;;f;;f;;f;;;f;;f;8700689;f;;f;f;;;;;;;;;;;;;;;;;;
 5135;St-Amand-Longpré;st-amand-longpre;;;47.6833330000;1.0166670000;;t;FR;f;Europe/Paris;f;FRSAM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5136;St-Amand-Longpré;st-amand-longpre;8742246;87422469;47.69413;1.008203;5135;f;FR;t;Europe/Paris;t;FRSML;;t;;f;8704960;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5137;Sedan Place Calonne;sedan-place-calonne;8710882;;49.7000000000;4.9500000000;5165;f;FR;f;Europe/Paris;t;FRSAN;;t;;f;8705146;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5138;St-Amour;st-amour;8771829;87718296;46.43383828183556;5.334189534187317;;f;FR;f;Europe/Paris;t;FRSAR;;t;;f;8702469;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5138;St-Amour;st-amour;8771829;87718296;46.43383828183556;5.334189534187317;;f;FR;f;Europe/Paris;t;FRSAR;;t;;f;8702469;f;;f;;f;;f;;;f;;f;8700494;f;;f;f;;;;;;;;;;;;;;;;;;
 5141;St-Flour Les Allées;st-flour-les-allees;8739582;87395822;45.033835;3.084981;;f;FR;f;Europe/Paris;t;FRSBF;;t;;f;8705346;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5142;Sarrebourg;sarrebourg;8721501;87215012;48.73867261087419;7.052257061004639;5706;f;FR;t;Europe/Paris;t;FRSBG;SBG;t;;f;8700265;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;サールブール;;;;;;;萨尔雷布尔
-5144;St-Brieuc;st-brieuc;8747300;87473009;48.507506811647325;-2.7649927139282227;;f;FR;f;Europe/Paris;t;FRSBK;SBC;t;SBK;t;8700212;f;gbw5cp;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;サン＝ブリユー;;;;Сен-Бриё;;;圣布里厄
+5142;Sarrebourg;sarrebourg;8721501;87215012;48.73867261087419;7.052257061004639;5706;f;FR;t;Europe/Paris;t;FRSBG;SBG;t;;f;8700265;f;;f;;f;;f;;;f;;f;8700923;f;;f;t;;;;;;;;;;;サールブール;;;;;;;萨尔雷布尔
+5144;St-Brieuc;st-brieuc;8747300;87473009;48.507506811647325;-2.7649927139282227;;f;FR;f;Europe/Paris;t;FRSBK;SBC;t;SBK;t;8700212;f;gbw5cp;t;;f;;f;;;f;;f;8700731;f;;f;t;;;;;;;;;;;サン＝ブリユー;;;;Сен-Бриё;;;圣布里厄
 5145;Sous-le-Bois;sous-le-bois;8729554;87295543;50.265566;3.939612;;f;FR;f;Europe/Paris;t;FRSBO;;t;;f;8702064;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5146;Sellières D475;sellieres-d475;8743901;87439018;46.819758;5.537049;;f;FR;f;Europe/Paris;t;FRSBP;;t;;f;8705833;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5147;Salies-de-Béarn Thermes;salies-de-bearn-thermes;8730672;87306720;43.4742240000;-0.9244820000;;f;FR;f;Europe/Paris;t;FRSBR;;t;;f;8701887;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3882,26 +3882,26 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5156;St-Cyr-en-Val-la-Source;st-cyr-en-val-la-source;8754311;87543116;47.819304;1.94736;;f;FR;f;Europe/Paris;t;FRSCV;;t;;f;8702326;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5158;Mauléon Office de Tourisme;mauleon-office-de-tourisme;8746512;87465120;43.2333330000;-0.8833330000;;f;FR;f;Europe/Paris;t;FRSCX;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5159;Mauléon Lycée;mauleon-lycee;8746513;87465138;43.2333330000;-0.8833330000;;f;FR;f;Europe/Paris;t;FRSCY;;t;;f;8706355;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5162;St-Denis-près-Martel;st-denis-pres-martel;8759457;87594572;44.945804;1.666231;;f;FR;f;Europe/Paris;t;FRSDM;SDM;t;;f;8700466;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5163;Surdon;surdon;8744456;87444562;48.66518;0.134065;;f;FR;f;Europe/Paris;t;FRSDN;SDN;t;;f;8700229;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5162;St-Denis-près-Martel;st-denis-pres-martel;8759457;87594572;44.945804;1.666231;;f;FR;f;Europe/Paris;t;FRSDM;SDM;t;;f;8700466;f;;f;;f;;f;;;f;;f;8700247;f;;f;f;;;;;;;;;;;;;;;;;;
+5163;Surdon;surdon;8744456;87444562;48.66518;0.134065;;f;FR;f;Europe/Paris;t;FRSDN;SDN;t;;f;8700229;f;;f;;f;;f;;;f;;f;8700783;f;;f;f;;;;;;;;;;;;;;;;;;
 5164;St-Dizier Hôpital;st-dizier-hopital;8710747;87107474;48.65657;4.96873;5167;f;FR;f;Europe/Paris;t;FRSDP;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝ディジエ;;;;Сен-Дизье;;;聖迪濟耶
 5165;Sedan;sedan;;;49.7000000000;4.9500000000;;t;FR;f;Europe/Paris;f;FRSDV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5166;Sedan;sedan;8717225;87172254;49.695119;4.930115;5165;f;FR;t;Europe/Paris;t;FRXSW;SED;t;;f;8700242;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;スダン;;;;Седан;;;
+5166;Sedan;sedan;8717225;87172254;49.695119;4.930115;5165;f;FR;t;Europe/Paris;t;FRXSW;SED;t;;f;8700242;f;;f;;f;;f;;;f;;f;8700855;f;;f;t;;;;;;;;;;;スダン;;;;Седан;;;
 5167;St-Dizier;st-dizier;;;48.6500000000;4.8166670000;;t;FR;f;Europe/Paris;f;FRSDZ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5168;St-Hilaire-le-Château;st-hilaire-le-chateau;8731595;87315952;45.9833330000;1.9000000000;;f;FR;f;Europe/Paris;t;FRSED;;t;;f;8704832;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5169;Seilhac;seilhac;8759406;87594069;45.3666670000;1.7166670000;;f;FR;f;Europe/Paris;t;FRSEI;;t;;f;8704472;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5170;Reims Franchet d’Esperey;reims-franchet-desperey;8741744;87417444;49.242512;4.0138;89;f;FR;f;Europe/Paris;t;FRSEP;;t;;f;8706275;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;Remeš;;;ランス;兰斯;;;Реймс;;;兰斯
-5171;Serqueux;serqueux;8741147;87411470;49.631485170953525;1.5395450592041016;;f;FR;f;Europe/Paris;t;FRSEQ;;t;;f;8700235;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5171;Serqueux;serqueux;8741147;87411470;49.631485170953525;1.5395450592041016;;f;FR;f;Europe/Paris;t;FRSEQ;;t;;f;8700235;f;;f;;f;;f;;;f;;f;8700826;f;;f;f;;;;;;;;;;;;;;;;;;
 5172;Serres Place de la Liberté;serres-place-de-la-liberte;8755619;;44.4333330000;5.7166670000;5239;f;FR;f;Europe/Paris;t;FRSER;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5173;St-Étienne-de-Boulogne;st-etienne-de-boulogne;8742048;87420489;44.7000000000;4.4666670000;;f;FR;f;Europe/Paris;t;FRSET;;t;;f;8705651;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5174;Cesson-Sévigné;cesson-sevigne;8733449;87334490;48.112595;-1.602282;;f;FR;f;Europe/Paris;t;FRSEV;;t;;f;8702594;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;瑟松塞维涅
 5176;St-Florentin HLM;st-florentin-hlm;8731974;;48.0000000000;3.7333330000;5193;f;FR;f;Europe/Paris;f;FRSFH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5178;St-Georges-d’Aurac;st-georges-daurac;8773430;87734301;45.1500000000;3.5333330000;5179;f;FR;t;Europe/Paris;t;FRSGA;SGA;t;;f;8700122;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5178;St-Georges-d’Aurac;st-georges-daurac;8773430;87734301;45.1500000000;3.5333330000;5179;f;FR;t;Europe/Paris;t;FRSGA;SGA;t;;f;8700122;f;;f;;f;;f;;;f;;f;8700224;f;;f;f;;;;;;;;;;;;;;;;;;
 5179;St-Georges-d’Aurac;st-georges-daurac;;;45.1500000000;3.5333330000;;t;FR;f;Europe/Paris;f;FRSGB;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5180;St-Genis-Pouilly Centre;st-genis-pouilly-centre;8755659;87556597;46.24436944673613;6.026333570480347;;f;FR;f;Europe/Paris;t;FRSGC;;t;;f;8704567;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5181;St-Germain-des-Fossés;st-germain-des-fosses;8773220;87732206;46.2090319678267;3.430652618408203;;f;FR;f;Europe/Paris;t;FRSGF;SGF;t;;f;8700033;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5181;St-Germain-des-Fossés;st-germain-des-fosses;8773220;87732206;46.2090319678267;3.430652618408203;;f;FR;f;Europe/Paris;t;FRSGF;SGF;t;;f;8700033;f;;f;;f;;f;;;f;;f;8700039;f;;f;f;;;;;;;;;;;;;;;;;;
 5182;St-Girons;st-girons;8761173;87611731;42.98629;1.14378;;f;FR;f;Europe/Paris;t;FRSGI;;t;;f;8704580;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5183;St-Agne;st-agne;8761130;87611301;43.5796525060526;1.4501953125;;f;FR;f;Europe/Paris;t;FRSGN;XAE;t;;f;8702042;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5183;St-Agne;st-agne;8761130;87611301;43.5796525060526;1.4501953125;;f;FR;f;Europe/Paris;t;FRSGN;XAE;t;;f;8702042;f;;f;;f;;f;;;f;;f;8700178;f;;f;f;;;;;;;;;;;;;;;;;;
 5184;St-Germain-au-Mont-d’Or;st-germain-au-mont-dor;8772128;87721282;45.88843245629337;4.804630279541016;;f;FR;f;Europe/Paris;t;FRSGO;SGO;t;;f;8702006;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5185;Segré;segre;;;47.7000000000;-0.4500000000;;t;FR;f;Europe/Paris;f;FRSGR;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5186;Segré Centre;segre-centre;8721357;87213579;47.686134676302196;-0.8762884140014648;5185;f;FR;f;Europe/Paris;t;FRSRC;;t;;f;8705099;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3912,54 +3912,54 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5191;St-Hilaire-au-Temple;st-hilaire-au-temple;8717444;87174441;49.0500000000;4.3833330000;;f;FR;f;Europe/Paris;t;FRSHT;;t;;f;8701972;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5193;St-Florentin;st-florentin;;;48.0000000000;3.7333330000;;t;FR;f;Europe/Paris;f;FRSIF;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5197;St-Jean-de-Losne;st-jean-de-losne;8771365;87713651;47.099807335060696;5.244244337081909;;f;FR;f;Europe/Paris;t;FRSJL;SJL;t;;f;8702519;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5199;St-Just-en-Chaussée;st-just-en-chaussee;8731327;87313270;49.50354478419664;2.42948055267334;;f;FR;f;Europe/Paris;t;FRSJS;SJS;t;;f;8701983;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5199;St-Just-en-Chaussée;st-just-en-chaussee;8731327;87313270;49.50354478419664;2.42948055267334;;f;FR;f;Europe/Paris;t;FRSJS;SJS;t;;f;8701983;f;;f;;f;;f;;;f;;f;8700876;f;;f;f;;;;;;;;;;;;;;;;;;
 5200;St-Julien-les-Villas;st-julien-les-villas;8721602;;48.2666670000;4.1000000000;;f;FR;f;Europe/Paris;t;FRSJV;;t;;f;8705184;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5201;Marigny Centre;marigny-centre;8732168;87321687;49.09848697798081;-1.2430429458618164;;f;FR;f;Europe/Paris;t;FRSKI;;t;;f;8702198;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5202;Santenay-les-Bains;santenay-les-bains;8771359;87713594;46.910639;4.70196;;f;FR;f;Europe/Paris;t;FRSLB;;t;;f;8700426;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5204;St-Léonard-de-Noblat;st-leonard-de-noblat;;;45.8333330000;1.4833330000;;t;FR;f;Europe/Paris;f;FRSLL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5205;St-Léonard-de-Noblat Ville;st-leonard-de-noblat-ville;8744604;87446047;45.836275;1.49335;5204;f;FR;f;Europe/Paris;t;FRSLN;;t;;f;8704603;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5206;St-Lô;st-lo;8744700;87447003;49.11676921883513;-1.1000168323516846;;f;FR;f;Europe/Paris;t;FRSLO;SLO;t;;f;8700231;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;サン＝ロー;생로;;;Сен-Ло;;;圣洛
+5206;St-Lô;st-lo;8744700;87447003;49.11676921883513;-1.1000168323516846;;f;FR;f;Europe/Paris;t;FRSLO;SLO;t;;f;8700231;f;;f;;f;;f;;;f;;f;8700798;f;;f;f;;;;;;;;;;;サン＝ロー;생로;;;Сен-Ло;;;圣洛
 5207;Sellières;sellieres;8756700;87567008;46.8333330000;5.5666670000;;f;FR;f;Europe/Paris;t;FRSLR;;t;;f;8704962;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5208;St-Lary-Soulan;st-lary-soulan;8761972;87619726;42.8171250000;0.3223800000;;f;FR;f;Europe/Paris;t;FRSLS;;t;;f;8704418;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5210;Senailly;senailly;8721814;87218149;47.5833330000;4.2666670000;;f;FR;f;Europe/Paris;t;FRSLY;;t;;f;8705217;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5211;St-Martin-de-Ré;st-martin-de-re;8732189;87321893;46.20563878889878;-1.364949345588684;;f;FR;f;Europe/Paris;t;FRSME;;t;;f;8704857;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5212;Ste-Marie-de-Ré;ste-marie-de-re;8732191;87321919;46.1500000000;-1.3000000000;;f;FR;f;Europe/Paris;t;FRSMR;;t;;f;8704896;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5216;Saverne;saverne;8721222;87212225;48.74472896621444;7.361966371536256;;f;FR;f;Europe/Paris;t;FRSNE;SNE;t;;f;8700266;f;;f;;f;;f;;;f;;f;;f;;f;t;;Zabern;;;;;;;;;サヴェルヌ;;;;Саверн;;;萨韦尔恩
+5216;Saverne;saverne;8721222;87212225;48.74472896621444;7.361966371536256;;f;FR;f;Europe/Paris;t;FRSNE;SNE;t;;f;8700266;f;;f;;f;;f;;;f;;f;8700924;f;;f;t;;Zabern;;;;;;;;;サヴェルヌ;;;;Саверн;;;萨韦尔恩
 5217;Steinbourg;steinbourg;8721220;87212209;48.763648;7.416244;;f;FR;f;Europe/Paris;t;FRSNG;;t;;f;8702047;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5219;St-Nazaire;st-nazaire;8748170;87481705;47.28671099954221;-2.2109556198120117;;f;FR;f;Europe/Paris;t;FRSNR;SNA;t;;f;8700198;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;サン＝ナゼール;생나제르;;;Сен-Назер;;;圣纳泽尔
-5221;Savenay;savenay;8748183;87481838;47.35844944872113;-1.9509851932525635;;f;FR;f;Europe/Paris;t;FRSNY;SNY;t;;f;8700067;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;萨沃奈
-5222;Siorac-en-Périgord;siorac-en-perigord;8759576;87595769;44.819834122811535;0.9841775894165039;;f;FR;f;Europe/Paris;t;FRSOC;;t;;f;8704502;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5223;Somain;somain;8734531;87345314;50.355413;3.276963;;f;FR;f;Europe/Paris;t;FRSOM;;t;;f;8700125;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5219;St-Nazaire;st-nazaire;8748170;87481705;47.28671099954221;-2.2109556198120117;;f;FR;f;Europe/Paris;t;FRSNR;SNA;t;;f;8700198;f;;f;;f;;f;;;f;;f;8700617;f;;f;t;;;;;;;;;;;サン＝ナゼール;생나제르;;;Сен-Назер;;;圣纳泽尔
+5221;Savenay;savenay;8748183;87481838;47.35844944872113;-1.9509851932525635;;f;FR;f;Europe/Paris;t;FRSNY;SNY;t;;f;8700067;f;;f;;f;;f;;;f;;f;8700082;f;;f;f;;;;;;;;;;;;;;;;;;萨沃奈
+5222;Siorac-en-Périgord;siorac-en-perigord;8759576;87595769;44.819834122811535;0.9841775894165039;;f;FR;f;Europe/Paris;t;FRSOC;;t;;f;8704502;f;;f;;f;;f;;;f;;f;8700655;f;;f;f;;;;;;;;;;;;;;;;;;
+5223;Somain;somain;8734531;87345314;50.355413;3.276963;;f;FR;f;Europe/Paris;t;FRSOM;;t;;f;8700125;f;;f;;f;;f;;;f;;f;8700234;f;;f;f;;;;;;;;;;;;;;;;;;
 5224;Soncourt-sur-Marne;soncourt-sur-marne;8710743;87107433;48.25191;5.114934;;f;FR;f;Europe/Paris;t;FRSOT;;t;;f;8705034;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5225;Souillac;souillac;8759433;87594333;44.902233;1.466653;;f;FR;f;Europe/Paris;t;FRSOU;SOU;t;;f;8700497;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5225;Souillac;souillac;8759433;87594333;44.902233;1.466653;;f;FR;f;Europe/Paris;t;FRSOU;SOU;t;;f;8700497;f;;f;;f;;f;;;f;;f;8700551;f;;f;f;;;;;;;;;;;;;;;;;;
 5227;Soyons;soyons;8776150;87761502;44.897774;4.856089;;f;FR;f;Europe/Paris;t;FRSOY;;t;;f;8705278;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5228;St-Pierre-d’Albigny;st-pierre-dalbigny;8774122;87741223;45.55726570532618;6.1563509702682495;;f;FR;f;Europe/Paris;t;FRSPA;SPA;t;;f;8700371;f;;f;;f;8774122;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5228;St-Pierre-d’Albigny;st-pierre-dalbigny;8774122;87741223;45.55726570532618;6.1563509702682495;;f;FR;f;Europe/Paris;t;FRSPA;SPA;t;;f;8700371;f;;f;;f;8774122;f;;;f;;f;8700075;f;;f;f;;;;;;;;;;;;;;;;;;
 5229;Ste-Pazanne Mairie;ste-pazanne-mairie;8732862;87328625;47.1000000000;-1.8166670000;5230;f;FR;f;Europe/Paris;t;FRSPC;;t;;f;8704912;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;圣帕藏
 5230;Ste-Pazanne;ste-pazanne;;;47.1000000000;-1.8166670000;;t;FR;f;Europe/Paris;f;FRSPL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5231;Ste-Pazanne;ste-pazanne;8748122;87481226;47.105543;-1.813879;5230;f;FR;t;Europe/Paris;t;FRSPZ;;t;;f;8704678;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;圣帕藏
+5231;Ste-Pazanne;ste-pazanne;8748122;87481226;47.105543;-1.813879;5230;f;FR;t;Europe/Paris;t;FRSPZ;;t;;f;8704678;f;;f;;f;;f;;;f;;f;8700784;f;;f;f;;;;;;;;;;;;;;;;;;圣帕藏
 5232;St-Pol-sur-Ternoise;st-pol-sur-ternoise;8734233;87342337;50.37886047136934;2.3397231101989746;;f;FR;f;Europe/Paris;t;FRSPT;SPT;t;;f;8700422;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5234;Serquigny;serquigny;8744431;87444315;49.1000000000;0.7166670000;;f;FR;f;Europe/Paris;t;FRSQY;SYD;t;;f;8700220;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5234;Serquigny;serquigny;8744431;87444315;49.1000000000;0.7166670000;;f;FR;f;Europe/Paris;t;FRSQY;SYD;t;;f;8700220;f;;f;;f;;f;;;f;;f;8700766;f;;f;f;;;;;;;;;;;;;;;;;;
 5235;Sarralbe;sarralbe;8719371;87193714;49.0000000000;7.0166670000;;f;FR;f;Europe/Paris;t;FRSRB;;t;;f;8700532;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5236;Ars-en-Ré;ars-en-re;8732184;87321844;46.2166670000;-1.5166670000;;f;FR;f;Europe/Paris;t;FRSRE;;t;;f;8704916;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Иль де Ре;;;雷地区阿尔
 5237;Surins;surins;8727916;87279166;46.836514;1.556805;;f;FR;f;Europe/Paris;t;FRSRN;;t;;f;8702404;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5238;St-Roch;st-roch;8731308;87313080;49.893296;2.283898;;f;FR;f;Europe/Paris;t;FRSRO;SRO;t;;f;8702030;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5239;Serres;serres;;;44.4333330000;5.7166670000;;t;FR;f;Europe/Paris;f;FRSRS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5241;St-Savin;st-savin;8720244;87202440;46.5666670000;0.8666670000;;f;FR;f;Europe/Paris;t;FRSSG;;t;;f;8705082;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5243;St-Sulpice-Laurière;st-sulpice-lauriere;8759234;87592345;46.0500000000;1.4666670000;;f;FR;f;Europe/Paris;t;FRSSL;SSL;t;;f;8701433;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5244;St-Sulpice;st-sulpice;8761534;87615344;43.7833330000;1.7000000000;;f;FR;f;Europe/Paris;t;FRSST;SST;t;;f;8704658;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5243;St-Sulpice-Laurière;st-sulpice-lauriere;8759234;87592345;46.0500000000;1.4666670000;;f;FR;f;Europe/Paris;t;FRSSL;SSL;t;;f;8701433;f;;f;;f;;f;;;f;;f;8700033;f;;f;f;;;;;;;;;;;;;;;;;;
+5244;St-Sulpice;st-sulpice;8761534;87615344;43.7833330000;1.7000000000;;f;FR;f;Europe/Paris;t;FRSST;SST;t;;f;8704658;f;;f;;f;;f;;;f;;f;8700528;f;;f;f;;;;;;;;;;;;;;;;;;
 5245;St-André (Nord);st-andre-nord;8728619;87286195;50.6666670000;3.0500000000;;f;FR;f;Europe/Paris;t;FRSTA;;t;;f;8704531;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5246;Ste-Gemme;ste-gemme;8734444;87344440;46.9000000000;-0.2833330000;;f;FR;f;Europe/Paris;t;FRSTG;;t;;f;8704968;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5247;Bâle St-Jean;bale-st-jean;8718793;87187930;;;5877;f;CH;f;Europe/Zurich;f;FRSTJ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5250;St-Satur Place du Marché;st-satur-place-du-marche;8731489;;47.3333330000;2.8500000000;;f;FR;f;Europe/Paris;t;FRSTU;;t;;f;8700502;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5251;Sauveterre-de-Béarn;sauveterre-de-bearn;8767245;87672451;43.4000000000;-0.9333330000;;f;FR;f;Europe/Paris;t;FRSUA;;t;;f;8704462;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5254;Séverac-le-Château;severac-le-chateau;8778336;87783365;44.32464247418238;3.0570316314697266;;f;FR;f;Europe/Paris;t;FRSVC;SVC;t;;f;8700420;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5254;Séverac-le-Château;severac-le-chateau;8778336;87783365;44.32464247418238;3.0570316314697266;;f;FR;f;Europe/Paris;t;FRSVC;SVC;t;;f;8700420;f;;f;;f;;f;;;f;;f;8700072;f;;f;f;;;;;;;;;;;;;;;;;;
 5256;St-Valéry-en-Caux;st-valery-en-caux;;;49.8000000000;1.3166670000;;t;FR;f;Europe/Paris;f;FRSVV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5257;Les Forges-de-Clairvaux;les-forges-de-clairvaux;8721496;87214965;48.164104;4.790009;;f;FR;f;Europe/Paris;t;FRSVX;;t;;f;8705163;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5258;Schweighouse-sur-Moder;schweighouse-sur-moder;8721310;87213108;48.8166670000;7.7333330000;;f;FR;f;Europe/Paris;t;FRSWG;;t;;f;8701960;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5259;Buswiller;buswiller;8700623;87006239;48.8196370000;7.5586800000;;f;FR;f;Europe/Paris;t;FRSWR;;t;;f;8705742;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5260;Strasbourg;strasbourg;;;48.58333;7.74593;;t;FR;f;Europe/Paris;t;FRSXB;;f;;f;;f;u0ts2h;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5260;Strasbourg;strasbourg;;;48.58333;7.74593;;t;FR;f;Europe/Paris;t;FRSXB;;f;;f;;f;u0ts2h;t;;f;;f;;;f;;f;8700027;f;;f;t;;;;;;;;;;;;;;;;;;
 5261;Cussy-les-Forges;cussy-les-forges;8720467;87204677;47.4666670000;4.0333330000;;f;FR;f;Europe/Paris;t;FRSYF;;t;;f;8705200;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5263;Saincaize;saincaize;8769626;87696260;46.9076500000;3.0840680000;;f;FR;f;Europe/Paris;t;FRSZE;SZE;t;;f;8700035;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5263;Saincaize;saincaize;8769626;87696260;46.9076500000;3.0840680000;;f;FR;f;Europe/Paris;t;FRSZE;SZE;t;;f;8700035;f;;f;;f;;f;;;f;;f;8700043;f;;f;f;;;;;;;;;;;;;;;;;;
 5266;Gan;gan;8767261;87672618;43.2333330000;-0.3833330000;;f;FR;f;Europe/Paris;t;FRTAN;;t;;f;8704942;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5267;St-Cyprien Arènes;st-cyprien-arenes;8744617;87446179;43.59399429710338;1.4178425073623657;5306;f;FR;f;Europe/Paris;t;FRTAR;TEW;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;Toulouse;Toulouse;Tolosa;Toulouse;Tolosa;Toulouse;Toulouse;;Toulouse;トゥールーズ;툴루즈;Tuluza;Toulouse;Тулуза;;Toulouse;圖盧茲
 5268;Tassin;tassin;8772151;87721514;45.761647;4.758628;;f;FR;f;Europe/Paris;t;FRTAS;TAS;t;;f;8704695;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3968,33 +3968,33 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5273;Bitche;bitche;;;49.0500000000;7.4333330000;;t;FR;f;Europe/Paris;f;FRTCH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5274;Château-Gontier;chateau-gontier;;;47.8500000000;-0.9500000000;;t;FR;f;Europe/Paris;f;FRTCL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5275;Château-Gontier Centre;chateau-gontier-centre;8721343;87213439;47.829462;-0.705833;5274;f;FR;f;Europe/Paris;t;FRTCT;;t;;f;8705095;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5276;Tarascon-sur-Rhône;tarascon-sur-rhone;8776535;87765354;43.801171;4.656924;;f;FR;f;Europe/Paris;t;FRTCN;TCN;t;;f;8700058;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5276;Tarascon-sur-Rhône;tarascon-sur-rhone;8776535;87765354;43.801171;4.656924;;f;FR;f;Europe/Paris;t;FRTCN;TCN;t;;f;8700058;f;;f;;f;;f;;;f;;f;8700069;f;;f;f;;;;;;;;;;;;;;;;;;
 5277;Enveitg;enveitg;;;;;;t;FR;f;Europe/Paris;f;FRTDE;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5278;Latour-de-Carol;latour-de-carol;7177310;;;;5277;f;ES;f;Europe/Madrid;f;ESAGL;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5279;Latour-de-Carol – Enveitg;latour-de-carol-enveitg;8761148;87611483;42.458731;1.904778;5277;f;FR;t;Europe/Paris;t;FRXTE;LTL;t;;f;8700148;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5279;Latour-de-Carol – Enveitg;latour-de-carol-enveitg;8761148;87611483;42.458731;1.904778;5277;f;FR;t;Europe/Paris;t;FRXTE;LTL;t;;f;8700148;f;;f;;f;;f;;;f;;f;8700291;f;;f;f;;;;;;;;;;;;;;;;;;
 5280;Bouziès;bouzies;8744037;87440370;44.4833330000;1.6333330000;;f;FR;f;Europe/Paris;t;FRTDO;;t;;f;8705862;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5281;Neuillé-Pont-Pierre;neuille-pont-pierre;;;47.5500000000;0.5500000000;;t;FR;f;Europe/Paris;f;FRTEC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5282;Terrasson;terrasson;8759440;87594408;45.135791;1.300424;;f;FR;f;Europe/Paris;t;FRTER;TOD;t;;f;8702129;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5283;Tessonnières;tessonnieres;8761524;87615245;43.92835;1.937004;;f;FR;f;Europe/Paris;t;FRTES;;t;;f;8704706;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5282;Terrasson;terrasson;8759440;87594408;45.135791;1.300424;;f;FR;f;Europe/Paris;t;FRTER;TOD;t;;f;8702129;f;;f;;f;;f;;;f;;f;8700989;f;;f;f;;;;;;;;;;;;;;;;;;
+5283;Tessonnières;tessonnieres;8761524;87615245;43.92835;1.937004;;f;FR;f;Europe/Paris;t;FRTES;;t;;f;8704706;f;;f;;f;;f;;;f;;f;8700042;f;;f;f;;;;;;;;;;;;;;;;;;
 5285;Torfou;torfou;;;;;;t;FR;f;Europe/Paris;f;FRTFU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5288;Tergnier;tergnier;8729644;87296442;49.659297;3.296928;;f;FR;f;Europe/Paris;t;FRTGR;TGR;t;;f;8700077;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5288;Tergnier;tergnier;8729644;87296442;49.659297;3.296928;;f;FR;f;Europe/Paris;t;FRTGR;TGR;t;;f;8700077;f;;f;;f;;f;;;f;;f;8700092;f;;f;f;;;;;;;;;;;;;;;;;;
 5289;Artigues (Lot-et-Garonne);artigues-lot-et-garonne;8712405;87124057;44.252843;0.691090;;f;FR;f;Europe/Paris;t;FRTGS;;t;;f;8706324;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5290;Thiers;thiers;;;;;;t;FR;f;Europe/Paris;f;FRTHA;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5291;Thiers Mairie;thiers-mairie;8740950;87409508;45.856465;3.54441;5290;f;FR;f;Europe/Paris;t;FRTVM;;t;;f;8705690;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;泰夫河畔蒂耶尔
 5292;Thiers Le Moutier;thiers-le-moutier;8740951;87409516;45.847547;3.507312;5290;f;FR;f;Europe/Paris;t;FRTMO;;t;;f;8705689;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5293;Thiers Lycée;thiers-lycee;8739574;87395749;45.885716;3.529299;5290;f;FR;f;Europe/Paris;t;FRTHH;;t;;f;8705348;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;泰夫河畔蒂耶尔
 5294;Thésée;thesee;8732819;87328195;47.322255;1.312029;;f;FR;f;Europe/Paris;t;FRTHE;;t;;f;8704710;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5295;Thiers;thiers;8773447;87734475;45.86113;3.54326;5290;f;FR;t;Europe/Paris;t;FRTHI;THI;t;;f;8702106;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;泰夫河畔蒂耶尔
+5295;Thiers;thiers;8773447;87734475;45.86113;3.54326;5290;f;FR;t;Europe/Paris;t;FRTHI;THI;t;;f;8702106;f;;f;;f;;f;;;f;;f;8700379;f;;f;f;;;;;;;;;;;;;;;;;;泰夫河畔蒂耶尔
 5297;Thoiry Mairie;thoiry-mairie;8755607;87556076;46.230758;5.980352;5300;f;FR;t;Europe/Paris;t;FRTHO;;t;;f;8704714;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5298;Haute-Picardie TGV;haute-picardie-tgv;8731388;87313882;49.859082553758014;2.832198143005371;;f;FR;f;Europe/Paris;t;FRTHP;HPI;t;;f;8704957;f;;f;THP;t;;f;;;f;;f;;f;;f;t;;40km von Amiens und Saint-Quentin entfernt;40km from Amiens and Saint-Quentin;a 40 km de Amiens y Saint-Quentin;à 40 km d’Amiens et Saint-Quentin;40km da Amiens e Saint-Quentin;;;;;;;;;;;;
-5299;Thouars;thouars;8748700;87487009;46.985204;-0.209799;;f;FR;f;Europe/Paris;t;FRTHR;;t;;f;8704717;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Туар;;;圖阿爾
+5298;Haute-Picardie TGV;haute-picardie-tgv;8731388;87313882;49.859082553758014;2.832198143005371;;f;FR;f;Europe/Paris;t;FRTHP;HPI;t;;f;8704957;f;;f;THP;t;;f;;;f;;f;8700506;f;;f;t;;40km von Amiens und Saint-Quentin entfernt;40km from Amiens and Saint-Quentin;a 40 km de Amiens y Saint-Quentin;à 40 km d’Amiens et Saint-Quentin;40km da Amiens e Saint-Quentin;;;;;;;;;;;;
+5299;Thouars;thouars;8748700;87487009;46.985204;-0.209799;;f;FR;f;Europe/Paris;t;FRTHR;;t;;f;8704717;f;;f;;f;;f;;;f;;f;8700612;f;;f;f;;;;;;;;;;;;;;;Туар;;;圖阿爾
 5300;Thoiry;thoiry;;;;;;t;FR;f;Europe/Paris;f;FRTHV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5304;Toulon;toulon;8775500;87755009;43.128409;5.929599;;f;FR;f;Europe/Paris;t;FRTLN;TLN;t;TLN;t;8700108;f;spsjr1;t;;f;8775500;t;;;f;;f;;f;;f;t;;;;Tolón;;Tolone;;;;;トゥーロン;툴롱;Tulon;;Тулон;;;土伦
+5304;Toulon;toulon;8775500;87755009;43.128409;5.929599;;f;FR;f;Europe/Paris;t;FRTLN;TLN;t;TLN;t;8700108;f;spsjr1;t;;f;8775500;t;;;f;;f;8700190;f;;f;t;;;;Tolón;;Tolone;;;;;トゥーロン;툴롱;Tulon;;Тулон;;;土伦
 5306;Toulouse;toulouse;9900006;;43.60446386099808;1.444004774093628;;t;FR;f;Europe/Paris;t;FRTLS;;t;;f;;f;spc00c;t;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5307;Toulouse St-Michel;toulouse-st-michel;8744372;87443721;43.586095272195166;1.447121500968933;5306;f;FR;f;Europe/Paris;t;FRUIC;;t;;f;8705995;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5308;Toulouse Langlade;toulouse-langlade;8744946;87449462;43.572045;1.44302;5306;f;FR;f;Europe/Paris;t;FRULK;;t;;f;8706103;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5310;Toulouse Croix de Pierre;toulouse-croix-de-pierre;8744999;87449991;43.5852870498513;1.4282548427581785;5306;f;FR;f;Europe/Paris;t;FRULL;;t;;f;8706104;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
-5311;Toulouse Matabiau;toulouse-matabiau;8761100;87611004;43.611409;1.453942;5306;f;FR;t;Europe/Paris;t;FRXYT;TSE;t;XYT;t;8700065;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
+5311;Toulouse Matabiau;toulouse-matabiau;8761100;87611004;43.611409;1.453942;5306;f;FR;t;Europe/Paris;t;FRXYT;TSE;t;XYT;t;8700065;f;;f;;f;;f;;;f;;f;8700079;f;;f;t;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5312;Toulouse Jeanne d’Arc;toulouse-jeanne-darc;8744373;87443739;43.621522;1.465951;5306;f;FR;f;Europe/Paris;t;FRUIO;;t;;f;8705996;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5313;Toulouse Bellevue;toulouse-bellevue;8744371;87443713;43.604496;1.461502;5306;f;FR;f;Europe/Paris;t;FRUIB;;t;;f;8705994;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5314;Troyes St-Martin Delaunay;troyes-st-martin-delaunay;8713950;87139501;48.311787;4.047959;5342;f;FR;f;Europe/Paris;t;FRTMD;;t;;f;8705066;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4004,19 +4004,19 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5318;Nantes Centre;nantes-centre;8721351;87213512;47.216317;-1.548329;5317;f;FR;f;Europe/Paris;f;FRTSC;;t;;f;8705098;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5320;La Trinité-sur-Mer;la-trinite-sur-mer;8728965;87289652;47.58845936232747;-3.028331995010376;;f;FR;f;Europe/Paris;t;FRTNM;;t;;f;8702711;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5321;Trannes;trannes;8721573;87215731;48.300209;4.586736;;f;FR;f;Europe/Paris;t;FRTNS;;t;;f;8705170;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5322;Toul;toul;8714104;87141044;48.678997;5.880931;;f;FR;f;Europe/Paris;t;FRTOL;TOL;t;;f;8700263;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;トゥール;툴;;;Туль;;;图勒
+5322;Toul;toul;8714104;87141044;48.678997;5.880931;;f;FR;f;Europe/Paris;t;FRTOL;TOL;t;;f;8700263;f;;f;;f;;f;;;f;;f;8700921;f;;f;t;;;;;;;;;;;トゥール;툴;;;Туль;;;图勒
 5323;Tournon Centre;tournon-centre;8776146;87761460;45.061773;4.833212;;f;FR;f;Europe/Paris;f;FRTOU;;t;;f;8705279;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5324;Chatonrupt;chatonrupt;8710748;87107482;48.4833330000;5.1166670000;;f;FR;f;Europe/Paris;t;FRTPT;;t;;f;8705035;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5326;Troyes Quennedey;troyes-quennedey;8731258;87312587;48.262841;4.126821;5342;f;FR;f;Europe/Paris;t;FRTQY;;t;;f;8700476;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5327;Trébeurden;trebeurden;8733829;;48.7694774382905;-3.5650473833084106;;f;FR;f;Europe/Paris;t;FRTRB;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Требёрден;;;特雷伯尔当
-5328;Trouville—Deauville;trouville-deauville;8744437;87444372;49.35963978644228;0.08439302444458006;9995;f;FR;t;Europe/Paris;t;FRTRD;TDE;t;;f;8704747;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5328;Trouville—Deauville;trouville-deauville;8744437;87444372;49.35963978644228;0.08439302444458006;9995;f;FR;t;Europe/Paris;t;FRTRD;TDE;t;;f;8704747;f;;f;;f;;f;;;f;;f;8700788;f;;f;t;;;;;;;;;;;;;;;;;;
 5329;Trégastel;tregastel;8733831;87338319;48.822702940150755;-3.5093647241592407;;f;FR;f;Europe/Paris;t;FRTRF;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5330;Le Tranger;le-tranger;8720677;87206771;46.9500000000;1.2333330000;;f;FR;f;Europe/Paris;t;FRTRG;;t;;f;8705192;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5331;Traou-Nez;traou-nez;8732234;87322347;48.748555;-3.13488;;f;FR;f;Europe/Paris;t;FRTRN;;t;;f;8704984;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5333;Toutry;toutry;8713999;87139998;47.503253;4.115225;;f;FR;f;Europe/Paris;t;FRTRY;;t;;f;8705104;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5334;Troyes Delestraint Belgique;troyes-delestraint-belgique;8713965;87139659;48.2883687684885;4.07392680644989;5342;f;FR;f;Europe/Paris;t;FRTSA;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5335;Genève;geneve;8585444;;46.208942;6.145262;;t;CH;f;Europe/Zurich;t;FRTTX;;t;;f;;f;u0hqgf;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5336;Genève Cornavin;geneve-cornavin;8501008;85010082;46.210208;6.142428;5335;f;CH;t;Europe/Zurich;t;CHGVA;;t;;f;8501008;t;;f;;f;8501008;t;;;f;;f;;f;;f;f;;Genf Hauptbahnhof;Geneva Main station;Ginebra Estación central;;Ginevra Stazione centrale;;Ženeva;;Genf;ジュネーヴ;제네바;Genewa;Genebra;Женева;;Cenevre;日内瓦
+5336;Genève Cornavin;geneve-cornavin;8501008;85010082;46.210208;6.142428;5335;f;CH;t;Europe/Zurich;t;CHGVA;;t;;f;8501008;t;;f;;f;8501008;t;;;f;;f;85444;f;;f;f;;Genf Hauptbahnhof;Geneva Main station;Ginebra Estación central;;Ginevra Stazione centrale;;Ženeva;;Genf;ジュネーヴ;제네바;Genewa;Genebra;Женева;;Cenevre;日内瓦
 5337;Genève;geneve;8585440;;;;5335;f;CH;f;Europe/Zurich;f;CHAFH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5338;Tours;tours;;;;;;t;FR;f;Europe/Paris;f;FRTUF;;t;;f;;f;u02mx9;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5339;La Tuque;la-tuque;8713435;87134353;44.139966;0.656392;;f;FR;f;Europe/Paris;t;FRTUQ;;t;;f;8705049;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4105,7 +4105,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5429;Verfeil—Fenouille;verfeil-fenouille;8744315;87443150;43.656813;1.669162;;f;FR;f;Europe/Paris;t;FRUIK;;t;;f;8706177;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5430;Gaillac Place de la Libération;gaillac-place-de-la-liberation;8717752;87177527;43.9000000000;1.9166670000;;f;FR;f;Europe/Paris;t;FRUIM;;t;;f;8706049;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5431;Lisle-sur-Tarn Place Paul Saissac;lisle-sur-tarn-place-paul-saissac;8744285;87442855;43.8500000000;1.8000000000;;f;FR;f;Europe/Paris;t;FRUIN;;t;;f;8706050;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5432;Quimper;quimper;8747409;87474098;47.99453845483072;-4.092122912406921;;f;FR;f;Europe/Paris;t;FRUIP;QPR;t;UIP;t;8700208;f;gbt14b;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;カンペール;캥페르;;;Кемпер;;;坎佩尔
+5432;Quimper;quimper;8747409;87474098;47.99453845483072;-4.092122912406921;;f;FR;f;Europe/Paris;t;FRUIP;QPR;t;UIP;t;8700208;f;gbt14b;t;;f;;f;;;f;;f;8700682;f;;f;t;;;;;;;;;;;カンペール;캥페르;;;Кемпер;;;坎佩尔
 5433;Rabastens-de-Bigorre Centre;rabastens-de-bigorre-centre;8744286;87442863;43.819448973072184;1.7304325103759766;;f;FR;f;Europe/Paris;t;FRUIQ;;t;;f;8706051;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5434;St-Sulpice Gare Routière;st-sulpice-gare-routiere;8744188;87441881;43.7833330000;1.7000000000;;f;FR;f;Europe/Paris;f;FRUIR;;t;;f;8706052;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5435;L’Huis-Renaud;lhuis-renaud;8720468;87204685;47.186284;4.2782;;f;FR;f;Europe/Paris;t;FRUIS;;t;;f;8705105;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4261,18 +4261,18 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5597;Seuzac;seuzac;8716711;87167114;44.474841;1.807919;;f;FR;f;Europe/Paris;t;FRUPQ;;t;;f;8706278;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5598;Urt;urt;;;;;;t;FR;f;Europe/Paris;f;FRURC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5599;Urt;urt;8767238;87672386;43.499385;-1.300586;5598;f;FR;t;Europe/Paris;t;FRURT;;t;;f;8702144;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Ahurti;;;;;;;;;;;;;;于尔
-5601;Rouen Rive Droite;rouen-rive-droite;8741101;87411017;49.44904;1.094113;5603;f;FR;t;Europe/Paris;t;FRURD;RRD;t;;f;8700113;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;Ruan;;;;;;;ルーアン;루앙;;Ruão;Руан;;;鲁昂
+5601;Rouen Rive Droite;rouen-rive-droite;8741101;87411017;49.44904;1.094113;5603;f;FR;t;Europe/Paris;t;FRURD;RRD;t;;f;8700113;f;;f;;f;;f;;;f;;f;8700204;f;;f;t;;;;Ruan;;;;;;;ルーアン;루앙;;Ruão;Руан;;;鲁昂
 5602;Rouen Gare Routière;rouen-gare-routiere;8740189;87401893;49.4431290000;1.0993190000;5601;f;FR;f;Europe/Paris;f;FRURG;;f;;f;8705355;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5603;Rouen;rouen;9919002;;49.4431290000;1.0993190000;;t;FR;f;Europe/Paris;t;FRURL;;t;;f;;f;u0bc30;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5604;Aubusson;aubusson;;;45.95473010854736;2.1672892570495605;;t;FR;f;Europe/Paris;f;FRUSO;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5605;Ussel;ussel;8759409;87594093;45.557475;2.314353;10657;f;FR;f;Europe/Paris;t;FRUSS;USL;t;;f;8700098;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5605;Ussel;ussel;8759409;87594093;45.557475;2.314353;10657;f;FR;f;Europe/Paris;t;FRUSS;USL;t;;f;8700098;f;;f;;f;;f;;;f;;f;8700174;f;;f;f;;;;;;;;;;;;;;;;;;
 5606;Eurville;eurville;;;48.5833330000;5.0333330000;;t;FR;f;Europe/Paris;f;FRUVI;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5607;Uzerche;uzerche;;;;;;t;FR;f;Europe/Paris;f;FRUZC;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5608;Uzer;uzer;8776481;87764811;44.523059;4.324251;;f;FR;f;Europe/Paris;t;FRUZR;;t;;f;8705284;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5609;Ailleville;ailleville;8721562;87215624;48.2500000000;4.6833330000;;f;FR;f;Europe/Paris;t;FRVAA;;t;;f;8705167;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5610;Valence Ville;valence-ville;8776100;87761007;44.927654;4.893475;5611;f;FR;f;Europe/Paris;t;FRVAF;VCE;t;;f;8700056;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5611;Valence;valence;8724857;;44.93324;4.89236;;t;FR;f;Europe/Paris;t;FRVAV;;t;;f;;f;spgrxe;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5614;Valence TGV;valence-tgv;8776302;87763029;44.991975191343265;4.978635907173157;5611;f;FR;f;Europe/Paris;t;FRVLA;VAL;t;;f;8704943;f;;f;VCE;t;8776302;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5610;Valence Ville;valence-ville;8776100;87761007;44.927654;4.893475;5611;f;FR;f;Europe/Paris;t;FRVAF;VCE;t;;f;8700056;f;;f;;f;;f;;;f;;f;8700067;f;;f;t;;;;;;;;;;;;;;;;;;
+5611;Valence;valence;8724857;;44.93324;4.89236;;t;FR;f;Europe/Paris;t;FRVAV;;t;;f;;f;spgrxe;t;;f;;f;;;f;;f;87067;f;;f;f;;;;;;;;;;;;;;;;;;
+5614;Valence TGV;valence-tgv;8776302;87763029;44.991975191343265;4.978635907173157;5611;f;FR;f;Europe/Paris;t;FRVLA;VAL;t;;f;8704943;f;;f;VCE;t;8776302;f;;;f;;f;8700810;f;;f;t;;;;;;;;;;;;;;;;;;
 5616;Barbonvielle;barbonvielle;8713436;87134361;44.031331;0.67179;;f;FR;f;Europe/Paris;t;FRVBB;;t;;f;8705050;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5617;Vouciennes;vouciennes;8717333;87173336;48.844156;4.450631;;f;FR;f;Europe/Paris;t;FRVCN;;t;;f;8705188;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5618;Vouecourt;vouecourt;8727986;87279869;48.267354;5.132912;;f;FR;f;Europe/Paris;t;FRVCT;;t;;f;8705189;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4282,7 +4282,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5622;St-Vaast-Dieppedalle;st-vaast-dieppedalle;8700971;87009712;49.7500000000;0.7166670000;;f;FR;f;Europe/Paris;t;FRVDP;;t;;f;8705051;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5623;Val-de-Reuil;val-de-reuil;8741587;87415877;49.275467;1.224987;;f;FR;f;Europe/Paris;t;FRVDR;VDR;t;;f;8700321;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5625;Vendeuvre;vendeuvre;;;;;;t;FR;f;Europe/Paris;f;FRVDV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5626;Veynes—Dévoluy;veynes-devoluy;8776330;87763300;44.53200353825134;5.815737247467041;;f;FR;f;Europe/Paris;t;FRVDY;VDY;t;;f;8700110;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5626;Veynes—Dévoluy;veynes-devoluy;8776330;87763300;44.53200353825134;5.815737247467041;;f;FR;f;Europe/Paris;t;FRVDY;VDY;t;;f;8700110;f;;f;;f;;f;;;f;;f;8700196;f;;f;f;;;;;;;;;;;;;;;;;;
 5627;Velluire Centre;velluire-centre;8733417;;46.402218;-0.894363;;f;FR;f;Europe/Paris;t;FRVEC;;t;;f;8702449;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5630;Ventimiglia;ventimiglia;8383322;;;;;t;IT;f;Europe/Rome;f;FRVES;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5633;Vitry-le-François Office de Tourisme;vitry-le-francois-office-de-tourisme;8732639;87326397;48.719961;4.583797;5655;f;FR;f;Europe/Paris;t;FRVFO;;t;;f;8703736;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Витри-ле-Франсуа;;;维特里勒弗朗索瓦
@@ -4290,10 +4290,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5635;Vignory Centre;vignory-centre;8710740;87107409;48.280118;5.110232;5672;f;FR;f;Europe/Paris;t;FRVGC;;t;;f;8705036;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5636;Chauvigny;chauvigny;8720246;87202465;46.5666670000;0.6500000000;;f;FR;f;Europe/Paris;t;FRVGY;;t;;f;8705081;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5637;Vendenheim;vendenheim;8721211;87212118;48.666097;7.718219;;f;FR;f;Europe/Paris;t;FRVHM;VHM;t;;f;8702148;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5638;Vichy;vichy;8773200;87732008;46.12666783946477;3.430910110473633;;f;FR;f;Europe/Paris;t;FRVHY;VHY;t;;f;8700120;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ヴィシー;비시;;;Виши;;;维琪
+5638;Vichy;vichy;8773200;87732008;46.12666783946477;3.430910110473633;;f;FR;f;Europe/Paris;t;FRVHY;VHY;t;;f;8700120;f;;f;;f;;f;;;f;;f;8700219;f;;f;t;;;;;;;;;;;ヴィシー;비시;;;Виши;;;维琪
 5639;Viéville;vieville;8731975;87319756;48.227846;5.124642;;f;FR;f;Europe/Paris;t;FRVIE;;t;;f;8702780;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5640;Vif;vif;8774757;87747576;45.047579;5.685434;;f;FR;f;Europe/Paris;t;FRVIF;;t;;f;8704842;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5641;Villefranche-sur-Mer;villefranche-sur-mer;8775636;87756361;43.706928;7.314171;;f;FR;f;Europe/Paris;t;FRVIM;;t;;f;8702169;f;;f;;f;8775636;f;;;f;;f;;f;;f;f;;;;;;Villafranca Marittima;;;;;ヴィルフランシュ＝シュル＝メール;;;;Вильфранш-сюр-Мер;;;滨海自由城
+5641;Villefranche-sur-Mer;villefranche-sur-mer;8775636;87756361;43.706928;7.314171;;f;FR;f;Europe/Paris;t;FRVIM;;t;;f;8702169;f;;f;;f;8775636;f;;;f;;f;8700250;f;;f;f;;;;;;Villafranca Marittima;;;;;ヴィルフランシュ＝シュル＝メール;;;;Вильфранш-сюр-Мер;;;滨海自由城
 5642;Villefranche-Vernet-les-Bains;villefranche-vernet-les-bains;8778468;87784686;42.591723892220664;2.3703324794769287;;f;FR;f;Europe/Paris;t;FRVIV;;t;;f;8700454;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5643;Valréas Rond-Point;valreas-rond-point;8724008;87240085;44.387537;4.986586;;f;FR;f;Europe/Paris;t;FRVIW;;t;;f;8705829;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5644;Vix Centre;vix-centre;8748508;87485086;46.364625;-0.872816;;f;FR;f;Europe/Paris;t;FRVIX;;t;;f;8702450;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4304,14 +4304,14 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5650;Cruas Centre;cruas-centre;8750454;;44.6500000000;4.7666670000;;f;FR;f;Europe/Paris;t;FRVJM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5655;Vitry-le-François;vitry-le-francois;;;;;;t;FR;f;Europe/Paris;f;FRVLF;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5656;Blonville;blonville;;;49.3166670000;0.0333330000;;t;FR;f;Europe/Paris;f;FRVLL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5657;Villeneuve-St-Georges;villeneuve-st-georges;;;48.730172;2.446243;;t;FR;f;Europe/Paris;t;FRVLN;;t;;f;8704867;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5657;Villeneuve-St-Georges;villeneuve-st-georges;;;48.730172;2.446243;;t;FR;f;Europe/Paris;t;FRVLN;;t;;f;8704867;f;;f;;f;;f;;;f;;f;8700140;f;;f;t;;;;;;;;;;;;;;;;;;
 5658;Villedieu-les-Poêles;villedieu-les-poeles;;;;;;t;FR;f;Europe/Paris;f;FRVLP;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5660;Vitrey-sur-Mance;vitrey-sur-mance;8731656;87316562;47.828833;5.753545;;f;FR;f;Europe/Paris;t;FRVMA;;t;;f;8703059;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5661;Villers-sur-Mer;villers-sur-mer;;;;;;t;FR;f;Europe/Paris;f;FRVMR;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5663;Vannes;vannes;8747660;87476606;47.665256;-2.752559;;f;FR;f;Europe/Paris;t;FRVNE;VAN;t;VNE;t;8700205;f;gbqp15;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ヴァンヌ;반;;;Ванн;;;瓦讷
+5663;Vannes;vannes;8747660;87476606;47.665256;-2.752559;;f;FR;f;Europe/Paris;t;FRVNE;VAN;t;VNE;t;8700205;f;gbqp15;t;;f;;f;;;f;;f;8700675;f;;f;t;;;;;;;;;;;ヴァンヌ;반;;;Ванн;;;瓦讷
 5664;St-Pantaléon-les-Vignes;st-pantaleon-les-vignes;8724020;87240200;44.398064;5.041339;;f;FR;f;Europe/Paris;t;FRVNG;;t;;f;8705845;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5665;Vogue Centre;vogue-centre;8776473;87764738;44.542916;4.414206;;f;FR;f;Europe/Paris;t;FRVOG;;t;;f;8705289;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5666;Volvic;volvic;8764142;87641423;45.864987;3.002954;;f;FR;f;Europe/Paris;t;FRVOL;;t;;f;8702242;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ヴォルヴィック;볼빅;;;;;;沃尔维克
+5666;Volvic;volvic;8764142;87641423;45.864987;3.002954;;f;FR;f;Europe/Paris;t;FRVOL;;t;;f;8702242;f;;f;;f;;f;;;f;;f;8700985;f;;f;f;;;;;;;;;;;ヴォルヴィック;볼빅;;;;;;沃尔维克
 5667;La Voulte;la-voulte;;;44.8000000000;4.7833330000;;t;FR;f;Europe/Paris;f;FRVOU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5668;Vallon-Pont-d’Arc;vallon-pont-darc;8792902;87929026;44.407431;4.385441;;f;FR;f;Europe/Paris;t;FRVPA;;t;;f;8704771;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5669;Veyras;veyras;8733701;87337014;44.727465;4.556173;;f;FR;f;Europe/Paris;t;FRVRA;;t;;f;8705290;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4319,11 +4319,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5671;Ventimiglia Frontière;ventimiglia-frontiere;8775690;;;;5630;f;IT;f;Europe/Rome;f;FRVRM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;Vintimille;;;;;;ヴェンティミーリア;;;;Вентимилья;;;文蒂米利亚
 5672;Vignory;vignory;;;;;;t;FR;f;Europe/Paris;f;FRVRY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5673;Vierzon;vierzon;;;;;;t;FR;f;Europe/Paris;f;FRVRZ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5674;Vierzon;vierzon;8757600;87576009;47.226726;2.05995;5673;f;FR;t;Europe/Paris;t;FRXVZ;VER;t;;f;8704839;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ヴィエルゾン;;;;Вьерзон;;;维耶尔宗
+5674;Vierzon;vierzon;8757600;87576009;47.226726;2.05995;5673;f;FR;t;Europe/Paris;t;FRXVZ;VER;t;;f;8704839;f;;f;;f;;f;;;f;;f;8700006;f;;f;t;;;;;;;;;;;ヴィエルゾン;;;;Вьерзон;;;维耶尔宗
 5675;Viescamp-sous-Jalles;viescamp-sous-jalles;8764511;;;;;f;FR;f;Europe/Paris;f;FRVSJ;;t;;f;8704840;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5676;Ville-sous-la-Ferté;ville-sous-la-ferte;8721558;87215582;48.122205;4.78947;;f;FR;f;Europe/Paris;t;FRVSL;;t;;f;8705162;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5677;Vesseaux;vesseaux;8733702;87337022;44.65221513717455;4.44371223449707;;f;FR;f;Europe/Paris;t;FRVSX;;t;;f;8705291;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5678;Vittel;vittel;8714427;87144279;48.202505;5.94186;;f;FR;f;Europe/Paris;t;FRVTL;;t;;f;8700520;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ヴィッテル;;;;;;;维特
+5678;Vittel;vittel;8714427;87144279;48.202505;5.94186;;f;FR;f;Europe/Paris;t;FRVTL;;t;;f;8700520;f;;f;;f;;f;;;f;;f;8700370;f;;f;f;;;;;;;;;;;ヴィッテル;;;;;;;维特
 5679;Venterol;venterol;8724021;87240218;44.389839;5.094942;;f;FR;f;Europe/Paris;t;FRVTN;;t;;f;8705846;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5680;Vitry-la-Ville;vitry-la-ville;;;;;;t;FR;f;Europe/Paris;f;FRVTV;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5681;Vitry-la-Ville Mairie;vitry-la-ville-mairie;8721476;;48.837638;4.45757;5680;f;FR;t;Europe/Paris;f;FRVTY;;f;;f;8705187;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4359,142 +4359,142 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5711;Wingen-sur-Moder;wingen-sur-moder;8721374;87213744;48.920357;7.381869;;f;FR;f;Europe/Paris;t;FRWIM;WMG;t;;f;8700327;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5713;Vauchonvilliers;vauchonvilliers;8727992;;48.259542;4.529358;;f;FR;f;Europe/Paris;t;FRWPA;;t;;f;8705172;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5715;Wissembourg;wissembourg;;;;;;t;FR;f;Europe/Paris;f;FRWSL;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5720;Dives—Cabourg;dives-cabourg;8744441;87444414;49.28647;-0.107807;10248;f;FR;t;Europe/Paris;t;FRXDC;;t;;f;8703221;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5720;Dives—Cabourg;dives-cabourg;8744441;87444414;49.28647;-0.107807;10248;f;FR;t;Europe/Paris;t;FRXDC;;t;;f;8703221;f;;f;;f;;f;;;f;;f;8700792;f;;f;f;;;;;;;;;;;;;;;;;;
 5741;Arsonval;arsonval;8721570;87215707;48.2666670000;4.6500000000;;f;FR;f;Europe/Paris;t;FRXAA;;t;;f;8705168;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5742;Abbeville;abbeville;8731736;87317362;50.10215589451615;1.8243902921676636;;f;FR;f;Europe/Paris;t;FRXAB;ABB;t;;f;8700238;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アブヴィル;아브빌;;;Абвиль;;;阿贝维尔拉里维埃
-5743;Arcachon;arcachon;8758266;87582668;44.65897699818545;-1.1657309532165525;;f;FR;f;Europe/Paris;t;FRXAC;ARC;t;;f;8700197;f;ezznj3;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;アルカション;;;;Аркашон;;;阿尔卡雄
-5744;Agde;agde;8778127;87781278;43.31732542255665;3.4661972522735596;;f;FR;f;Europe/Paris;t;FRXAG;AGD;t;;f;8700145;f;spdw20;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;アグド;;;;Агд;;;阿格德
-5745;Aix-les-Bains—Le Revard;aix-les-bains-le-revard;8774113;87741132;45.68809730934939;5.909056663513184;;f;FR;f;Europe/Paris;t;FRXAI;AIX;t;XAI;f;8700048;f;;f;;f;8774113;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5746;Amboise;amboise;8757434;87574343;47.42146734975387;0.9812164306640625;;f;FR;f;Europe/Paris;t;FRXAM;AMQ;t;;f;8700607;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;アンボワーズ;;;;Амбуаз;;;昂布瓦斯
-5747;Alençon;alencon;8744471;87444711;48.4339;0.0984;;f;FR;f;Europe/Paris;t;FRXAN;ALN;t;;f;8700141;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;Alenzón;;;;;;;アランソン;;;;Алансон;;;阿朗松
-5748;Alès;ales;8777528;87775288;44.12793673360334;4.085025787353515;;f;FR;f;Europe/Paris;t;FRXAS;ALS;t;;f;8700126;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5749;Antibes;antibes;8775767;87757674;43.58569116237965;7.119462490081787;;f;FR;f;Europe/Paris;t;FRXAT;ATB;t;;f;8700146;f;;f;;f;8775767;t;;;f;;f;;f;;f;t;;;;;;;;;;;アンティーブ;앙티브;;;Антиб;;;昂蒂布
-5750;Albertville;albertville;8774164;87741645;45.67309824794535;6.383163928985596;;f;FR;f;Europe/Paris;t;FRXAV;ALV;t;XAV;t;8700128;f;;f;;f;8774164;f;;;f;;f;;f;;f;t;;;;;;;;;;;アルベールヴィル;알베르빌;;;Альбервиль;;;阿尔贝维尔
+5742;Abbeville;abbeville;8731736;87317362;50.10215589451615;1.8243902921676636;;f;FR;f;Europe/Paris;t;FRXAB;ABB;t;;f;8700238;f;;f;;f;;f;;;f;;f;8700848;f;;f;t;;;;;;;;;;;アブヴィル;아브빌;;;Абвиль;;;阿贝维尔拉里维埃
+5743;Arcachon;arcachon;8758266;87582668;44.65897699818545;-1.1657309532165525;;f;FR;f;Europe/Paris;t;FRXAC;ARC;t;;f;8700197;f;ezznj3;t;;f;;f;;;f;;f;8700588;f;;f;f;;;;;;;;;;;アルカション;;;;Аркашон;;;阿尔卡雄
+5744;Agde;agde;8778127;87781278;43.31732542255665;3.4661972522735596;;f;FR;f;Europe/Paris;t;FRXAG;AGD;t;;f;8700145;f;spdw20;t;;f;;f;;;f;;f;8700287;f;;f;t;;;;;;;;;;;アグド;;;;Агд;;;阿格德
+5745;Aix-les-Bains—Le Revard;aix-les-bains-le-revard;8774113;87741132;45.68809730934939;5.909056663513184;;f;FR;f;Europe/Paris;t;FRXAI;AIX;t;XAI;f;8700048;f;;f;;f;8774113;f;;;f;;f;8700059;f;;f;t;;;;;;;;;;;;;;;;;;
+5746;Amboise;amboise;8757434;87574343;47.42146734975387;0.9812164306640625;;f;FR;f;Europe/Paris;t;FRXAM;AMQ;t;;f;8700607;f;;f;;f;;f;;;f;;f;8700637;f;;f;f;;;;;;;;;;;アンボワーズ;;;;Амбуаз;;;昂布瓦斯
+5747;Alençon;alencon;8744471;87444711;48.4339;0.0984;;f;FR;f;Europe/Paris;t;FRXAN;ALN;t;;f;8700141;f;;f;;f;;f;;;f;;f;8700280;f;;f;t;;;;Alenzón;;;;;;;アランソン;;;;Алансон;;;阿朗松
+5748;Alès;ales;8777528;87775288;44.12793673360334;4.085025787353515;;f;FR;f;Europe/Paris;t;FRXAS;ALS;t;;f;8700126;f;;f;;f;;f;;;f;;f;8700239;f;;f;t;;;;;;;;;;;;;;;;;;
+5749;Antibes;antibes;8775767;87757674;43.58569116237965;7.119462490081787;;f;FR;f;Europe/Paris;t;FRXAT;ATB;t;;f;8700146;f;;f;;f;8775767;t;;;f;;f;8700289;f;;f;t;;;;;;;;;;;アンティーブ;앙티브;;;Антиб;;;昂蒂布
+5750;Albertville;albertville;8774164;87741645;45.67309824794535;6.383163928985596;;f;FR;f;Europe/Paris;t;FRXAV;ALV;t;XAV;t;8700128;f;;f;;f;8774164;f;;;f;;f;8700244;f;;f;t;;;;;;;;;;;アルベールヴィル;알베르빌;;;Альбервиль;;;阿尔贝维尔
 5751;Barèges;bareges;8762017;87620179;42.9000000000;0.0666670000;;f;FR;f;Europe/Paris;t;FRXBA;;t;;f;8702772;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;巴雷热
-5752;Briançon;briancon;8776360;87763607;44.889969340028685;6.633086800575256;;f;FR;f;Europe/Paris;t;FRXBC;BRI;t;;f;8700158;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ブリアンソン;;;;Бриансон;;;布里昂松
-5753;Bar-le-Duc;bar-le-duc;8717504;87175042;48.773613961208746;5.167179107666016;;f;FR;f;Europe/Paris;t;FRXBD;BLD;t;;f;8700262;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;バル＝ル＝デュック;;;;Бар-ле-Дюк;;;巴勒迪克
-5754;Béthune;bethune;8734200;87342006;50.521189823237755;2.640151977539062;;f;FR;f;Europe/Paris;t;FRXBH;BET;t;;f;8700245;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ベテューヌ;;;;Бетюн;;;贝蒂讷
-5755;Bourg-en-Bresse;bourg-en-bresse;8774300;87743005;46.20003995671398;5.214600563049316;;f;FR;f;Europe/Paris;t;FRXBK;BGB;t;;f;8700037;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ブール＝ガン＝ブレス;;;;Бурк-ан-Брес;;;布雷斯地区布尔格
-5756;Beaulieu-sur-Mer;beaulieu-sur-mer;8775637;87756379;43.70665506746812;7.331673502922059;;f;FR;f;Europe/Paris;t;FRXBM;;t;;f;8700446;f;;f;;f;8775637;f;;;f;;f;;f;;f;f;;;;;;Belluogo;;;;;ボーリュー＝シュル＝メール;;;;Больё-сюр-Мер;;;滨海博略
-5757;Blois – Chambord;blois-chambord;8757400;87574004;47.58535499390333;1.3235950469970703;;f;FR;f;Europe/Paris;t;FRXBQ;BLO;t;;f;8700193;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ブロワ;블루아;;;Блуа;;;布卢瓦
+5752;Briançon;briancon;8776360;87763607;44.889969340028685;6.633086800575256;;f;FR;f;Europe/Paris;t;FRXBC;BRI;t;;f;8700158;f;;f;;f;;f;;;f;;f;8700342;f;;f;f;;;;;;;;;;;ブリアンソン;;;;Бриансон;;;布里昂松
+5753;Bar-le-Duc;bar-le-duc;8717504;87175042;48.773613961208746;5.167179107666016;;f;FR;f;Europe/Paris;t;FRXBD;BLD;t;;f;8700262;f;;f;;f;;f;;;f;;f;8700918;f;;f;t;;;;;;;;;;;バル＝ル＝デュック;;;;Бар-ле-Дюк;;;巴勒迪克
+5754;Béthune;bethune;8734200;87342006;50.521189823237755;2.640151977539062;;f;FR;f;Europe/Paris;t;FRXBH;BET;t;;f;8700245;f;;f;;f;;f;;;f;;f;8700858;f;;f;t;;;;;;;;;;;ベテューヌ;;;;Бетюн;;;贝蒂讷
+5755;Bourg-en-Bresse;bourg-en-bresse;8774300;87743005;46.20003995671398;5.214600563049316;;f;FR;f;Europe/Paris;t;FRXBK;BGB;t;;f;8700037;f;;f;;f;;f;;;f;;f;8700045;f;;f;t;;;;;;;;;;;ブール＝ガン＝ブレス;;;;Бурк-ан-Брес;;;布雷斯地区布尔格
+5756;Beaulieu-sur-Mer;beaulieu-sur-mer;8775637;87756379;43.70665506746812;7.331673502922059;;f;FR;f;Europe/Paris;t;FRXBM;;t;;f;8700446;f;;f;;f;8775637;f;;;f;;f;8700292;f;;f;f;;;;;;Belluogo;;;;;ボーリュー＝シュル＝メール;;;;Больё-сюр-Мер;;;滨海博略
+5757;Blois – Chambord;blois-chambord;8757400;87574004;47.58535499390333;1.3235950469970703;;f;FR;f;Europe/Paris;t;FRXBQ;BLO;t;;f;8700193;f;;f;;f;;f;;;f;;f;87546;f;;f;t;;;;;;;;;;;ブロワ;블루아;;;Блуа;;;布卢瓦
 5758;Boulogne-sur-Mer;boulogne-sur-mer;;;50.7696340000;1.6113850000;;t;FR;f;Europe/Paris;f;FRXBS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5759;Banyuls-sur-Mer;banyuls-sur-mer;8778429;87784298;42.482948;3.124839;;f;FR;f;Europe/Paris;t;FRXBU;BAN;t;;f;8700485;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5760;Beaune;beaune;8771354;87713545;47.023041133284266;4.848489761352539;;f;FR;f;Europe/Paris;t;FRXBV;BEA;t;;f;8700550;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ボーヌ;;;;Бон;;;博恩拉罗朗德
-5761;Bernay;bernay;8744429;87444299;49.08697196091214;0.5957293510437012;;f;FR;f;Europe/Paris;t;FRXBX;BEY;t;;f;8700221;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5762;Bayonne;bayonne;8767300;87673004;43.49709463180589;-1.4703547954559326;;f;FR;f;Europe/Paris;t;FRXBY;BYE;t;XBY;t;8700257;f;ezwzq5;t;;f;;f;;;f;;f;;f;;f;t;;;;Baiona;;;;;;;バイヨンヌ;바욘;Bajonna;Baiona;Байонна;;;巴约讷
-5763;Bandol;bandol;8775522;87755223;43.14046747767621;5.750162601470947;;f;FR;f;Europe/Paris;t;FRXBZ;;t;;f;8700665;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Бандоль;;;邦多
+5759;Banyuls-sur-Mer;banyuls-sur-mer;8778429;87784298;42.482948;3.124839;;f;FR;f;Europe/Paris;t;FRXBU;BAN;t;;f;8700485;f;;f;;f;;f;;;f;;f;8700446;f;;f;f;;;;;;;;;;;;;;;;;;
+5760;Beaune;beaune;8771354;87713545;47.023041133284266;4.848489761352539;;f;FR;f;Europe/Paris;t;FRXBV;BEA;t;;f;8700550;f;;f;;f;;f;;;f;;f;8700343;f;;f;t;;;;;;;;;;;ボーヌ;;;;Бон;;;博恩拉罗朗德
+5761;Bernay;bernay;8744429;87444299;49.08697196091214;0.5957293510437012;;f;FR;f;Europe/Paris;t;FRXBX;BEY;t;;f;8700221;f;;f;;f;;f;;;f;;f;8700767;f;;f;t;;;;;;;;;;;;;;;;;;
+5762;Bayonne;bayonne;8767300;87673004;43.49709463180589;-1.4703547954559326;;f;FR;f;Europe/Paris;t;FRXBY;BYE;t;XBY;t;8700257;f;ezwzq5;t;;f;;f;;;f;;f;8700900;f;;f;t;;;;Baiona;;;;;;;バイヨンヌ;바욘;Bajonna;Baiona;Байонна;;;巴约讷
+5763;Bandol;bandol;8775522;87755223;43.14046747767621;5.750162601470947;;f;FR;f;Europe/Paris;t;FRXBZ;;t;;f;8700665;f;;f;;f;;f;;;f;;f;8700279;f;;f;f;;;;;;;;;;;;;;;Бандоль;;;邦多
 5764;Le Creusot TGV;le-creusot-tgv;8769410;87694109;46.765364;4.500071;;f;FR;f;Europe/Paris;t;FRXCC;LCM;t;;f;8700167;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ル＝クルーゾ;;;;Ле-Крёзо;;;
-5765;Chalon-sur-Saône;chalon-sur-saone;8772500;87725002;46.781034125625254;4.84371542930603;;f;FR;f;Europe/Paris;t;FRXCD;CSS;t;;f;8700091;t;;f;;f;8772500;f;;;f;;f;;f;;f;t;;;;;;;;;;;シャロン＝シュル＝ソーヌ;;;;Шалон-сюр-Сон;;;索恩河畔沙隆
-5766;Cerbère;cerbere;8778500;87785006;42.441661;3.163187;;f;FR;f;Europe/Paris;t;FRXCE;CER;t;;f;8700147;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5765;Chalon-sur-Saône;chalon-sur-saone;8772500;87725002;46.781034125625254;4.84371542930603;;f;FR;f;Europe/Paris;t;FRXCD;CSS;t;;f;8700091;t;;f;;f;8772500;f;;;f;;f;8700130;f;;f;t;;;;;;;;;;;シャロン＝シュル＝ソーヌ;;;;Шалон-сюр-Сон;;;索恩河畔沙隆
+5766;Cerbère;cerbere;8778500;87785006;42.441661;3.163187;;f;FR;f;Europe/Paris;t;FRXCE;CER;t;;f;8700147;f;;f;;f;;f;;;f;;f;8700290;f;;f;t;;;;;;;;;;;;;;;;;;
 5767;Chamonix Mont Blanc;chamonix-mont-blanc;8774678;87746784;45.91990069246709;6.866669654846191;;f;FR;f;Europe/Paris;t;FRXCF;CHX;t;;f;8700299;f;u0hvk2;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5768;Cagnes-sur-Mer;cagnes-sur-mer;;;43.6666670000;7.1500000000;;t;FR;f;Europe/Paris;f;FRXCG;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5769;Compiègne;compiegne;8727669;87276691;49.42230471648786;2.823502421379089;;f;FR;f;Europe/Paris;t;FRXCP;CPE;t;;f;8700246;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;コンピエーニュ;콩피에뉴;;;Компьень;;;贡比涅
-5770;La Ciotat;la-ciotat;8775178;87751784;43.19962313634956;5.632821321487426;;f;FR;f;Europe/Paris;t;FRXCT;;t;;f;8700885;f;;f;;f;8775178;f;;;f;;f;;f;;f;t;;;;;;;;;;;ラ・シオタ;;;;Ла-Сьота;;;拉西奥塔
-5771;Collioure;collioure;8778425;87784256;42.526905;3.078077;;f;FR;f;Europe/Paris;t;FRXCU;COX;t;;f;8700486;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Colliure;;;;;;;コリウール;;;;Коллиур;;;科利乌尔
-5772;Chantilly—Gouvieux;chantilly-gouvieux;8727611;87276113;49.187624;2.459565;;f;FR;f;Europe/Paris;t;FRXCV;CLY;t;;f;8700820;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5773;Châtellerault;chatellerault;8757514;87575142;46.818611837291904;0.5497026443481445;;f;FR;f;Europe/Paris;t;FRXCX;CRT;t;;f;8700553;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;シャテルロー;;;;Шательро;;;沙泰勒罗
-5774;Château-Thierry;chateau-thierry;8711658;87116582;49.037924212467836;3.4095382690429683;;f;FR;f;Europe/Paris;t;FRXCY;CTH;t;;f;8700261;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;シャトー＝ティエリ;;;;Шато-Тьерри;;;蒂耶里堡
-5775;Charleville-Mézières;charleville-mezieres;8717200;87172007;49.76779475895682;4.725322723388671;;f;FR;f;Europe/Paris;t;FRXCZ;CMZ;t;;f;8700050;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;シャルルヴィル＝メジエール;샤를빌메지에르;;;Шарлевиль-Мезьер;;;沙勒维尔-梅济耶尔
+5769;Compiègne;compiegne;8727669;87276691;49.42230471648786;2.823502421379089;;f;FR;f;Europe/Paris;t;FRXCP;CPE;t;;f;8700246;f;;f;;f;;f;;;f;;f;8700864;f;;f;t;;;;;;;;;;;コンピエーニュ;콩피에뉴;;;Компьень;;;贡比涅
+5770;La Ciotat;la-ciotat;8775178;87751784;43.19962313634956;5.632821321487426;;f;FR;f;Europe/Paris;t;FRXCT;;t;;f;8700885;f;;f;;f;8775178;f;;;f;;f;8700180;f;;f;t;;;;;;;;;;;ラ・シオタ;;;;Ла-Сьота;;;拉西奥塔
+5771;Collioure;collioure;8778425;87784256;42.526905;3.078077;;f;FR;f;Europe/Paris;t;FRXCU;COX;t;;f;8700486;f;;f;;f;;f;;;f;;f;8700447;f;;f;f;;;;Colliure;;;;;;;コリウール;;;;Коллиур;;;科利乌尔
+5772;Chantilly—Gouvieux;chantilly-gouvieux;8727611;87276113;49.187624;2.459565;;f;FR;f;Europe/Paris;t;FRXCV;CLY;t;;f;8700820;f;;f;;f;;f;;;f;;f;8700851;f;;f;t;;;;;;;;;;;;;;;;;;
+5773;Châtellerault;chatellerault;8757514;87575142;46.818611837291904;0.5497026443481445;;f;FR;f;Europe/Paris;t;FRXCX;CRT;t;;f;8700553;f;;f;;f;;f;;;f;;f;8700554;f;;f;t;;;;;;;;;;;シャテルロー;;;;Шательро;;;沙泰勒罗
+5774;Château-Thierry;chateau-thierry;8711658;87116582;49.037924212467836;3.4095382690429683;;f;FR;f;Europe/Paris;t;FRXCY;CTH;t;;f;8700261;f;;f;;f;;f;;;f;;f;8700917;f;;f;f;;;;;;;;;;;シャトー＝ティエリ;;;;Шато-Тьерри;;;蒂耶里堡
+5775;Charleville-Mézières;charleville-mezieres;8717200;87172007;49.76779475895682;4.725322723388671;;f;FR;f;Europe/Paris;t;FRXCZ;CMZ;t;;f;8700050;f;;f;;f;;f;;;f;;f;8700061;f;;f;t;;;;;;;;;;;シャルルヴィル＝メジエール;샤를빌메지에르;;;Шарлевиль-Мезьер;;;沙勒维尔-梅济耶尔
 5776;Dax;dax;;;43.7103230000;-1.0536580000;;t;FR;f;Europe/Paris;f;FRXDA;;t;;f;;f;ezz285;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5777;Douai;douai;8734500;87345009;50.371799139044754;3.0900871753692627;;f;FR;f;Europe/Paris;t;FRXDN;DOI;t;;f;8700007;f;u0fnwe;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;Dowaai;;;;ドゥエー;두에;;;Дуэ;;;杜埃
-5778;Évian-les-Bains;evian-les-bains;8774567;87745679;46.39791639609017;6.577699184417725;;f;FR;f;Europe/Paris;t;FRXEB;EVI;t;;f;8700090;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;エヴィアン＝レ＝バン;;;;Эвьян-ле-Бен;;;埃維昂萊班
-5779;Épernay;epernay;8717155;87171553;49.046289724740205;3.959857821464538;;f;FR;f;Europe/Paris;t;FRXEP;EPR;t;;f;8700053;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;エペルネー;;;;Эперне;;;埃佩尔奈
-5780;Foix;foix;8761161;87611616;42.97032707409799;1.6068470478057861;;f;FR;f;Europe/Paris;t;FRXFX;FXE;t;;f;8700191;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5781;St-Gervais-les-Bains—Le Fayet;st-gervais-les-bains-le-fayet;8774647;87746479;45.906661;6.701862;26833;f;FR;f;Europe/Paris;t;FRXGF;SGB;t;XGF;t;8704576;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5782;Guéret;gueret;8759760;87597609;46.17412493440401;1.8791556358337402;;f;FR;f;Europe/Paris;t;FRXGT;GTJ;t;;f;8700182;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5783;St-Gilles-Croix-de-Vie;st-gilles-croix-de-vie;8748657;87486571;46.696459135952594;-1.941409707069397;;f;FR;f;Europe/Paris;t;FRXGV;;t;;f;8704579;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5784;Hyères;hyeres;8775562;87755629;43.10881995697415;6.124212741851807;;f;FR;f;Europe/Paris;t;FRXHE;HYE;t;;f;8702308;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;イエール;;;;Йер;;;伊埃雷
+5777;Douai;douai;8734500;87345009;50.371799139044754;3.0900871753692627;;f;FR;f;Europe/Paris;t;FRXDN;DOI;t;;f;8700007;f;u0fnwe;t;;f;;f;;;f;;f;8700008;f;;f;t;;;;;;;Dowaai;;;;ドゥエー;두에;;;Дуэ;;;杜埃
+5778;Évian-les-Bains;evian-les-bains;8774567;87745679;46.39791639609017;6.577699184417725;;f;FR;f;Europe/Paris;t;FRXEB;EVI;t;;f;8700090;f;;f;;f;;f;;;f;;f;8700118;f;;f;f;;;;;;;;;;;エヴィアン＝レ＝バン;;;;Эвьян-ле-Бен;;;埃維昂萊班
+5779;Épernay;epernay;8717155;87171553;49.046289724740205;3.959857821464538;;f;FR;f;Europe/Paris;t;FRXEP;EPR;t;;f;8700053;f;;f;;f;;f;;;f;;f;8700064;f;;f;t;;;;;;;;;;;エペルネー;;;;Эперне;;;埃佩尔奈
+5780;Foix;foix;8761161;87611616;42.97032707409799;1.6068470478057861;;f;FR;f;Europe/Paris;t;FRXFX;FXE;t;;f;8700191;f;;f;;f;;f;;;f;;f;8700531;f;;f;f;;;;;;;;;;;;;;;;;;
+5781;St-Gervais-les-Bains—Le Fayet;st-gervais-les-bains-le-fayet;8774647;87746479;45.906661;6.701862;26833;f;FR;f;Europe/Paris;t;FRXGF;SGB;t;XGF;t;8704576;f;;f;;f;;f;;;f;;f;8700277;f;;f;f;;;;;;;;;;;;;;;;;;
+5782;Guéret;gueret;8759760;87597609;46.17412493440401;1.8791556358337402;;f;FR;f;Europe/Paris;t;FRXGT;GTJ;t;;f;8700182;f;;f;;f;;f;;;f;;f;8700462;f;;f;t;;;;;;;;;;;;;;;;;;
+5783;St-Gilles-Croix-de-Vie;st-gilles-croix-de-vie;8748657;87486571;46.696459135952594;-1.941409707069397;;f;FR;f;Europe/Paris;t;FRXGV;;t;;f;8704579;f;;f;;f;;f;;;f;;f;8700787;f;;f;f;;;;;;;;;;;;;;;;;;
+5784;Hyères;hyeres;8775562;87755629;43.10881995697415;6.124212741851807;;f;FR;f;Europe/Paris;t;FRXHE;HYE;t;;f;8702308;f;;f;;f;;f;;;f;;f;8700099;f;;f;t;;;;;;;;;;;イエール;;;;Йер;;;伊埃雷
 5785;Hendaye;hendaye;;;43.3666670000;-1.7833330000;;t;FR;f;Europe/Paris;f;FRXHY;;t;;f;;f;ezwwxv;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5786;Ste-Feyre;ste-feyre;8744500;87445007;46.140102683330724;1.925321817398071;;f;FR;f;Europe/Paris;t;FRXJK;;t;;f;8704670;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5788;St-Jean-de-Luz—Ciboure;st-jean-de-luz-ciboure;8767712;87677120;43.385825;-1.661107;26832;f;FR;f;Europe/Paris;t;FRXJZ;SJZ;t;XJZ;t;8700109;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5790;Landerneau;landerneau;8747423;87474239;48.453883478155966;-4.2563652992248535;;f;FR;f;Europe/Paris;t;FRXLD;LDO;t;XLD;t;8700453;f;gbsgx5;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ランデルノー;;;;;;;朗代尔诺
-5791;Lens;lens;8734502;87345025;50.426784045124485;2.8282284736633296;;f;FR;f;Europe/Paris;t;FRXLE;LNS;t;;f;8700244;f;;f;;f;;f;;;f;;f;;f;;f;t;;Frankreich;France;Francia;France;Francia;Frankrijk;;;;ランス;;;;;;;
-5792;Luchon;luchon;8761123;87611236;42.79727431598283;0.5965662002563477;;f;FR;f;Europe/Paris;t;FRXLH;LUC;t;;f;8703852;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5793;Lons-le-Saunier;lons-le-saunier;8771823;87718239;46.66846377007404;5.551185607910156;;f;FR;f;Europe/Paris;t;FRXLL;LLS;t;;f;8700189;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ロン＝ル＝ソーニエ;;;;Лон-ле-Сонье;;;隆勒索涅
-5794;Laon;laon;8729601;87296012;49.5709975971829;3.6237716674804688;;f;FR;f;Europe/Paris;t;FRXLN;LAO;t;;f;8700252;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ラン;랑;;;Лан;;;拉昂
-5795;Libourne;libourne;8758405;87584052;44.91591325811082;-0.23605585098266602;;f;FR;f;Europe/Paris;t;FRXLR;LIB;t;;f;8700185;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;リブルヌ;;;;Либурн;;;利布爾訥
-5796;Ax-les-Thermes;ax-les-thermes;8761153;87611533;42.724884539224256;1.8332576751708987;;f;FR;f;Europe/Paris;t;FRXLT;AXN;t;;f;8700192;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5797;Lisieux;lisieux;8744426;87444265;49.13825259786536;0.23104012012481687;;f;FR;f;Europe/Paris;t;FRXLX;LIS;t;;f;8700222;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;リジュー;;;;Лизьё;;;利雪
-5798;Maubeuge;maubeuge;8729500;87295006;50.272596958193354;3.9664721488952632;;f;FR;f;Europe/Paris;t;FRXME;MBG;t;;f;8700249;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モブージュ;;;;Мобёж;;;莫伯日
-5799;Montbéliard;montbeliard;8718452;87184523;47.51189641517181;6.80029034614563;10610;f;FR;f;Europe/Paris;t;FRXMF;MBD;t;;f;8700177;f;u0ky6s;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モンベリアル;몽벨리아르;;;Монбельяр;;;蒙贝利亚尔
+5788;St-Jean-de-Luz—Ciboure;st-jean-de-luz-ciboure;8767712;87677120;43.385825;-1.661107;26832;f;FR;f;Europe/Paris;t;FRXJZ;SJZ;t;XJZ;t;8700109;f;;f;;f;;f;;;f;;f;8700192;f;;f;t;;;;;;;;;;;;;;;;;;
+5790;Landerneau;landerneau;8747423;87474239;48.453883478155966;-4.2563652992248535;;f;FR;f;Europe/Paris;t;FRXLD;LDO;t;XLD;t;8700453;f;gbsgx5;t;;f;;f;;;f;;f;8700745;f;;f;f;;;;;;;;;;;ランデルノー;;;;;;;朗代尔诺
+5791;Lens;lens;8734502;87345025;50.426784045124485;2.8282284736633296;;f;FR;f;Europe/Paris;t;FRXLE;LNS;t;;f;8700244;f;;f;;f;;f;;;f;;f;8700857;f;;f;t;;Frankreich;France;Francia;France;Francia;Frankrijk;;;;ランス;;;;;;;
+5792;Luchon;luchon;8761123;87611236;42.79727431598283;0.5965662002563477;;f;FR;f;Europe/Paris;t;FRXLH;LUC;t;;f;8703852;f;;f;;f;;f;;;f;;f;8700559;f;;f;f;;;;;;;;;;;;;;;;;;
+5793;Lons-le-Saunier;lons-le-saunier;8771823;87718239;46.66846377007404;5.551185607910156;;f;FR;f;Europe/Paris;t;FRXLL;LLS;t;;f;8700189;f;;f;;f;;f;;;f;;f;8700493;f;;f;t;;;;;;;;;;;ロン＝ル＝ソーニエ;;;;Лон-ле-Сонье;;;隆勒索涅
+5794;Laon;laon;8729601;87296012;49.5709975971829;3.6237716674804688;;f;FR;f;Europe/Paris;t;FRXLN;LAO;t;;f;8700252;f;;f;;f;;f;;;f;;f;8700890;f;;f;f;;;;;;;;;;;ラン;랑;;;Лан;;;拉昂
+5795;Libourne;libourne;8758405;87584052;44.91591325811082;-0.23605585098266602;;f;FR;f;Europe/Paris;t;FRXLR;LIB;t;;f;8700185;f;;f;;f;;f;;;f;;f;8700466;f;;f;t;;;;;;;;;;;リブルヌ;;;;Либурн;;;利布爾訥
+5796;Ax-les-Thermes;ax-les-thermes;8761153;87611533;42.724884539224256;1.8332576751708987;;f;FR;f;Europe/Paris;t;FRXLT;AXN;t;;f;8700192;f;;f;;f;;f;;;f;;f;8700541;f;;f;f;;;;;;;;;;;;;;;;;;
+5797;Lisieux;lisieux;8744426;87444265;49.13825259786536;0.23104012012481687;;f;FR;f;Europe/Paris;t;FRXLX;LIS;t;;f;8700222;f;;f;;f;;f;;;f;;f;8700768;f;;f;t;;;;;;;;;;;リジュー;;;;Лизьё;;;利雪
+5798;Maubeuge;maubeuge;8729500;87295006;50.272596958193354;3.9664721488952632;;f;FR;f;Europe/Paris;t;FRXME;MBG;t;;f;8700249;f;;f;;f;;f;;;f;;f;8700875;f;;f;t;;;;;;;;;;;モブージュ;;;;Мобёж;;;莫伯日
+5799;Montbéliard;montbeliard;8718452;87184523;47.51189641517181;6.80029034614563;10610;f;FR;f;Europe/Paris;t;FRXMF;MBD;t;;f;8700177;f;u0ky6s;t;;f;;f;;;f;;f;8700443;f;;f;t;;;;;;;;;;;モンベリアル;몽벨리아르;;;Монбельяр;;;蒙贝利亚尔
 5800;Mont-de-Marsan;mont-de-marsan;8767101;87671016;43.88467486828255;-0.5045181512832642;;f;FR;f;Europe/Paris;t;FRXMJ;MMR;t;;f;8704015;f;ezz9sy;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モン＝ド＝マルサン;;;;Мон-де-Марсан;;;蒙德马桑
-5801;Monaco—Monte-Carlo;monaco-monte-carlo;8775640;87756403;43.738211;7.419606;;f;FR;f;Europe/Paris;t;FRXMM;MNA;t;;f;8700174;f;;f;;f;8775640;t;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5802;Marmande;marmande;8758654;87586545;44.50319349975489;0.1682603359222412;;f;FR;f;Europe/Paris;t;FRXMR;MMD;t;;f;8703918;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;マルマンド;;;;Марманд;;;马尔芒德
-5803;Moulins-sur-Allier;moulins-sur-allier;8769632;87696328;46.561255;3.339267;;f;FR;f;Europe/Paris;t;FRXMU;MSA;t;;f;8700041;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5804;Montauban Ville Bourbon;montauban-ville-bourbon;8761124;87611244;44.014287656042015;1.341281533241272;;f;FR;f;Europe/Paris;t;FRXMW;MBN;t;;f;8700057;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;モントーバン;;;;Монтобан;;;蒙托邦
+5801;Monaco—Monte-Carlo;monaco-monte-carlo;8775640;87756403;43.738211;7.419606;;f;FR;f;Europe/Paris;t;FRXMM;MNA;t;;f;8700174;f;;f;;f;8775640;t;;;f;;f;8700427;f;;f;t;;;;;;;;;;;;;;;;;;
+5802;Marmande;marmande;8758654;87586545;44.50319349975489;0.1682603359222412;;f;FR;f;Europe/Paris;t;FRXMR;MMD;t;;f;8703918;f;;f;;f;;f;;;f;;f;8700621;f;;f;t;;;;;;;;;;;マルマンド;;;;Марманд;;;马尔芒德
+5803;Moulins-sur-Allier;moulins-sur-allier;8769632;87696328;46.561255;3.339267;;f;FR;f;Europe/Paris;t;FRXMU;MSA;t;;f;8700041;f;;f;;f;;f;;;f;;f;8700050;f;;f;t;;;;;;;;;;;;;;;;;;
+5804;Montauban Ville Bourbon;montauban-ville-bourbon;8761124;87611244;44.014287656042015;1.341281533241272;;f;FR;f;Europe/Paris;t;FRXMW;MBN;t;;f;8700057;f;;f;;f;;f;;;f;;f;8700068;f;;f;t;;;;;;;;;;;モントーバン;;;;Монтобан;;;蒙托邦
 5805;Mazamet;mazamet;8761554;87615542;43.49782621031005;2.374849319458008;9221;f;FR;t;Europe/Paris;t;FRXMZ;;t;;f;8703960;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5806;Narbonne;narbonne;8778110;87781104;43.19059308540353;3.0056780576705933;;f;FR;f;Europe/Paris;t;FRXNA;NBN;t;;f;8700073;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;Narbona;;Narbona;;;;;ナルボンヌ;나르본;Narbona;Narbona;Нарбонна;;;纳博讷
+5806;Narbonne;narbonne;8778110;87781104;43.19059308540353;3.0056780576705933;;f;FR;f;Europe/Paris;t;FRXNA;NBN;t;;f;8700073;f;;f;;f;;f;;;f;;f;8700088;f;;f;t;;;;Narbona;;Narbona;;;;;ナルボンヌ;나르본;Narbona;Narbona;Нарбонна;;;纳博讷
 5807;Le Blanc;le-blanc;8720160;87201608;46.630784969862106;1.0635709762573242;;f;FR;f;Europe/Paris;t;FRXNC;;t;;f;8705084;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5808;Orange;orange;8776510;87765107;44.1375314225196;4.819436073303223;;f;FR;f;Europe/Paris;t;FRXOG;OGE;t;;f;8700433;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;オランジュ;;;;Оранж;;;
-5809;Aulnoye-Aymeries;aulnoye-aymeries;8729560;87295600;50.19718374384137;3.843551874160766;;f;FR;f;Europe/Paris;t;FRXOY;AYE;t;;f;8700017;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5810;Pontorson—Mont-St-Michel;pontorson-mont-st-michel;8747826;87478263;48.55264793385792;-1.5049391984939575;;f;FR;f;Europe/Paris;t;FRXPM;;t;;f;8704286;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5812;Port-Vendres;port-vendres;8778426;87784264;42.513493;3.102599;;f;FR;f;Europe/Paris;t;FRXPV;POV;t;;f;8700165;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5813;Armentières;armentieres;8728614;87286146;50.68059999647707;2.877345085144043;;f;FR;f;Europe/Paris;t;FRXRM;;t;;f;8700259;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5814;Redon;redon;8747130;87471300;47.65194632008738;-2.088249921798706;;f;FR;f;Europe/Paris;t;FRXRN;RDN;t;XRN;t;8700083;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5815;La Roche-sur-Yon;la-roche-sur-yon;8748601;87486019;46.67208591469653;-1.435861587524414;;f;FR;f;Europe/Paris;t;FRXRO;LRY;t;;f;8700069;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ラ・ロッシュ＝シュル＝ヨン;;;;Ла-Рош-сюр-Йон;;;永河畔拉罗什
-5816;Les Arcs—Draguignan;les-arcs-draguignan;8775544;87755447;43.45548904020495;6.482427120208739;;f;FR;f;Europe/Paris;t;FRXRS;LAC;t;;f;8700624;f;;f;;f;8775544;t;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5817;Rambouillet;rambouillet;8739331;;48.64430879442644;1.8328070640563965;;f;FR;f;Europe/Paris;t;FRXRT;;t;;f;8700186;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ランブイエ;;;;Рамбуйе;;;朗布依埃
-5818;St-Malo;st-malo;8747810;87478107;48.64663389373507;-2.0038890838623047;;f;FR;f;Europe/Paris;t;FRXSB;SMP;t;;f;8700228;f;gbwsdr;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;サン・マロ;;;;Сен-Мало;;;圣马洛
-5819;Sens;sens;8768300;87683003;48.197919069342625;3.2677567005157466;;f;FR;f;Europe/Paris;t;FRXSF;SES;t;;f;8702014;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5820;St-Omer;st-omer;8728144;87281444;50.753916161404945;2.266895771026611;;f;FR;f;Europe/Paris;t;FRXSG;STO;t;;f;8700260;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;Sint-Omaars;;;;;;;;;;;
-5821;St-Pierre-des-Corps;st-pierre-des-corps;8757124;87571240;47.38603813196069;0.7235956192016602;;f;FR;f;Europe/Paris;t;FRXSH;SPC;t;;f;8700006;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5808;Orange;orange;8776510;87765107;44.1375314225196;4.819436073303223;;f;FR;f;Europe/Paris;t;FRXOG;OGE;t;;f;8700433;f;;f;;f;;f;;;f;;f;8700172;f;;f;t;;;;;;;;;;;オランジュ;;;;Оранж;;;
+5809;Aulnoye-Aymeries;aulnoye-aymeries;8729560;87295600;50.19718374384137;3.843551874160766;;f;FR;f;Europe/Paris;t;FRXOY;AYE;t;;f;8700017;f;;f;;f;;f;;;f;;f;8700021;f;;f;f;;;;;;;;;;;;;;;;;;
+5810;Pontorson—Mont-St-Michel;pontorson-mont-st-michel;8747826;87478263;48.55264793385792;-1.5049391984939575;;f;FR;f;Europe/Paris;t;FRXPM;;t;;f;8704286;f;;f;;f;;f;;;f;;f;8700835;f;;f;f;;;;;;;;;;;;;;;;;;
+5812;Port-Vendres;port-vendres;8778426;87784264;42.513493;3.102599;;f;FR;f;Europe/Paris;t;FRXPV;POV;t;;f;8700165;f;;f;;f;;f;;;f;;f;8700375;f;;f;f;;;;;;;;;;;;;;;;;;
+5813;Armentières;armentieres;8728614;87286146;50.68059999647707;2.877345085144043;;f;FR;f;Europe/Paris;t;FRXRM;;t;;f;8700259;f;;f;;f;;f;;;f;;f;8700915;f;;f;t;;;;;;;;;;;;;;;;;;
+5814;Redon;redon;8747130;87471300;47.65194632008738;-2.088249921798706;;f;FR;f;Europe/Paris;t;FRXRN;RDN;t;XRN;t;8700083;f;;f;;f;;f;;;f;;f;8700098;f;;f;t;;;;;;;;;;;;;;;;;;
+5815;La Roche-sur-Yon;la-roche-sur-yon;8748601;87486019;46.67208591469653;-1.435861587524414;;f;FR;f;Europe/Paris;t;FRXRO;LRY;t;;f;8700069;f;;f;;f;;f;;;f;;f;8700084;f;;f;t;;;;;;;;;;;ラ・ロッシュ＝シュル＝ヨン;;;;Ла-Рош-сюр-Йон;;;永河畔拉罗什
+5816;Les Arcs—Draguignan;les-arcs-draguignan;8775544;87755447;43.45548904020495;6.482427120208739;;f;FR;f;Europe/Paris;t;FRXRS;LAC;t;;f;8700624;f;;f;;f;8775544;t;;;f;;f;8700283;f;;f;t;;;;;;;;;;;;;;;;;;
+5817;Rambouillet;rambouillet;8739331;;48.64430879442644;1.8328070640563965;;f;FR;f;Europe/Paris;t;FRXRT;;t;;f;8700186;f;;f;;f;;f;;;f;;f;8700470;f;;f;t;;;;;;;;;;;ランブイエ;;;;Рамбуйе;;;朗布依埃
+5818;St-Malo;st-malo;8747810;87478107;48.64663389373507;-2.0038890838623047;;f;FR;f;Europe/Paris;t;FRXSB;SMP;t;;f;8700228;f;gbwsdr;t;;f;;f;;;f;;f;8700778;f;;f;t;;;;;;;;;;;サン・マロ;;;;Сен-Мало;;;圣马洛
+5819;Sens;sens;8768300;87683003;48.197919069342625;3.2677567005157466;;f;FR;f;Europe/Paris;t;FRXSF;SES;t;;f;8702014;f;;f;;f;;f;;;f;;f;8700121;f;;f;t;;;;;;;;;;;;;;;;;;
+5820;St-Omer;st-omer;8728144;87281444;50.753916161404945;2.266895771026611;;f;FR;f;Europe/Paris;t;FRXSG;STO;t;;f;8700260;f;;f;;f;;f;;;f;;f;8700916;f;;f;t;;;;;;;Sint-Omaars;;;;;;;;;;;
+5821;St-Pierre-des-Corps;st-pierre-des-corps;8757124;87571240;47.38603813196069;0.7235956192016602;;f;FR;f;Europe/Paris;t;FRXSH;SPC;t;;f;8700006;f;;f;;f;;f;;;f;;f;8700007;f;;f;t;;;;;;;;;;;;;;;;;;
 5822;Villeneuve-sur-Lot Lycée;villeneuve-sur-lot-lycee;8746559;87465591;44.396149;0.70959;;f;FR;f;Europe/Paris;t;FRXSI;;t;;f;8706325;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ヴィルヌーヴ＝シュル＝ロット;;;;Вильнёв-сюр-Ло;;;洛特河畔新城
-5823;St-Quentin;st-quentin;8729600;87296004;49.83995795162259;3.297067880630493;;f;FR;f;Europe/Paris;t;FRXSJ;SQT;t;;f;8700176;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;Сен-Кантен-Фаллавье;;;圣屈昂坦法拉维耶
-5824;St-Raphaël—Valescure;st-raphael-valescure;8775752;87757526;43.42277;6.770126;;f;FR;f;Europe/Paris;t;FRXSK;SRV;t;XSK;t;8700143;f;;f;;f;8775752;t;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5823;St-Quentin;st-quentin;8729600;87296004;49.83995795162259;3.297067880630493;;f;FR;f;Europe/Paris;t;FRXSJ;SQT;t;;f;8700176;f;;f;;f;;f;;;f;;f;8700433;f;;f;t;;;;;;;;;;;;;;;Сен-Кантен-Фаллавье;;;圣屈昂坦法拉维耶
+5824;St-Raphaël—Valescure;st-raphael-valescure;8775752;87757526;43.42277;6.770126;;f;FR;f;Europe/Paris;t;FRXSK;SRV;t;XSK;t;8700143;f;;f;;f;8775752;t;;;f;;f;8700284;f;;f;t;;;;;;;;;;;;;;;;;;
 5825;Sarlat;sarlat;8759582;87595827;44.87706901752246;1.2204533815383911;;f;FR;f;Europe/Paris;t;FRXSL;;t;;f;8704451;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5826;Sallanches—Combloux—Megève;sallanches-combloux-megeve;8774643;87746438;45.935642;6.636484;;f;FR;f;Europe/Paris;t;FRXSN;SLS;t;XSN;t;8700441;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5826;Sallanches—Combloux—Megève;sallanches-combloux-megeve;8774643;87746438;45.935642;6.636484;;f;FR;f;Europe/Paris;t;FRXSN;SLS;t;XSN;t;8700441;f;;f;;f;;f;;;f;;f;8700275;f;;f;f;;;;;;;;;;;;;;;;;;
 5827;Aytré Plage;aytre-plage;8743780;87437806;46.127364;-1.128074;;f;FR;f;Europe/Paris;t;FRXSP;;t;;f;8706170;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5828;Sélestat;selestat;8721405;87214056;48.260341395845344;7.442979812622069;;f;FR;f;Europe/Paris;t;FRXSQ;STT;t;;f;8700179;f;;f;;f;;f;;;f;;f;;f;;f;t;;Schlettstadt;;;;;;;;;セレスタ;;;;Селеста;;;塞莱斯塔
+5828;Sélestat;selestat;8721405;87214056;48.260341395845344;7.442979812622069;;f;FR;f;Europe/Paris;t;FRXSQ;STT;t;;f;8700179;f;;f;;f;;f;;;f;;f;8700445;f;;f;t;;Schlettstadt;;;;;;;;;セレスタ;;;;Селеста;;;塞莱斯塔
 5829;Soissons;soissons;8727181;87271817;49.369072393345405;3.3382129669189453;;f;FR;f;Europe/Paris;t;FRXSS;;t;;f;8700408;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ソワソン;수아송;;;Суассон;;;苏瓦松
-5830;Saintes;saintes;8749100;87491001;45.74877955575805;-0.6178253889083861;;f;FR;f;Europe/Paris;t;FRXST;SKW;t;;f;8700418;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
+5830;Saintes;saintes;8749100;87491001;45.74877955575805;-0.6178253889083861;;f;FR;f;Europe/Paris;t;FRXST;SKW;t;;f;8700418;f;;f;;f;;f;;;f;;f;8700038;f;;f;t;;;;;;;;;;;;;;;;;;
 5831;Saumur;saumur;;;47.2666670000;-0.0833330000;;t;FR;f;Europe/Paris;f;FRXSU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5832;Senlis;senlis;8727166;87271668;49.206849248842424;2.589753270149231;;f;FR;f;Europe/Paris;t;FRXSV;;t;;f;8704478;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5833;Seclin;seclin;8728651;87286518;50.5500000000;3.0333330000;;f;FR;f;Europe/Paris;t;FRXSX;;t;;f;8701949;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5834;Sète;sete;8777320;87773200;43.41281046288451;3.696684837341308;;f;FR;f;Europe/Paris;t;FRXSY;STE;t;;f;8700099;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;セット;세트;;;Сет;;;塞特港
+5833;Seclin;seclin;8728651;87286518;50.5500000000;3.0333330000;;f;FR;f;Europe/Paris;t;FRXSX;;t;;f;8701949;f;;f;;f;;f;;;f;;f;8700340;f;;f;f;;;;;;;;;;;;;;;;;;
+5834;Sète;sete;8777320;87773200;43.41281046288451;3.696684837341308;;f;FR;f;Europe/Paris;t;FRXSY;STE;t;;f;8700099;f;;f;;f;;f;;;f;;f;8700175;f;;f;t;;;;;;;;;;;セット;세트;;;Сет;;;塞特港
 5835;Maranville La Poste;maranville-la-poste;8727988;87279885;48.1333330000;4.8666670000;;f;FR;f;Europe/Paris;t;FRXTA;;t;;f;8705154;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5836;Tarbes;tarbes;8767100;87671008;43.240271;0.069531;;f;FR;f;Europe/Paris;t;FRXTB;TBS;t;;f;8700104;f;sp8jcy;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;タルブ;;;;Тарб;;;塔布
-5837;St-Claude;st-claude;8774363;87743633;46.39006538884443;5.8603692054748535;;f;FR;f;Europe/Paris;t;FRXTC;;t;;f;8702464;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+5836;Tarbes;tarbes;8767100;87671008;43.240271;0.069531;;f;FR;f;Europe/Paris;t;FRXTB;TBS;t;;f;8700104;f;sp8jcy;t;;f;;f;;;f;;f;8700183;f;;f;t;;;;;;;;;;;タルブ;;;;Тарб;;;塔布
+5837;St-Claude;st-claude;8774363;87743633;46.39006538884443;5.8603692054748535;;f;FR;f;Europe/Paris;t;FRXTC;;t;;f;8702464;f;;f;;f;;f;;;f;;f;8700325;f;;f;f;;;;;;;;;;;;;;;;;;
 5838;St-Dié;st-die;8714401;87144014;48.28202200456835;6.9481658935546875;;f;FR;f;Europe/Paris;t;FRXTD;STD;t;;f;8700427;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5839;Thionville;thionville;8719100;87191007;49.332876273346976;6.150755882263184;;f;FR;f;Europe/Paris;t;FRXTH;THL;t;;f;8700059;f;;f;;f;;f;;;f;;f;;f;;f;t;;Diedenhofen;;;;;;;;;ティオンヴィル;;;;Тьонвиль;;;蒂永维尔
+5839;Thionville;thionville;8719100;87191007;49.332876273346976;6.150755882263184;;f;FR;f;Europe/Paris;t;FRXTH;THL;t;;f;8700059;f;;f;;f;;f;;;f;;f;8700070;f;;f;t;;Diedenhofen;;;;;;;;;ティオンヴィル;;;;Тьонвиль;;;蒂永维尔
 5840;Tourcoing;tourcoing;;;;;;t;FR;f;Europe/Paris;f;FRXTN;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5841;Tulle Préfecture;tulle-prefecture;8741775;87417758;45.270062;1.76531;9098;f;FR;f;Europe/Paris;t;FRXTP;;t;;f;8705710;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5842;Villeneuve-sur-Lot Hôtel de Ville;villeneuve-sur-lot-hotel-de-ville;8746560;87465609;44.443235;0.722876;;f;FR;f;Europe/Paris;t;FRXTQ;;t;;f;8706326;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5843;Thonon-les-Bains;thonon-les-bains;8774564;87745646;46.368958;6.481977;;f;FR;f;Europe/Paris;t;FRXTS;THO;t;;f;8700547;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;トノン＝レ＝バン;;;;Тонон-ле-Бен;;;
-5844;Tulle;tulle;8759449;87594499;45.258565;1.756384;9098;f;FR;t;Europe/Paris;t;FRXTU;TUL;t;;f;8700204;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;チュール;튈;;;Тюль;Tyll;;蒂勒
-5845;Auray;auray;8747620;87476200;47.68021184001663;-2.999417781829834;;f;FR;f;Europe/Paris;t;FRXUY;ARY;t;XUY;t;8700206;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;オーレー;오레;;;Оре;;;
+5843;Thonon-les-Bains;thonon-les-bains;8774564;87745646;46.368958;6.481977;;f;FR;f;Europe/Paris;t;FRXTS;THO;t;;f;8700547;f;;f;;f;;f;;;f;;f;8700123;f;;f;t;;;;;;;;;;;トノン＝レ＝バン;;;;Тонон-ле-Бен;;;
+5844;Tulle;tulle;8759449;87594499;45.258565;1.756384;9098;f;FR;t;Europe/Paris;t;FRXTU;TUL;t;;f;8700204;f;;f;;f;;f;;;f;;f;8700661;f;;f;f;;;;;;;;;;;チュール;튈;;;Тюль;Tyll;;蒂勒
+5845;Auray;auray;8747620;87476200;47.68021184001663;-2.999417781829834;;f;FR;f;Europe/Paris;t;FRXUY;ARY;t;XUY;t;8700206;f;;f;;f;;f;;;f;;f;8700676;f;;f;t;;;;;;;;;;;オーレー;오레;;;Оре;;;
 5846;Vendôme;vendome;;;;;;t;FR;f;Europe/Paris;f;FRXVD;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5847;Villefranche-sur-Saône;villefranche-sur-saone;8772133;87721332;45.98448;4.721143;;f;FR;f;Europe/Paris;t;FRXVF;VIS;t;;f;8702170;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;Villefranche sobre Saona;;;;;;;ヴィルフランシュ＝シュル＝ソーヌ;;;;Вильфранш-сюр-Сон;;;
-5848;Vienne;vienne;8772258;87722587;45.521023;4.8744;;f;FR;f;Europe/Paris;t;FRXVI;VIE;t;;f;8700095;f;;f;;f;;f;;;f;;f;;f;;f;t;;Frankreich;France;Francia;France;Francia;;;;;;;;;Вьенн;;;
+5847;Villefranche-sur-Saône;villefranche-sur-saone;8772133;87721332;45.98448;4.721143;;f;FR;f;Europe/Paris;t;FRXVF;VIS;t;;f;8702170;f;;f;;f;;f;;;f;;f;8700345;f;;f;t;;;;Villefranche sobre Saona;;;;;;;ヴィルフランシュ＝シュル＝ソーヌ;;;;Вильфранш-сюр-Сон;;;
+5848;Vienne;vienne;8772258;87722587;45.521023;4.8744;;f;FR;f;Europe/Paris;t;FRXVI;VIE;t;;f;8700095;f;;f;;f;;f;;;f;;f;8700163;f;;f;t;;Frankreich;France;Francia;France;Francia;;;;;;;;;Вьенн;;;
 5849;Buxières-Les-Villiers;buxieres-les-villiers;8721522;87215228;48.1000000000;5.0333330000;;f;FR;f;Europe/Paris;t;FRXVL;;t;;f;8705159;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5850;Verdun;verdun;8717577;87175778;49.165475;5.379163;;f;FR;f;Europe/Paris;t;FRXVN;;t;;f;8700523;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
-5851;Vesoul;vesoul;8718500;87185009;47.617541;6.152037;;f;FR;f;Europe/Paris;t;FRXVO;VES;t;;f;8700385;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ヴズー;;;;Везуль;;;沃苏勒
-5852;St-Michel—Valloire;st-michel-valloire;8774236;87742361;45.216855;6.471954;;f;FR;f;Europe/Paris;t;FRXVR;SMI;t;;f;8702381;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5853;Valenciennes;valenciennes;8734300;87343004;50.363371377157726;3.5166603326797485;;f;FR;f;Europe/Paris;t;FRXVS;VSN;t;;f;8700078;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ヴァランシエンヌ;;;;Валансьен;;;瓦朗謝訥
-5854;Vitré;vitre;8747150;87471508;48.122501;-1.21179;;f;FR;f;Europe/Paris;t;FRXVT;VTE;t;;f;8702235;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ヴィトレ;;;;Витрэ;;;
+5851;Vesoul;vesoul;8718500;87185009;47.617541;6.152037;;f;FR;f;Europe/Paris;t;FRXVO;VES;t;;f;8700385;f;;f;;f;;f;;;f;;f;8700947;f;;f;t;;;;;;;;;;;ヴズー;;;;Везуль;;;沃苏勒
+5852;St-Michel—Valloire;st-michel-valloire;8774236;87742361;45.216855;6.471954;;f;FR;f;Europe/Paris;t;FRXVR;SMI;t;;f;8702381;f;;f;;f;;f;;;f;;f;8700263;f;;f;f;;;;;;;;;;;;;;;;;;
+5853;Valenciennes;valenciennes;8734300;87343004;50.363371377157726;3.5166603326797485;;f;FR;f;Europe/Paris;t;FRXVS;VSN;t;;f;8700078;f;;f;;f;;f;;;f;;f;8700093;f;;f;t;;;;;;;;;;;ヴァランシエンヌ;;;;Валансьен;;;瓦朗謝訥
+5854;Vitré;vitre;8747150;87471508;48.122501;-1.21179;;f;FR;f;Europe/Paris;t;FRXVT;VTE;t;;f;8702235;f;;f;;f;;f;;;f;;f;8700715;f;;f;t;;;;;;;;;;;ヴィトレ;;;;Витрэ;;;
 5857;Cany-Barville;cany-barville;8700539;87005397;49.78835056573877;0.6375503540039062;;f;FR;f;Europe/Paris;t;FRYBV;;t;;f;8705052;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5859;Ydes;ydes;8700370;87003707;45.3391;2.454145;;f;FR;f;Europe/Paris;t;FRYDE;;t;;f;8704401;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5863;Bannay;bannay;8731490;87314906;47.388254;2.850371;;f;FR;f;Europe/Paris;t;FRYNN;;t;;f;8700504;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Бане;;;
 5864;Bayel;bayel;8727990;;48.197597;4.778306;;f;FR;f;Europe/Paris;t;FRYPA;;t;;f;8705164;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5865;Bricon La Poste;bricon-la-poste;8727987;;48.079326;4.974837;;f;FR;f;Europe/Paris;t;FRYTA;;t;;f;8705158;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5866;Chambray-les-Tours;chambray-les-tours;8720557;87205575;47.33812472032207;0.7150554656982422;;f;FR;f;Europe/Paris;t;FRYTS;;t;;f;8705191;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5867;Yvetot;yvetot;8741338;87413385;49.622244;0.75059;;f;FR;f;Europe/Paris;t;FRYVE;YVT;t;;f;8700328;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5870;Cahors;cahors;8761300;87613000;44.44931435627743;1.4330828189849854;9194;f;FR;t;Europe/Paris;t;FRZAO;CAH;t;;f;8700180;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;カオール;;;;Каор;;;卡奥尔
+5867;Yvetot;yvetot;8741338;87413385;49.622244;0.75059;;f;FR;f;Europe/Paris;t;FRYVE;YVT;t;;f;8700328;f;;f;;f;;f;;;f;;f;8700811;f;;f;f;;;;;;;;;;;;;;;;;;
+5870;Cahors;cahors;8761300;87613000;44.44931435627743;1.4330828189849854;9194;f;FR;t;Europe/Paris;t;FRZAO;CAH;t;;f;8700180;f;;f;;f;;f;;;f;;f;8700455;f;;f;t;;;;;;;;;;;カオール;;;;Каор;;;卡奥尔
 5871;Clairvaux;clairvaux;8727989;87279893;48.1500000000;4.7833330000;;f;FR;f;Europe/Paris;t;FRZAP;;t;;f;8705152;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5872;Neufchâteau Hôpital;neufchateau-hopital;8740574;87405746;48.3697;5.7069;;f;FR;f;Europe/Paris;t;FRZAU;;t;;f;8705384;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5874;La Bresse Place Champtel;la-bresse-place-champtel;8740581;87405811;48.0000000000;6.8833330000;;f;FR;f;Europe/Paris;t;FRZBF;;t;;f;8705394;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5875;Remiremont Cora;remiremont-cora;8740591;87405910;48.00471475041776;6.612616181373596;;f;FR;f;Europe/Paris;t;FRZBQ;;t;;f;8705403;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5876;Lexy Providence Usine;lexy-providence-usine;8740668;87406686;49.5000000000;5.7333330000;8749;f;FR;f;Europe/Paris;t;FRZCB;;t;;f;8705410;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5877;Basel;basel;;;47.567;7.583;;t;CH;f;Europe/Zurich;t;FRZDH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Basilea;Bâle;Basilea;Bazel;Basilej;;Bázel;バーゼル;바젤;Bazylea;Basileia;Базель;;;巴塞尔
-5878;Basel SBB;basel-sbb;8500010;85000109;47.5470755094;7.5891699960;5877;f;CH;t;Europe/Zurich;t;CHAJP;;t;;f;8500010;t;;f;;f;8500010;t;;;f;;f;;f;;f;f;;;;Basilea;Bâle;Basilea;Bazel;Basilej;;Bázel;バーゼル;바젤;Bazylea;Basileia;Базель;;;巴塞尔
+5878;Basel SBB;basel-sbb;8500010;85000109;47.5470755094;7.5891699960;5877;f;CH;t;Europe/Zurich;t;CHAJP;;t;;f;8500010;t;;f;;f;8500010;t;;;f;;f;8500010;f;;f;f;;;;Basilea;Bâle;Basilea;Bazel;Basilej;;Bázel;バーゼル;바젤;Bazylea;Basileia;Базель;;;巴塞尔
 5880;Hommarting Tilleuls;hommarting-tilleuls;8746360;87463604;48.7333330000;7.1500000000;;f;FR;f;Europe/Paris;t;FRZGX;;t;;f;8706463;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5881;Arzviller Fontaines;arzviller-fontaines;8746362;87463620;48.718639;7.16807;;f;FR;f;Europe/Paris;f;FRZGY;;t;;f;8706464;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5882;St-Louis (Moselle) Plan Incliné;st-louis-moselle-plan-incline;8746363;87463638;48.716419;7.189221;;f;FR;f;Europe/Paris;f;FRZGZ;;t;;f;8706465;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5883;Guntzviller;guntzviller;8746361;87463612;48.712077;7.158083;;f;FR;f;Europe/Paris;t;FRZHA;;t;;f;8706466;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5884;Berthelming Mairie;berthelming-mairie;8747756;;48.8166670000;7.0000000000;;f;FR;f;Europe/Paris;t;FRZHB;;t;;f;8706467;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5890;Zornhoff;zornhoff;;;;;;t;FR;f;Europe/Paris;f;FRZNF;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5892;London St-Pancras;london-st-pancras;7015400;70154005;51.5319210000;-0.1263610000;8267;f;GB;t;Europe/London;t;GBSPX;;t;;f;7004428;t;;f;;f;;f;;;f;;f;;f;STP;t;f;;;;Londres;Londres;Londra;Londen;Londýn;;;ロンドン;런던;Londyn;Londres;Лондон;;Londra;伦敦
-5893;Bruxelles-Midi;bruxelles-midi;8814001;88140010;50.835374;4.335695;5974;f;BE;t;Europe/Brussels;t;BEBMI;;t;;f;8800004;t;;f;;f;;f;;;f;;f;;f;;f;f;;Brüssel;Brussels;Bruselas;;;Brussel-Zuid;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
-5894;Amsterdam-Centraal;amsterdam-centraal;8400058;84000588;52.37919;4.899426;8657;f;NL;t;Europe/Amsterdam;t;NLAMA;;t;;f;8400058;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;Amszterdam;アムステルダム;암스테르담;;Amesterdão;Амстердам;;;阿姆斯特丹
+5892;London St-Pancras;london-st-pancras;7015400;70154005;51.5319210000;-0.1263610000;8267;f;GB;t;Europe/London;t;GBSPX;;t;;f;7004428;t;;f;;f;;f;;;f;;f;7015400;f;STP;t;f;;;;Londres;Londres;Londra;Londen;Londýn;;;ロンドン;런던;Londyn;Londres;Лондон;;Londra;伦敦
+5893;Bruxelles-Midi;bruxelles-midi;8814001;88140010;50.835374;4.335695;5974;f;BE;t;Europe/Brussels;t;BEBMI;;t;;f;8800004;t;;f;;f;;f;;;f;;f;8800104;f;;f;f;;Brüssel;Brussels;Bruselas;;;Brussel-Zuid;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
+5894;Amsterdam-Centraal;amsterdam-centraal;8400058;84000588;52.37919;4.899426;8657;f;NL;t;Europe/Amsterdam;t;NLAMA;;t;;f;8400058;t;;f;;f;;f;;;f;;f;8400058;f;;f;f;;;;;;;;;;Amszterdam;アムステルダム;암스테르담;;Amesterdão;Амстердам;;;阿姆斯特丹
 5901;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5902;Soignies;soignies;8883113;;50.573177;4.069281;;f;BE;f;Europe/Brussels;f;BEAAB;;f;;f;8800144;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;Zinnik;;;;;;;;;;;
 5903;Tubize;tubize;8883808;;50.691834;4.205693;;f;BE;f;Europe/Brussels;f;BEAAC;;f;;f;8800402;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;Tubeke;;;;;;;;;;;
@@ -4523,7 +4523,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5926;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5927;La Louvière Centre;la-louviere-centre;8882107;;50.478161;4.179858;;f;BE;f;Europe/Brussels;f;BEABA;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;Centrum;;;;;;;;;;;
 5928;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5929;Antwerpen-Centraal;antwerpen-centraal;8821006;88210060;51.21552672202654;4.42100465297699;5964;f;BE;t;Europe/Brussels;t;BEABC;;t;;f;8800007;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Antwerp;;Anvers;Anversa;;;;;;;;;;;;
+5929;Antwerpen-Centraal;antwerpen-centraal;8821006;88210060;51.21552672202654;4.42100465297699;5964;f;BE;t;Europe/Brussels;t;BEABC;;t;;f;8800007;t;;f;;f;;f;;;f;;f;8800210;f;;f;f;;;Antwerp;;Anvers;Anversa;;;;;;;;;;;;
 5930;Zeebrugge-Dorp;zeebrugge-dorp;8891553;;51.326383;3.19517;;f;BE;f;Europe/Brussels;f;BEABD;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5931;Waregem;waregem;8896149;;50.890855;3.425303;;f;BE;f;Europe/Brussels;f;BEABE;;f;;f;8800092;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5932;Torhout;torhout;8891314;;51.064455;3.105656;;f;BE;f;Europe/Brussels;f;BEABF;;f;;f;8800087;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4567,10 +4567,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5970;Blandain Ville;blandain-ville;;;;;;t;BE;f;Europe/Brussels;f;BEBDN;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5971;Bruxelles-Nord;bruxelles-nord;8812005;;50.8602380000;4.3614580000;5974;f;BE;f;Europe/Brussels;t;BEBNO;;t;;f;8800002;t;;f;;f;;f;;;f;;f;;f;;f;f;;Brüssel;Brussels;Bruselas;;;Brussel;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 5972;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5973;Brugge;brugge;8891009;;51.19722998626312;3.217062950134277;;f;BE;f;Europe/Brussels;t;BEBRG;;t;;f;8800029;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Bruges;Brujas;Bruges;Bruges;;Bruggy;;;ブルッヘ;브뤼허;Brugia;Bruges;Брюгге;Brygge;;布鲁日
+5973;Brugge;brugge;8891009;;51.19722998626312;3.217062950134277;;f;BE;f;Europe/Brussels;t;BEBRG;;t;;f;8800029;t;;f;;f;;f;;;f;;f;8800910;f;;f;f;;;Bruges;Brujas;Bruges;Bruges;;Bruggy;;;ブルッヘ;브뤼허;Brugia;Bruges;Брюгге;Brygge;;布鲁日
 5974;Bruxelles;bruxelles;9900009;;50.84651957961837;4.351739287376404;;t;BE;f;Europe/Brussels;t;BEBRU;;t;;f;;f;u1516c;t;;f;;f;;;f;;f;;f;;f;f;;Brüssel;Brussels;Bruselas;;;Brussel;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 5975;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5976;Charleroi-Sud;charleroi-sud;8872009;;50.4044220000;4.4387740000;;f;BE;f;Europe/Brussels;t;BECRL;;t;;f;8800024;t;;f;;f;;f;;;f;;f;;f;;f;f;;;South;;;;Zuid;;;;シャルルロワ;샤를루아;;;Шарлеруа;;;沙勒罗瓦
+5976;Charleroi-Sud;charleroi-sud;8872009;;50.4044220000;4.4387740000;;f;BE;f;Europe/Brussels;t;BECRL;;t;;f;8800024;t;;f;;f;;f;;;f;;f;8800720;f;;f;f;;;South;;;;Zuid;;;;シャルルロワ;샤를루아;;;Шарлеруа;;;沙勒罗瓦
 5977;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5978;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5979;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4579,7 +4579,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5982;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5983;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5984;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5985;Gent-Sint-Pieters;gent-sint-pieters;8892007;;51.0356270000;3.7106120000;;f;BE;f;Europe/Brussels;t;BEGNT;;t;;f;8800031;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Ghent;;Gand;Gand;;;;;;;;;;;;
+5985;Gent-Sint-Pieters;gent-sint-pieters;8892007;;51.0356270000;3.7106120000;;f;BE;f;Europe/Brussels;t;BEGNT;;t;;f;8800031;t;;f;;f;;f;;;f;;f;8800920;f;;f;f;;;Ghent;;Gand;Gand;;;;;;;;;;;;
 5986;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5987;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5988;Herseaux;herseaux;8885753;;50.713723;3.24604;;f;BE;f;Europe/Brussels;f;BEHER;;f;;f;8800064;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4589,13 +4589,13 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5992;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5993;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5994;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5995;Liège-Guillemins;liege-guillemins;8841004;88410040;50.6242970000;5.5666670000;23044;f;BE;t;Europe/Brussels;t;BELGG;;t;;f;8800012;t;;f;;f;;f;;;f;;f;;f;;f;f;;Lüttich;;Lieja;;Liegi;Luik;Lutych;;;リエージュ;리에주;;;Льеж;;;列日
+5995;Liège-Guillemins;liege-guillemins;8841004;88410040;50.6242970000;5.5666670000;23044;f;BE;t;Europe/Brussels;t;BELGG;;t;;f;8800012;t;;f;;f;;f;;;f;;f;8800410;f;;f;f;;Lüttich;;Lieja;;Liegi;Luik;Lutych;;;リエージュ;리에주;;;Льеж;;;列日
 5996;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5997;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5998;Oostende;oostende;8891702;;51.2284900000;2.9268240000;;f;BE;f;Europe/Brussels;t;BEOST;;t;;f;8800030;t;;f;;f;;f;;;f;;f;;f;;f;f;;Ostende;Ostend;Ostende;Ostende;Ostenda;;Ostende;Ostende;;オーステンデ;오스텐더;Ostenda;Ostende;Остенде;;;奥斯滕德
+5998;Oostende;oostende;8891702;;51.2284900000;2.9268240000;;f;BE;f;Europe/Brussels;t;BEOST;;t;;f;8800030;t;;f;;f;;f;;;f;;f;8800917;f;;f;f;;Ostende;Ostend;Ostende;Ostende;Ostenda;;Ostende;Ostende;;オーステンデ;오스텐더;Ostenda;Ostende;Остенде;;;奥斯滕德
 5999;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6000;Mons;mons;8881000;;50.45612423580516;3.9446711540222164;;f;BE;f;Europe/Brussels;t;BEQMO;;t;;f;8800025;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;Bergen;;;;モンス;몽스;;;Монс;;;蒙斯
-6001;Namur;namur;8863008;;50.4689830000;4.8624990000;;f;BE;f;Europe/Brussels;t;BEQNM;;t;;f;8800018;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;Namen;;;;ナミュール;나무르;;;Намюр;;;那慕爾
+6000;Mons;mons;8881000;;50.45612423580516;3.9446711540222164;;f;BE;f;Europe/Brussels;t;BEQMO;;t;;f;8800025;t;;f;;f;;f;;;f;;f;8800810;f;;f;f;;;;;;;Bergen;;;;モンス;몽스;;;Монс;;;蒙斯
+6001;Namur;namur;8863008;;50.4689830000;4.8624990000;;f;BE;f;Europe/Brussels;t;BEQNM;;t;;f;8800018;t;;f;;f;;f;;;f;;f;8800630;f;;f;f;;;;;;;Namen;;;;ナミュール;나무르;;;Намюр;;;那慕爾
 6002;;;;;;;;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6003;Quévy Ville;quevy-ville;;;;;;t;BE;f;Europe/Brussels;f;BEQUE;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6004;;;;;;;5974;f;BE;f;Europe/Brussels;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4759,7 +4759,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6162;Effretikon;effretikon;8503305;;47.4257390000;8.6869500000;;f;CH;f;Europe/Zurich;t;CHAFX;;f;;f;8503305;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6163;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6164;Puidoux-Chexbres;puidoux-chexbres;8504012;;46.493809;6.765695;;f;CH;f;Europe/Zurich;f;CHAFZ;;f;;f;8504012;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6165;Martigny;martigny;8501500;;46.1058340000;7.0791220000;6391;f;CH;f;Europe/Zurich;t;CHAGA;;t;;f;8501500;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+6165;Martigny;martigny;8501500;;46.1058340000;7.0791220000;6391;f;CH;f;Europe/Zurich;t;CHAGA;;t;;f;8501500;t;;f;;f;;f;;;f;;f;8500150;f;;f;f;;;;;;;;;;;;;;;;;;
 6166;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6167;Degersheim;degersheim;8506292;;47.372127;9.199551;;f;CH;f;Europe/Zurich;f;CHAGC;;f;;f;8506292;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6168;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4770,7 +4770,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6173;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6174;Le Chable;le-chable;8501579;;46.078732;7.215047;;f;CH;f;Europe/Zurich;f;CHAGJ;;f;;f;8501579;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6175;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6176;Vallorbe;vallorbe;8501103;85011031;46.712427;6.370529;6367;f;CH;f;Europe/Zurich;t;CHAGL;;t;;f;8501103;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+6176;Vallorbe;vallorbe;8501103;85011031;46.712427;6.370529;6367;f;CH;f;Europe/Zurich;t;CHAGL;;t;;f;8501103;f;;f;;f;;f;;;f;;f;8500990;f;;f;f;;;;;;;;;;;;;;;;;;
 6177;Rheinfelden;rheinfelden;8500301;;47.5512100000;7.7921550000;;f;CH;f;Europe/Zurich;t;CHAGM;;f;;f;8500301;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6178;Pratteln;pratteln;8500021;;47.5226600000;7.6908200000;;f;CH;f;Europe/Zurich;t;CHAGN;;f;;f;8500021;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6179;Arth;arth;8505004;;47.0491630000;8.5494780000;;f;CH;f;Europe/Zurich;t;CHAGO;;f;;f;8505004;t;;f;;f;8505004;t;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4839,9 +4839,9 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6242;Muri;muri;8502215;;;;;f;CH;f;Europe/Zurich;f;CHAJA;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6243;Raefis;raefis;8509405;;;;;f;CH;f;Europe/Zurich;f;CHAJB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6244;Othmarsingen;othmarsingen;8502105;;47.407446;8.214783;;f;CH;f;Europe/Zurich;f;CHAJC;;f;;f;8502105;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6245;Zürich HB;zurich-hb;8503000;85030007;47.378186;8.539203;6401;f;CH;f;Europe/Zurich;t;CHAJD;;t;;f;8503000;t;;f;;f;8503000;t;;;f;;f;;f;;f;f;;;;;;Zurigo;;Curych;;;チューリッヒ;취리히;Zurych;Zurique;Цюрих;;Zürih;
+6245;Zürich HB;zurich-hb;8503000;85030007;47.378186;8.539203;6401;f;CH;f;Europe/Zurich;t;CHAJD;;t;;f;8503000;t;;f;;f;8503000;t;;;f;;f;85200;f;;f;f;;;;;;Zurigo;;Curych;;;チューリッヒ;취리히;Zurych;Zurique;Цюрих;;Zürih;
 6246;Vernayaz;vernayaz;;;;;;t;CH;f;Europe/Zurich;f;CHAJE;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6247;Lausanne;lausanne;8501120;85011205;46.5167040000;6.6290500000;6354;f;CH;t;Europe/Zurich;t;CHAJF;;t;;f;8501120;t;;f;;f;8501120;t;;;f;;f;;f;;f;f;;;;Lausana;;Losanna;;;;;ローザンヌ;;Lozanna;Lausana;Лозанна;;Lozan;洛桑
+6247;Lausanne;lausanne;8501120;85011205;46.5167040000;6.6290500000;6354;f;CH;t;Europe/Zurich;t;CHAJF;;t;;f;8501120;t;;f;;f;8501120;t;;;f;;f;85550;f;;f;f;;;;Lausana;;Losanna;;;;;ローザンヌ;;Lozanna;Lausana;Лозанна;;Lozan;洛桑
 6248;Grenchen Nord;grenchen-nord;8500159;;47.1918210000;7.3894560000;6325;f;CH;f;Europe/Zurich;t;CHAJG;;f;;f;8500159;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6249;Leukerbad;leukerbad;8501656;;46.379781;7.626457;;f;CH;f;Europe/Zurich;f;CHAJH;;f;;f;8501656;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6251;Lausanne—Ouchy;lausanne-ouchy;8585555;;;;6354;f;CH;f;Europe/Zurich;f;CHAJJ;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4893,7 +4893,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6297;Brügg;brugg;8500309;;47.4808510000;8.2088320000;;f;CH;f;Europe/Zurich;t;CHBGG;;f;;f;8500309;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;브루그;;;Брюгг;;;布魯格
 6298;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6299;Braunwald;braunwald;8503261;;46.938685;8.998597;;f;CH;f;Europe/Zurich;f;CHBNW;;f;;f;8503261;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6300;Bern;bern;8507000;85070003;46.9491130000;7.4384830000;;f;CH;f;Europe/Zurich;t;CHBRN;;t;;f;8507000;t;;f;;f;8507000;t;;;f;;f;;f;;f;f;;Schweiz;Switzerland;Berna;Berne, Suisse;Berna, Svizzera;;;;;ベルン;베른;Berno;Berna;Берн;;;伯恩
+6300;Bern;bern;8507000;85070003;46.9491130000;7.4384830000;;f;CH;f;Europe/Zurich;t;CHBRN;;t;;f;8507000;t;;f;;f;8507000;t;;;f;;f;85031;f;;f;f;;Schweiz;Switzerland;Berna;Berne, Suisse;Berna, Svizzera;;;;;ベルン;베른;Berno;Berna;Берн;;;伯恩
 6301;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6302;Chandolin Poste;chandolin-poste;8501755;;;;;f;CH;f;Europe/Zurich;f;CHCHA;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6303;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4936,7 +4936,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6346;Lenzerheide/Lai;lenzerheide-slash-lai;8509790;;;;;f;CH;f;Europe/Zurich;f;CHLZH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6347;Morgins Poste;morgins-poste;8501890;;;;;f;CH;f;Europe/Zurich;f;CHMRG;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6348;Monthey;monthey;8501421;;;;;t;CH;f;Europe/Zurich;f;CHMTY;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6349;Neuchâtel;neuchatel;8504244;;46.996728;6.93569;6350;f;CH;f;Europe/Zurich;t;CHNBT;;t;;f;8504221;t;;f;;f;;f;;;f;;f;;f;;f;f;;Neuenburg;;;;;;;;;ヌーシャテル;뇌샤텔;;;Невшатель;;;纳沙泰尔
+6349;Neuchâtel;neuchatel;8504244;;46.996728;6.93569;6350;f;CH;f;Europe/Zurich;t;CHNBT;;t;;f;8504221;t;;f;;f;;f;;;f;;f;8500038;f;;f;f;;Neuenburg;;;;;;;;;ヌーシャテル;뇌샤텔;;;Невшатель;;;纳沙泰尔
 6350;Neuchâtel;neuchatel;;;;;;t;CH;f;Europe/Zurich;f;CHNLO;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;Neuenburg;;;;;;;;;ヌーシャテル;뇌샤텔;;;Невшатель;;;纳沙泰尔
 6351;Neuchâtel;neuchatel;8504221;;46.996513;6.935914;6349;f;CH;f;Europe/Zurich;f;CHQNC;;t;;f;8530791;f;;f;;f;;f;;;f;;f;;f;;f;f;;Neuenburg;;;;;;;;;ヌーシャテル;뇌샤텔;;;Невшатель;;;纳沙泰尔
 6352;St-Gallen;st-gallen;8506302;;47.423276;9.369303;6358;f;CH;f;Europe/Zurich;t;CHQGL;;f;;f;8506302;t;;f;;f;8506302;f;;;f;;f;;f;;f;f;;;;;Saint-Gall;San Gallo;;;;;;;;;Санкт-Галлен;;;
@@ -4965,11 +4965,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6375;Brigue;brigue;8500324;;;;;f;CH;f;Europe/Zurich;f;CHZDL;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6376;Buchs;buchs;8500271;;;;;f;CH;f;Europe/Zurich;f;CHZDO;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6377;Chiasso;chiasso;8500321;;;;;f;CH;f;Europe/Zurich;f;CHZDS;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6378;Chur;chur;8509000;;46.85344;9.528475;;f;CH;f;Europe/Zurich;t;CHZDT;;f;;f;8509000;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;Coira;Coire;Coira;;;;;クール;쿠어;;Coira;Кур;;;庫爾
+6378;Chur;chur;8509000;;46.85344;9.528475;;f;CH;f;Europe/Zurich;t;CHZDT;;f;;f;8509000;t;;f;;f;;f;;;f;;f;8500900;f;;f;f;;;;Coira;Coire;Coira;;;;;クール;쿠어;;Coira;Кур;;;庫爾
 6379;Delemont;delemont;8500109;;47.3619960000;7.3500470000;;f;CH;f;Europe/Zurich;t;CHZDW;;f;;f;8500109;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6380;Einsiedeln;einsiedeln;8503283;;47.1303350000;8.7457220000;;f;CH;f;Europe/Zurich;t;CHZDZ;;f;;f;8503283;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6381;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6382;Fribourg;fribourg;8504100;85041004;46.8031460000;7.1510260000;;f;CH;f;Europe/Zurich;t;CHZHF;;t;;f;8504100;t;;f;;f;8504100;f;;;f;;f;;f;;f;f;;Freiburg;;Friburgo;;Friburgo;;;;;フリブール;;Fryburg;Friburgo;Фрибур;;;
+6382;Fribourg;fribourg;8504100;85041004;46.8031460000;7.1510260000;;f;CH;f;Europe/Zurich;t;CHZHF;;t;;f;8504100;t;;f;;f;8504100;f;;;f;;f;85410;f;;f;f;;Freiburg;;Friburgo;;Friburgo;;;;;フリブール;;Fryburg;Friburgo;Фрибур;;;
 6383;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6384;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6385;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4979,7 +4979,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6389;Les Diablerets;les-diablerets;8501479;;46.351159;7.155017;;f;CH;f;Europe/Zurich;f;CHZJF;;f;;f;8501479;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6390;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6391;Martigny;martigny;;;;;;t;CH;f;Europe/Zurich;f;CHZJM;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6392;Montreux;montreux;8501300;85013003;46.4358640000;6.9104300000;;f;CH;f;Europe/Zurich;t;CHZJP;;t;;f;8501300;t;;f;;f;8501300;t;S01235;;f;;f;;f;;f;f;;;;;;;;;;;モントルー;몽트뢰;;;Монтрё;;Montrö;蒙特勒
+6392;Montreux;montreux;8501300;85013003;46.4358640000;6.9104300000;;f;CH;f;Europe/Zurich;t;CHZJP;;t;;f;8501300;t;;f;;f;8501300;t;S01235;;f;;f;8500116;f;;f;f;;;;;;;;;;;モントルー;몽트뢰;;;Монтрё;;Montrö;蒙特勒
 6393;Olten;olten;8500218;;47.3520090000;7.9076210000;;f;CH;f;Europe/Zurich;t;CHZJU;;t;;f;8500218;t;;f;;f;8500218;t;S01150;;f;;f;;f;;f;f;;;;;;;;;;;オルテン;올텐;;;Ольтен;;;奧爾滕
 6394;;;;;;;;f;CH;f;Europe/Zurich;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6395;Schaffhausen;schaffhausen;8503424;;47.6982830000;8.6327360000;;f;CH;f;Europe/Zurich;t;CHZKJ;;f;;f;8503424;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;Schaffhouse;Sciaffusa;;;;;シャフハウゼン;샤프하우젠;Szafuza;Sciaffusa;Шаффхаузен;;;沙夫豪森
@@ -5286,7 +5286,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6697;Neckarsulm;neckarsulm;8029635;;49.188973;9.220064;;f;DE;f;Europe/Berlin;t;DEAAG;;f;;f;8004220;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6698;Aachen;aachen;;;50.77607;6.08378;;t;DE;f;Europe/Berlin;t;DEAAH;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Aquisgrán;Aix-la-Chapelle;Aquisgrana;Aken;Cáchy;;;アーヘン;아헨;Akwizgran;Aquisgrano;Ахен;;;亚琛
 6699;Aachen-Rothe Erde;aachen-rothe-erde;8015342;;50.770202;6.116476;6698;f;DE;f;Europe/Berlin;t;DEACP;;f;;f;8000406;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;Aquisgrán;Aix-la-Chapelle;Aquisgrana;Aken;Cáchy;;;アーヘン;아헨;Akwizgran;Aquisgrano;Ахен;;;亚琛
-6700;Aachen Hbf;aachen-hbf;8015345;;50.767802;6.091495;6698;f;DE;t;Europe/Berlin;t;DEBDY;;t;;f;8000001;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Aquisgrán;Aix-la-Chapelle Gare centrale;Aquisgrana Stazione centrale;Aken;Cáchy;;;アーヘン;아헨;Akwizgran;Aquisgrano;Ахен;;;亚琛
+6700;Aachen Hbf;aachen-hbf;8015345;;50.767802;6.091495;6698;f;DE;t;Europe/Berlin;t;DEBDY;;t;;f;8000001;t;;f;;f;;f;;;f;;f;8052101;f;;f;f;;;Main station;Aquisgrán;Aix-la-Chapelle Gare centrale;Aquisgrana Stazione centrale;Aken;Cáchy;;;アーヘン;아헨;Akwizgran;Aquisgrano;Ахен;;;亚琛
 6701;Aachen Süd (Gr);aachen-sud-gr;8000452;;50.731917;6.045407;6698;f;DE;f;Europe/Berlin;f;DEAQK;;f;;f;8000403;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6702;Aachen West;aachen-west;8015199;;50.78036;6.070712;6698;f;DE;f;Europe/Berlin;t;DEAAW;;f;;f;8000404;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;Aquisgrán;Aix-la-Chapelle;Aquisgrana;Aken;Cáchy;;;アーヘン;아헨;Akwizgran;Aquisgrano;Ахен;;;亚琛
 6703;Buxtehude;buxtehude;8001188;;53.47049;9.688313;;f;DE;f;Europe/Berlin;t;DEAAI;;f;;f;8001315;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -5436,7 +5436,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6847;Castrop-Rauxel Hbf;castrop-rauxel-hbf;8010036;;51.573694;7.304562;;f;DE;f;Europe/Berlin;t;DEAFY;;f;;f;8001327;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;;;;;;;;
 6848;Calmbach Bahnhof;calmbach-bahnhof;8029457;;48.776485;8.571133;;f;DE;f;Europe/Berlin;t;DEAFZ;;f;;f;8001320;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6849;Cham (Oberpf);cham-oberpf;8026249;;49.221864;12.656829;;f;DE;f;Europe/Berlin;t;DEAGA;;f;;f;8001330;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6850;Augsburg Hbf;augsburg-hbf;8002140;;48.365444;10.885568;;f;DE;f;Europe/Berlin;t;DEAGB;;t;;f;8000013;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Augsburgo Estación central;Gare centrale;Stazione centrale;;;;;アウクスブルク;아우크스부르크;;Augsburgo;Аугсбург;;;奥格斯堡
+6850;Augsburg Hbf;augsburg-hbf;8002140;;48.365444;10.885568;;f;DE;f;Europe/Berlin;t;DEAGB;;t;;f;8000013;t;;f;;f;;f;;;f;;f;8086120;f;;f;f;;;Main station;Augsburgo Estación central;Gare centrale;Stazione centrale;;;;;アウクスブルク;아우크스부르크;;Augsburgo;Аугсбург;;;奥格斯堡
 6851;Öhringen-Cappel;ohringen-cappel;8001594;;49.201917;9.526686;;f;DE;f;Europe/Berlin;t;DEAGC;;f;;f;8004620;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6852;Deggendorf Hbf;deggendorf-hbf;8026450;;48.839436;12.949725;;f;DE;f;Europe/Berlin;t;DEAGD;;f;;f;8001397;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;;;;;Деггендорф;;;德根多尔夫
 6853;Derneburg (Han);derneburg-han;8013377;;52.096848;10.143715;;f;DE;f;Europe/Berlin;t;DEAGE;;f;;f;8000071;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -6058,12 +6058,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 7472;Bochum Hbf;bochum-hbf;8010179;;51.478651;7.224109;7470;f;DE;f;Europe/Berlin;t;DEQBO;;f;;f;8000041;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;ボーフム;보훔;;;Бохум;;;波鸿
 7473;Bonn Hbf;bonn-hbf;8015485;;50.732007;7.097136;7545;f;DE;f;Europe/Berlin;t;DEBEA;;f;;f;8000044;t;;f;;f;;f;;;f;108000044;t;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;ボン;본;;Bona;Бонн;;;波恩
 7474;Hamburg Hbf;hamburg-hbf;8001071;;53.552732;10.006908;7626;f;DE;f;Europe/Berlin;t;DEBEB;;f;;f;8002549;t;;f;;f;;f;;;f;108001071;t;;f;;f;f;;;Main station;Hamburgo;Hambourg Gare centrale;Amburgo Stazione centrale;;Hamburk;Hamborg;;ハンブルク;함부르크;;Hamburgo;Гамбург;;;汉堡市
-7475;Düsseldorf Hbf;dusseldorf-hbf;8008094;;51.21996;6.794316;7578;f;DE;f;Europe/Berlin;t;DEBEC;;t;;f;8000085;t;;f;;f;;f;;;f;108008094;t;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;デュッセルドルフ;뒤셀도르프;;;Дюссельдорф;;;
+7475;Düsseldorf Hbf;dusseldorf-hbf;8008094;;51.21996;6.794316;7578;f;DE;f;Europe/Berlin;t;DEBEC;;t;;f;8000085;t;;f;;f;;f;;;f;108008094;t;8040260;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;デュッセルドルフ;뒤셀도르프;;;Дюссельдорф;;;
 7476;Lindau reutin;lindau-reutin;8000467;;;;;f;DE;f;Europe/Berlin;f;DEBED;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7477;Mittenwald (Gr);mittenwald-gr;8000464;;47.39807;11.267439;7685;f;DE;f;Europe/Berlin;f;DEBEE;;f;;f;8004044;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7478;Mannheim;mannheim;;;;;;t;DE;f;Europe/Berlin;f;DEBEF;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-7479;Mannheim Hbf;mannheim-hbf;8014008;;49.479295999056305;8.469530940055847;7478;f;DE;t;Europe/Berlin;t;DEMHG;;t;;f;8000244;t;;f;;f;8014008;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;マンハイム;만하임;;;Мангейм;;;曼海姆
-7480;München Hbf;munchen-hbf;8020347;;48.140228;11.558338;;f;DE;f;Europe/Berlin;t;DEBEG;;t;;f;8000261;t;;f;;f;8020347;f;;;f;;f;;f;;f;f;;;Munich Main station;Múnich;Munich Gare centrale;Monaco di Baviera Stazione centrale;;Mnichov;;;ミュンヘン;뮌헨;Monachium;Munique;Мюнхен;;Münih;慕尼黑
+7479;Mannheim Hbf;mannheim-hbf;8014008;;49.479295999056305;8.469530940055847;7478;f;DE;t;Europe/Berlin;t;DEMHG;;t;;f;8000244;t;;f;;f;8014008;f;;;f;;f;8068585;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;マンハイム;만하임;;;Мангейм;;;曼海姆
+7480;München Hbf;munchen-hbf;8020347;;48.140228;11.558338;;f;DE;f;Europe/Berlin;t;DEBEG;;t;;f;8000261;t;;f;;f;8020347;f;;;f;;f;8080600;f;;f;f;;;Munich Main station;Múnich;Munich Gare centrale;Monaco di Baviera Stazione centrale;;Mnichov;;;ミュンヘン;뮌헨;Monachium;Munique;Мюнхен;;Münih;慕尼黑
 7481;Neustadt;neustadt;;;;;;t;DE;f;Europe/Berlin;f;DEBEH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7482;Neustadt (Weinstr) Hbf;neustadt-weinstr-hbf;8019403;;49.34961;8.140379;7481;f;DE;f;Europe/Berlin;t;DEQNL;;f;;f;8000275;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;ノイシュタット・バイ・コーブルク;;;;Нойштадт-ам-Ренштайг;;;伦斯泰希地区诺伊斯塔特
 7483;Wuppertal;wuppertal;;;;;;t;DE;f;Europe/Berlin;f;DEBEI;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -6144,7 +6144,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 7558;Köln;koln;;;50.941312;6.967206;;t;DE;f;Europe/Berlin;t;DECGN;;t;;f;8096022;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Cologne;Colonia;Cologne;Colonia;Keulen;Kolín nad Rýnem;;;ケルン;쾰른;Kolonia;Colônia;Кёльн;;;科隆
 7559;Köln-Mülheim;koln-mulheim;8015541;;50.957987;7.013294;7558;f;DE;f;Europe/Berlin;t;DEKOM;;f;;f;8000209;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Cologne;Colonia;Cologne;Colonia;Keulen;Kolín nad Rýnem;;;ケルン;쾰른;Kolonia;Colônia;Кёльн;;;科隆
 7560;Köln Messe/Deutz;koln-messe-deutz;8015561;;50.940871;6.975;7558;f;DE;f;Europe/Berlin;t;DEKOD;;f;;f;8003368;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Cologne;Colonia;Cologne;Colonia;Keulen;Kolín nad Rýnem;;;ケルン;쾰른;Kolonia;Colônia;Кёльн;;;科隆
-7561;Köln Hbf;koln-hbf;8015458;80154583;50.943029;6.958729;7558;f;DE;t;Europe/Berlin;t;DEKOH;;t;;f;8000207;t;;f;;f;8015458;f;S02100;;f;108015458;t;;f;;f;f;;;Cologne Main station;Colonia Estación central;Cologne Gare centrale;Colonia Stazione centrale;Keulen;Kolín nad Rýnem;;;ケルン;쾰른;Kolonia;Colônia;Кёльн;;;科隆
+7561;Köln Hbf;koln-hbf;8015458;80154583;50.943029;6.958729;7558;f;DE;t;Europe/Berlin;t;DEKOH;;t;;f;8000207;t;;f;;f;8015458;f;S02100;;f;108015458;t;8050500;f;;f;f;;;Cologne Main station;Colonia Estación central;Cologne Gare centrale;Colonia Stazione centrale;Keulen;Kolín nad Rýnem;;;ケルン;쾰른;Kolonia;Colônia;Кёльн;;;科隆
 7562;Celle;celle;8013631;;52.621171;10.062704;;f;DE;f;Europe/Berlin;t;DECLL;;f;;f;8000064;t;;f;;f;;f;;;f;;f;;f;;f;f;;Deutschland;Germany;Alemania;Allemagne;Germania;;;;;ツェレ;첼레;;;Целле;;;策勒
 7563;Cochem (Mosel);cochem-mosel;8025107;;50.153093;7.166739;;f;DE;f;Europe/Berlin;t;DECMO;;f;;f;8001340;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;コッヘム;;;;Кохем;;;科赫姆
 7564;Crailsheim;crailsheim;8029685;;49.137869;10.064322;;f;DE;f;Europe/Berlin;t;DECRH;;f;;f;8000067;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -6159,7 +6159,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 7573;Dortmund Hbf;dortmund-hbf;8010053;;51.517898;7.459293;;f;DE;f;Europe/Berlin;t;DEDTM;;t;;f;8000080;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;ドルトムント;도르트문트;;;Дортмунд;;;多特蒙德
 7574;Düsseldorf-Benrath;dusseldorf-benrath;8008117;;51.162375;6.87904;7578;f;DE;f;Europe/Berlin;t;DEDUB;;f;;f;8001584;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Дюссельдорф-Бенрат;;;
 7575;Düsseldorf Flughafen;dusseldorf-flughafen;8039904;;51.292008;6.786837;7578;f;DE;f;Europe/Berlin;t;DEDUF;;t;;f;8000082;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Airport;Aeropuerto;Aéroport;Aeroporto;;;;;デュッセルドルフ;뒤셀도르프;;;Дюссельдорф;;;
-7576;Duisburg Hbf;duisburg-hbf;8010316;;51.429786;6.775906;;f;DE;f;Europe/Berlin;t;DEDUI;;t;;f;8000086;t;;f;;f;;f;;;f;108010316;t;;f;;f;f;;;Main station;Duisburgo Estación central;Duisbourg Gare centrale;Stazione centrale;;;;;デュイスブルク;뒤스부르크;;Duisburgo;Дуйсбург;;;杜伊斯堡
+7576;Duisburg Hbf;duisburg-hbf;8010316;;51.429786;6.775906;;f;DE;f;Europe/Berlin;t;DEDUI;;t;;f;8000086;t;;f;;f;;f;;;f;108010316;t;8047270;f;;f;f;;;Main station;Duisburgo Estación central;Duisbourg Gare centrale;Stazione centrale;;;;;デュイスブルク;뒤스부르크;;Duisburgo;Дуйсбург;;;杜伊斯堡
 7577;Düren;duren;8015330;;50.809395;6.482031;;f;DE;f;Europe/Berlin;t;DEDUR;;f;;f;8000084;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;뒤렌;;;Дюрен;;;迪伦
 7578;Düsseldorf;dusseldorf;8080260;;;;;t;DE;f;Europe/Berlin;f;DEDUS;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7579;Eberbach;eberbach;8014121;;49.465769;8.984152;;f;DE;f;Europe/Berlin;t;DEEBB;;f;;f;8000369;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -6186,7 +6186,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 7601;Reichenbach (Vogtl) ob Bf;reichenbach-vogtl-ob-bf;8006704;;50.627777;12.293117;;f;DE;f;Europe/Berlin;t;DEFLW;;f;;f;8012739;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7602;Frankfurt (Main);frankfurt-main;;;50.107149;8.663785;;t;DE;f;Europe/Berlin;t;DEFRA;;t;;f;8096021;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;Fráncfort;Francfort;Francoforte;;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 7603;Frankfurt (Main) Süd;frankfurt-main-sud;8011065;;50.09958;8.686303;7602;f;DE;f;Europe/Berlin;t;DEFRS;;f;;f;8002041;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;Fráncfort;Francfort;Francoforte;;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
-7604;Frankfurt (Main) Hbf;frankfurt-main-hbf;8011068;;50.107149;8.663785;7602;f;DE;t;Europe/Berlin;t;DEFRH;;t;;f;8000105;t;;f;;f;8011068;f;;;f;108000105;t;;f;;f;f;;;Main station;Fráncfort;Francfort Gare centrale;Francoforte Stazione centrale;;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
+7604;Frankfurt (Main) Hbf;frankfurt-main-hbf;8011068;;50.107149;8.663785;7602;f;DE;t;Europe/Berlin;t;DEFRH;;t;;f;8000105;t;;f;;f;8011068;f;;;f;108000105;t;8060315;f;;f;f;;;Main station;Fráncfort;Francfort Gare centrale;Francoforte Stazione centrale;;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 7605;Frankfurt-Höchst;frankfurt-hochst;8011100;;50.102636;8.542368;7602;f;DE;f;Europe/Berlin;t;DEFRO;;f;;f;8000106;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;Fráncfort;Francfort;Francoforte;;Frankfurt nad Mohanem;;;フランクフルト・アム・マイン;프랑크푸르트;Frankfurt nad Menem;;Франкфурт-на-Майне;;;法兰克福
 7606;Freudenstadt;freudenstadt;;;;;;t;DE;f;Europe/Berlin;f;DEFRE;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7607;Gengenbach;gengenbach;8014497;;48.404655;8.010188;;f;DE;f;Europe/Berlin;t;DEGGB;;f;;f;8002235;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -6248,8 +6248,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 7663;Kiel Hbf;kiel-hbf;8001304;;54.314982;10.131975;;f;DE;f;Europe/Berlin;t;DEKIE;;f;;f;8000199;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;Kehl;;;;ケール;킬;Kilonia;Kehl;Кель;;;凱爾
 7664;Kirchenlaibach;kirchenlaibach;8026089;;49.869906;11.776327;;f;DE;f;Europe/Berlin;t;DEKLB;;f;;f;8000201;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7665;Karlsruhe;karlsruhe;;;;;;t;DE;f;Europe/Berlin;f;DEKLS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-7666;Karlsruhe Hbf;karlsruhe-hbf;8014228;;48.993509649554724;8.401848077774048;7665;f;DE;t;Europe/Berlin;t;DEQKA;;t;;f;8000191;t;;f;;f;8014231;f;S01800;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;カールスルーエ;카를스루에;;;Карлсруэ;;;卡尔斯鲁厄
-7667;Kaiserslautern Hbf;kaiserslautern-hbf;8019698;;49.43614;7.768711;;f;DE;f;Europe/Berlin;t;DEKLT;;t;;f;8000189;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;カイザースラウテルン;카이저슬라우테른;;;Кайзерслаутерн;;;
+7666;Karlsruhe Hbf;karlsruhe-hbf;8014228;;48.993509649554724;8.401848077774048;7665;f;DE;t;Europe/Berlin;t;DEQKA;;t;;f;8000191;t;;f;;f;8014231;f;S01800;;f;;f;8076475;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;カールスルーエ;카를스루에;;;Карлсруэ;;;卡尔斯鲁厄
+7667;Kaiserslautern Hbf;kaiserslautern-hbf;8019698;;49.43614;7.768711;;f;DE;f;Europe/Berlin;t;DEKLT;;t;;f;8000189;t;;f;;f;;f;;;f;;f;8067471;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;カイザースラウテルン;카이저슬라우테른;;;Кайзерслаутерн;;;
 7668;Kornwestheim Pbf;kornwestheim-pbf;8029026;;48.862215;9.179964;;f;DE;f;Europe/Berlin;t;DEKOR;;f;;f;8003411;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7669;Konstanz-Petershausen;konstanz-petershausen;8014584;;47.674839;9.171514;;f;DE;f;Europe/Berlin;t;DEKPT;;f;;f;8003401;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7670;Kreiensen;kreiensen;8013060;;51.851425;9.967796;;f;DE;f;Europe/Berlin;t;DEKRS;;f;;f;8000213;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -6282,7 +6282,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 7697;Puttgarden;puttgarden;8001669;;54.500941;11.227832;7696;f;DE;f;Europe/Berlin;t;DEPUT;;f;;f;8004903;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7698;Pegnitz;pegnitz;8022298;;49.75834;11.547542;;f;DE;f;Europe/Berlin;t;DEPGN;;f;;f;8004759;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7699;Mayen Ost;mayen-ost;8025074;;50.329263;7.238968;;f;DE;f;Europe/Berlin;t;DEQMZ;;f;;f;8000248;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-7700;Ulm Hbf;ulm-hbf;8029103;;48.399432;9.982224;;f;DE;f;Europe/Berlin;t;DEQUL;;t;;f;8000170;t;;f;;f;8029103;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;ウルム;울름;;;Ульм;;;乌尔姆
+7700;Ulm Hbf;ulm-hbf;8029103;;48.399432;9.982224;;f;DE;f;Europe/Berlin;t;DEQUL;;t;;f;8000170;t;;f;;f;8029103;f;;;f;;f;8089880;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;ウルム;울름;;;Ульм;;;乌尔姆
 7701;Würzburg Hbf;wurzburg-hbf;8022534;;49.801794;9.935777;;f;DE;f;Europe/Berlin;t;DEQWU;;f;;f;8000260;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Wurzburgo Estación central;Gare centrale;Stazione centrale;;;;;ヴュルツブルク;뷔르츠부르크;;Wurtzburgo;Вюрцбург;;;维尔茨堡
 7702;Radolfzell;radolfzell;8014571;;47.735875;8.968987;;f;DE;f;Europe/Berlin;t;DERAD;;f;;f;8000880;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7703;Rastatt;rastatt;8014245;;48.860579;8.215745;;f;DE;f;Europe/Berlin;t;DERAS;;f;;f;8000306;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ラシュタット;;;;Раштатт;;;拉施塔特
@@ -6290,9 +6290,9 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 7705;Remscheid;remscheid;;;;;;t;DE;f;Europe/Berlin;f;DEREM;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7706;Ribnitz-Damgarten West;ribnitz-damgarten-west;8027064;;54.239175;12.436962;;f;DE;f;Europe/Berlin;t;DERIB;;f;;f;8012763;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7707;Salzgitter;salzgitter;8033859;;52.106134;10.390649;;t;DE;f;Europe/Berlin;t;DESAL;;f;;f;8096006;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ザルツギッター;잘츠기터;;;Зальцгиттер;;;薩爾茨吉特
-7708;Saarbrücken Hbf;saarbrucken-hbf;8025391;80253914;49.24115221039208;6.990984678268433;;f;DE;f;Europe/Berlin;t;DESBK;;t;;f;8000323;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Main station;Sarrebruck Estación central;Sarrebruck Gare centrale;Stazione centrale;;;;;ザールブリュッケン;자르브뤼켄;;;Саарбрюккен;;;萨尔布吕肯
+7708;Saarbrücken Hbf;saarbrucken-hbf;8025391;80253914;49.24115221039208;6.990984678268433;;f;DE;f;Europe/Berlin;t;DESBK;;t;;f;8000323;t;;f;;f;;f;;;f;;f;8066800;f;;f;f;;;Main station;Sarrebruck Estación central;Sarrebruck Gare centrale;Stazione centrale;;;;;ザールブリュッケン;자르브뤼켄;;;Саарбрюккен;;;萨尔布吕肯
 7709;Schirnding;schirnding;8000644;;50.077296;12.228745;;f;DE;f;Europe/Berlin;t;DESCH;;f;;f;8005352;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-7710;Stuttgart Hbf;stuttgart-hbf;8029034;80290346;48.784081;9.181636;7714;f;DE;f;Europe/Berlin;t;DESGT;;t;;f;8000096;t;;f;;f;8029034;f;S03800;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;シュトゥットガルト;슈투트가르트;;Estugarda;Штутгарт;;;斯图加特
+7710;Stuttgart Hbf;stuttgart-hbf;8029034;80290346;48.784081;9.181636;7714;f;DE;f;Europe/Berlin;t;DESGT;;t;;f;8000096;t;;f;;f;8029034;f;S03800;;f;;f;8070830;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;シュトゥットガルト;슈투트가르트;;Estugarda;Штутгарт;;;斯图加特
 7711;Solingen;solingen;;;;;;t;DE;f;Europe/Berlin;f;DESLG;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7712;Schnabelwaid;schnabelwaid;8022297;;49.810451;11.595662;;f;DE;f;Europe/Berlin;t;DESNW;;f;;f;8000328;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 7713;Sulzbach rosenberg;sulzbach-rosenberg;;;;;;t;DE;f;Europe/Berlin;f;DESRB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -6737,7 +6737,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 8152;Belfast Central;belfast-central;;;54.5953;-5.9172;;f;GB;f;Europe/London;t;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;BFC;t;f;;;;;;;;;;;;;;;;;;
 8153;Arbroath;arbroath;7090790;;56.559628;-2.588928;;f;GB;f;Europe/London;t;GBARB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;ARB;t;f;;;;;;;;;;;;;;;;;;
 8154;Ashford;ashford;7070512;;;;;t;GB;f;Europe/London;f;GBASD;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-8155;Ashford International;ashford-international;7054660;70546606;51.14335293766652;0.8751672506332396;8154;f;GB;t;Europe/London;t;GBASI;;t;;f;7098107;f;;f;;f;;f;;;f;;f;;f;AFK;t;f;;;;;;;;;;;;;;;;;;
+8155;Ashford International;ashford-international;7054660;70546606;51.14335293766652;0.8751672506332396;8154;f;GB;t;Europe/London;t;GBASI;;t;;f;7098107;f;;f;;f;;f;;;f;;f;7000512;f;AFK;t;f;;;;;;;;;;;;;;;;;;
 8156;Aberystwyth;aberystwyth;7043030;;52.414017;-4.081946;;f;GB;f;Europe/London;t;GBAWY;;f;;f;;f;;f;;f;;f;;;f;;f;;f;AYW;t;f;;;;;;;;;;;;;;;;;;
 8157;London St-Pancras;london-st-pancras;7015550;;51.531831;-0.126747;8267;f;GB;f;Europe/London;f;GBBAA;;f;;f;7001424;f;;f;;f;;f;;;f;;f;;f;;f;f;5892;;;;;;;;;;;;;;;;;
 8158;Tilbury Town;tilbury-town;7074620;;51.462879;0.353724;26797;f;GB;f;Europe/London;t;GBBAB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;TIL;t;f;;;;;;;;;;;;;;;;;;
@@ -6806,7 +6806,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 8221;Dumfries;dumfries;7094900;;55.072395;-3.605261;;f;GB;f;Europe/London;t;GBDUM;;f;;f;;f;;f;;f;;f;;;f;;f;;f;DMF;t;f;;;;;;;;;;;;;;;;;;
 8222;Dawlish;dawlish;7034080;;50.580692;-3.464583;;f;GB;f;Europe/London;t;GBDWL;;f;;f;;f;;f;;f;;f;;;f;;f;;f;DWL;t;f;;;;;;;;;;;;;;;;;;
 8223;Fishguard Harbour;fishguard-harbour;7040760;;52.011505;-4.985713;;f;GB;f;Europe/London;t;GBEAS;;f;;f;;f;;f;;f;;f;;;f;;f;;f;FGH;t;f;;;;;;;;;;;;;;;;;;
-8224;Ebbsfleet International;ebbsfleet-international;7015440;70154401;51.443009;0.320887;;f;GB;f;Europe/London;t;GBEBF;;t;;f;7004419;f;;f;;f;;f;;;f;;f;;f;EBD;t;f;;;;;;;;;;;;;;;;;;
+8224;Ebbsfleet International;ebbsfleet-international;7015440;70154401;51.443009;0.320887;;f;GB;f;Europe/London;t;GBEBF;;t;;f;7004419;f;;f;;f;;f;;;f;;f;7015440;f;EBD;t;f;;;;;;;;;;;;;;;;;;
 8225;Edinburgh Waverley;edinburgh-waverley;7093280;;55.952442;-3.188236;;f;GB;f;Europe/London;t;GBEDB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;EDB;t;f;;;;;;;;;;;;;;;;;;
 8226;Exeter Central;exeter-central;7057550;;50.726471;-3.532973;8228;f;GB;f;Europe/London;t;GBEXC;;f;;f;;f;;f;;f;;f;;;f;;f;;f;EXC;t;f;;;;;;;;;;;;;;;;;;
 8227;Exeter St Davids;exeter-st-davids;7034100;;50.729019;-3.544387;8228;f;GB;f;Europe/London;t;GBEXD;;f;;f;;f;;f;;f;;f;;;f;;f;;f;EXD;t;f;;;;;;;;;;;;;;;;;;
@@ -7072,7 +7072,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 8487;;;;;;;8483;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8488;;;;;;;8483;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8489;;;;;;;8483;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-8490;Milano Centrale;milano-centrale;8301700;83017004;45.487143;9.204828;8483;f;IT;t;Europe/Rome;t;ITBGE;;t;;f;8300046;t;;f;;f;8301700;t;S01700;MC_;t;;f;;f;;f;f;;Mailand;Milan;Milán;Milan;;Milaan;Milán;;;ミラノ;밀라노;Mediolan;Milão;Милан;;;
+8490;Milano Centrale;milano-centrale;8301700;83017004;45.487143;9.204828;8483;f;IT;t;Europe/Rome;t;ITBGE;;t;;f;8300046;t;;f;;f;8301700;t;S01700;MC_;t;;f;83111;f;;f;f;;Mailand;Milan;Milán;Milan;;Milaan;Milán;;;ミラノ;밀라노;Mediolan;Milão;Милан;;;
 8491;Milano Rogoredo;milano-rogoredo;8301820;83018200;45.4336660000;9.2390140000;8483;f;IT;f;Europe/Rome;t;ITMRO;;f;;f;8300418;t;;f;;f;8301820;t;S01820;RG_;t;;f;;f;;f;f;;Mailand;Milan;Milán;Milan;;Milaan;Milán;;;ミラノ;밀라노;Mediolan;Milão;Милан;;;
 8492;Milano Porta Garibaldi;milano-porta-garibaldi;8301645;83016451;45.484437;9.187299;8483;f;IT;f;Europe/Rome;t;ITMPG;;t;;f;8300047;t;;f;;f;8301645;t;S01645;MPG;t;;f;;f;;f;f;;Mailand;Milan;Milán;Milan;;Milaan;Milán;;;ミラノ;밀라노;Mediolan;Milão;Милан;;;
 8493;Modena;modena;8305032;;44.654616;10.929948;;;IT;f;Europe/Rome;t;ITMOD;;f;;f;8300214;f;;f;;f;8305032;t;S05032;Q__;t;;f;;f;;f;f;;;;;Modène;;;;;;モデナ;;;;Модена;;;
@@ -7091,7 +7091,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 8506;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8507;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8508;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-8509;Oulx;oulx;8300204;83002048;45.03877849785553;6.831125020980835;;f;IT;f;Europe/Rome;t;ITOCS;;t;;f;;f;;f;;f;8300204;t;S00204;;f;;f;;f;;f;f;;;;;;;;;;;ウルクス;;;;;;;
+8509;Oulx;oulx;8300204;83002048;45.03877849785553;6.831125020980835;;f;IT;f;Europe/Rome;t;ITOCS;;t;;f;;f;;f;;f;8300204;t;S00204;;f;;f;8300011;f;;f;f;;;;;;;;;;;ウルクス;;;;;;;
 8510;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8511;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8512;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -7150,14 +7150,14 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 8565;Torino;torino;8300996;;45.07075504730648;7.686063051223755;;t;IT;f;Europe/Rome;t;ITTRN;;t;;f;8396006;f;u0j2qu;t;;f;8300996;t;;TO0;t;;f;;f;;f;f;;Turin;Turin;Turín;Turin;;Turijn;Turín;;;トリノ;토리노;Turyn;Turim;Турин;Turin;;
 8566;Torino Lingotto;torino-lingotto;8300452;;45.026194;7.657532;8565;;IT;f;Europe/Rome;t;ITABV;;f;;f;8300516;f;;f;;f;8300452;t;S00452;;f;;f;;f;;f;f;;Turin;Turin;Turín;Turin;;Turijn;Turín;;;トリノ;토리노;Turyn;Turim;Турин;Turin;;
 8567;Torino Porta Nuova;torino-porta-nuova;8300219;;45.061000;7.677713;8565;f;IT;f;Europe/Rome;t;ITBGD;;f;;f;8300001;f;;f;;f;8300219;t;S00219;TOP;t;;f;;f;;f;f;;Turin;Turin;Turín;Turin;;Turijn;Turín;;;トリノ;토리노;Turyn;Turim;Турин;Turin;;
-8568;Torino Porta Susa;torino-porta-susa;8300222;83002220;45.071832;7.665164;8565;f;IT;f;Europe/Rome;t;ITTRS;;t;;f;8300522;f;;f;;f;8300222;t;S00035;OUE;t;;f;;f;;f;f;;Turin;Turin;Turín;Turin;;Turijn;Turín;;;トリノ;토리노;Turyn;Turim;Турин;Turin;;
+8568;Torino Porta Susa;torino-porta-susa;8300222;83002220;45.071832;7.665164;8565;f;IT;f;Europe/Rome;t;ITTRS;;t;;f;8300522;f;;f;;f;8300222;t;S00035;OUE;t;;f;83002;f;;f;f;;Turin;Turin;Turín;Turin;;Turijn;Turín;;;トリノ;토리노;Turyn;Turim;Турин;Turin;;
 8569;;;;;;;8565;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8570;;;;;;;8565;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8571;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8572;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8573;Venezia;venezia;8302998;;45.43711;12.33475;;t;IT;f;Europe/Rome;t;ITVCE;;f;;f;8396008;f;;f;;f;8302998;t;;VE0;t;;f;;f;;f;f;;Venedig;Venice;Venecia;Venise;;Venetië;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
-8574;Venezia Santa Lucia;venezia-santa-lucia;8302593;83025932;45.4413970000;12.3204620000;8573;f;IT;t;Europe/Rome;t;ITAGP;;f;;f;8300094;t;;f;;f;8302593;t;S02593;VSL;t;;f;;f;;f;f;;Venedig Hauptbahnhof;Venice Main station;Venecia;Venise Gare centrale;;Venetië;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
-8575;Venezia Mestre;venezia-mestre;8302589;83025890;45.4819020000;12.2319000000;8573;f;IT;f;Europe/Rome;t;ITBGG;;f;;f;8300093;t;;f;;f;8302589;t;S02589;VEM;t;;f;;f;;f;f;;Venedig;Venice;Venecia;Venise;;Venetië;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
+8574;Venezia Santa Lucia;venezia-santa-lucia;8302593;83025932;45.4413970000;12.3204620000;8573;f;IT;t;Europe/Rome;t;ITAGP;;f;;f;8300094;t;;f;;f;8302593;t;S02593;VSL;t;;f;8300222;f;;f;f;;Venedig Hauptbahnhof;Venice Main station;Venecia;Venise Gare centrale;;Venetië;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
+8575;Venezia Mestre;venezia-mestre;8302589;83025890;45.4819020000;12.2319000000;8573;f;IT;f;Europe/Rome;t;ITBGG;;f;;f;8300093;t;;f;;f;8302589;t;S02589;VEM;t;;f;8300221;f;;f;f;;Venedig;Venice;Venecia;Venise;;Venetië;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
 8576;Venezia Carpenedo;venezia-carpenedo;8302672;;45.506676;12.247595;8573;f;IT;f;Europe/Rome;t;ITAID;;f;;f;8300968;f;;f;;f;8302672;t;S02672;;f;;f;;f;;f;f;;Venedig;Venice;Venecia;Venise;;Venetië;Benátky;Venedig;Velence;ヴェネツィア;베네치아;Wenecja;Veneza;Венеция;Venedig;Venedik;威尼斯
 8577;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8578;Ventimiglia;ventimiglia;8304501;;43.792586;7.609953;9604;f;IT;f;Europe/Rome;t;ITVEF;;t;;f;8300146;f;;f;;f;8304501;t;S04501;;f;;f;;f;;f;f;;;;;Vintimille;;;;;;ヴェンティミーリア;;;;Вентимилья;;;文蒂米利亚
@@ -7185,7 +7185,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 8601;;;;;;;;f;LU;f;Europe/Luxembourg;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8602;;;;;;;;f;LU;f;Europe/Luxembourg;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8603;Kautenbach;kautenbach;8200130;;49.94919;6.021702;;f;LU;f;Europe/Luxembourg;f;LUKTB;;f;;f;8270630;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-8604;Luxembourg;luxembourg;8200100;82001000;49.599717;6.134391;8731;f;LU;t;Europe/Luxembourg;t;LULUX;;t;;f;8200100;t;;f;;f;;f;;;f;;f;;f;;f;f;;Luxemburg;;Luxemburgo;;Lussemburgo;Luxemburg;Lucemburk;;;ルクセンブルク;룩셈부르크;Luksemburg;Luxemburgo;Люксембург;;Lüksemburg;盧森堡市
+8604;Luxembourg;luxembourg;8200100;82001000;49.599717;6.134391;8731;f;LU;t;Europe/Luxembourg;t;LULUX;;t;;f;8200100;t;;f;;f;;f;;;f;;f;8200100;f;;f;f;;Luxemburg;;Luxemburgo;;Lussemburgo;Luxemburg;Lucemburk;;;ルクセンブルク;룩셈부르크;Luksemburg;Luxemburgo;Люксембург;;Lüksemburg;盧森堡市
 8605;Pétange;petange;8200930;;49.554195;5.879169;;f;LU;f;Europe/Luxembourg;f;LUPET;;f;;f;8200930;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8606;Rodange;rodange;8200940;;49.551283;5.845028;;t;LU;f;Europe/Luxembourg;f;LURDG;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8607;Alkmaar;alkmaar;8400050;;52.6379540000;4.7384740000;;f;NL;f;Europe/Amsterdam;t;NLAAA;;f;;f;8400050;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;アルクマール;알크마르;;;Алкмаар;;;阿尔克马尔
@@ -7251,9 +7251,9 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 8667;Haarlem;haarlem;8400285;;52.3871100000;4.6364650000;;f;NL;f;Europe/Amsterdam;t;NLGRZ;;f;;f;8400285;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ハールレム;하를럼;;;Харлем;;;哈勒姆
 8668;Maastricht;maastricht;8400424;;50.849811;5.705875;;f;NL;f;Europe/Amsterdam;t;NLMST;;f;;f;8400424;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8669;Roosendaal;roosendaal;8400526;;51.5398590000;4.4566360000;;f;NL;f;Europe/Amsterdam;t;NLROO;;f;;f;8400526;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;Rosendael;;;;;;ローゼンダール;;;;Розендал;;;罗森达尔
-8670;Rotterdam Centraal;rotterdam-centraal;8400530;84005306;51.925068244603146;4.468839168548584;23616;f;NL;f;Europe/Amsterdam;t;NLRTA;;t;;f;8400530;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ロッテルダム;로테르담;;Roterdão;Роттердам;;;鹿特丹
+8670;Rotterdam Centraal;rotterdam-centraal;8400530;84005306;51.925068244603146;4.468839168548584;23616;f;NL;f;Europe/Amsterdam;t;NLRTA;;t;;f;8400530;f;;f;;f;;f;;;f;;f;8400530;f;;f;f;;;;;;;;;;;ロッテルダム;로테르담;;Roterdão;Роттердам;;;鹿特丹
 8671;;;;;;;;f;NL;f;Europe/Amsterdam;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-8672;Schiphol Airport;schiphol-airport;8400561;;52.3087870000;4.7614870000;;f;NL;f;Europe/Amsterdam;t;NLSPH;;t;;f;8400561;t;;f;;f;;f;;;f;;f;;f;;f;f;;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amszterdam;アムステルダム;암스테르담;Amsterdam;Amesterdão;Амстердам;Amsterdam;Amsterdam;阿姆斯特丹
+8672;Schiphol Airport;schiphol-airport;8400561;;52.3087870000;4.7614870000;;f;NL;f;Europe/Amsterdam;t;NLSPH;;t;;f;8400561;t;;f;;f;;f;;;f;;f;8400561;f;;f;f;;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amsterdam;Amszterdam;アムステルダム;암스테르담;Amsterdam;Amesterdão;Амстердам;Amsterdam;Amsterdam;阿姆斯特丹
 8673;Utrecht Centraal;utrecht-centraal;8400621;;52.0875800000;5.1111670000;;f;NL;f;Europe/Amsterdam;t;NLUTC;;f;;f;8400621;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ユトレヒト;;;;Утрехт;;;
 8674;Pinhel;pinhel;9448595;;;;;f;PT;f;Europe/Lisbon;f;PTAAA;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 8675;Vila Franca das Naves;vila-franca-das-naves;9448546;;40.724541;-7.258357;;f;PT;f;Europe/Lisbon;t;PTAAB;;f;;f;9400083;f;;f;;f;;f;;;f;;f;94546;t;;f;f;;;;;;;;;;;;;;;;;;
@@ -7654,7 +7654,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 9148;Lugny;lugny;8729716;;;;;f;FR;f;Europe/Paris;f;FRCOT;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9149;Roissy-Aéroport-CDG 2;roissy-aeroport-cdg-2;8740204;;;;;f;FR;f;Europe/Paris;f;FRROI;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9150;Laroche-St-Cydroine;laroche-st-cydroine;;;47.9666670000;3.5166670000;;t;FR;f;Europe/Paris;f;FRLAR;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9151;Brienon;brienon;;;48.0000000000;3.6166670000;;t;FR;f;Europe/Paris;f;FRISJ;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+9151;Brienon;brienon;;;48.0000000000;3.6166670000;;t;FR;f;Europe/Paris;f;FRISJ;;f;;f;;f;;f;;f;;f;;;f;;f;8700973;f;;f;f;;;;;;;;;;;;;;;;;;
 9152;Gallardon Pont;gallardon-pont;8739487;;48.5333330000;1.7000000000;;f;FR;f;Europe/Paris;f;FRDLB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9153;Nanterre;nanterre;;;48.9000000000;2.2000000000;;t;FR;f;Europe/Paris;f;FRISN;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9154;Aéroport-Charles-de-Gaulle-1;aeroport-charles-de-gaulle-1;8727146;;49.009764;2.56126;1143;f;FR;f;Europe/Paris;f;FRISO;;f;;f;8704377;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -7742,7 +7742,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 9236;Orgerus—Béhoust;orgerus-behoust;8739344;;48.826707;1.702826;;f;FR;f;Europe/Paris;f;FRDJA;;f;;f;8704154;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9237;Tacoignières-Richebourg;tacoignieres-richebourg;8739345;;48.829449;1.669045;;f;FR;f;Europe/Paris;f;FRDJB;;f;;f;8704687;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9238;Jaleyrac—Sourniac;jaleyrac-sourniac;8764527;;;;;f;FR;f;Europe/Paris;f;FRGBU;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9239;Houdan;houdan;8739346;;48.7833330000;1.6000000000;;f;FR;f;Europe/Paris;f;FRDJC;;f;;f;8703473;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+9239;Houdan;houdan;8739346;;48.7833330000;1.6000000000;;f;FR;f;Europe/Paris;f;FRDJC;;f;;f;8703473;f;;f;;f;;f;;;f;;f;8700460;f;;f;f;;;;;;;;;;;;;;;;;;
 9240;Marchezais-Broué;marchezais-broue;8739347;;48.768412;1.513693;;f;FR;f;Europe/Paris;f;FRDJD;;f;;f;8703907;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9241;Ermont;ermont;;;48.9833330000;2.2666670000;;t;FR;f;Europe/Paris;f;FRRMT;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9242;Largnac;largnac;8764529;;;;;f;FR;f;Europe/Paris;f;FRGBW;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -7802,7 +7802,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 9296;Chénérailles;chenerailles;8715803;87158030;46.1166670000;2.1666670000;;f;FR;f;Europe/Paris;t;FRIPK;;t;;f;8703090;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9297;Meudon;meudon;8739310;;48.8166670000;2.2333330000;;f;FR;f;Europe/Paris;f;FRDIA;;f;;f;8703982;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9298;Bellevue;bellevue;8739311;;48.818977;2.229585;;f;FR;f;Europe/Paris;f;FRDIB;;f;;f;8702804;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9299;Gap;gap;8776300;87763003;44.563730871358366;6.085787415504456;;f;FR;f;Europe/Paris;t;FRGAT;GAP;t;;f;8700111;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;ギャップ;;;;;;;
+9299;Gap;gap;8776300;87763003;44.563730871358366;6.085787415504456;;f;FR;f;Europe/Paris;t;FRGAT;GAP;t;;f;8700111;f;;f;;f;;f;;;f;;f;8700197;f;;f;t;;;;;;;;;;;ギャップ;;;;;;;
 9300;St-Méen-le-Grand;st-meen-le-grand;8733805;;48.1833330000;-2.2000000000;;f;FR;f;Europe/Paris;f;FRMEE;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9301;Lignerolles;lignerolles;8764179;;46.2833330000;2.5666670000;;f;FR;f;Europe/Paris;f;FRGAU;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9302;Sèvres;sevres;;;48.8166670000;2.2000000000;;t;FR;f;Europe/Paris;f;FRAIJ;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -7970,7 +7970,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 9464;Orly Ville;orly-ville;8754620;;48.741894;2.402951;9037;f;FR;f;Europe/Paris;f;FRORY;;f;;f;8704155;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9465;Coolus;coolus;8711775;;48.9166670000;4.3500000000;;f;FR;f;Europe/Paris;f;FRAOK;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9466;Le Grand-Bourg;le-grand-bourg;8732119;87321190;48.641296;2.429029;;f;FR;f;Europe/Paris;f;FRGSF;;f;;f;8706475;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9467;Pontoise;pontoise;8727613;;49.0500000000;2.1000000000;;f;FR;f;Europe/Paris;f;FRPOX;;f;;f;8704285;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+9467;Pontoise;pontoise;8727613;;49.0500000000;2.1000000000;;f;FR;f;Europe/Paris;f;FRPOX;;f;;f;8704285;f;;f;;f;;f;;;f;;f;8700831;f;;f;f;;;;;;;;;;;;;;;;;;
 9468;La Ferté-Hauterive;la-ferte-hauterive;8769634;;46.4000000000;3.3333330000;;f;FR;f;Europe/Paris;f;FRGSV;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9469;Vertheuil;vertheuil;8758129;;;;;f;FR;f;Europe/Paris;f;FRFAB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9470;Bourg-Lastic—Messeix;bourg-lastic-messeix;8764126;87641266;45.627554;2.559444;;f;FR;f;Europe/Paris;f;FRBLM;;f;;f;8702887;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -7993,7 +7993,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 9487;Léaz;leaz;8774266;;46.1000000000;5.8833330000;;f;FR;f;Europe/Paris;f;FRHPW;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9488;Ecorans;ecorans;8774267;;;;;f;FR;f;Europe/Paris;f;FRHPX;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9489;Vanchy;vanchy;8774269;;;;;f;FR;f;Europe/Paris;f;FRHPZ;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9490;Lérouville;lerouville;8717524;87175240;48.797231;5.538763;;f;FR;f;Europe/Paris;t;FRLER;;t;;f;8700060;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+9490;Lérouville;lerouville;8717524;87175240;48.797231;5.538763;;f;FR;f;Europe/Paris;t;FRLER;;t;;f;8700060;f;;f;;f;;f;;;f;;f;8700071;f;;f;f;;;;;;;;;;;;;;;;;;
 9491;Joncels;joncels;;;43.7333330000;3.1833330000;;f;FR;f;Europe/Paris;f;FRIME;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9492;Rosendaël;rosendael;;;51.0333330000;2.4000000000;;f;FR;f;Europe/Paris;f;FRCIV;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9493;Leffrinckoucke;leffrinckoucke;;;51.0333330000;2.4666670000;;f;FR;f;Europe/Paris;f;FRCIW;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -8248,7 +8248,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 9742;Pont-Petit;pont-petit;8727615;;49.060364;2.130695;;f;FR;f;Europe/Paris;f;FRCFL;;f;;f;8704275;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9743;Chaponval;chaponval;8727616;;49.069434;2.142381;;f;FR;f;Europe/Paris;f;FRCFM;;f;;f;8703044;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9744;St-Gratien;st-gratien;8727617;;48.9666670000;2.2833330000;;f;FR;f;Europe/Paris;f;FRCFN;;f;;f;8704583;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9745;Sannois;sannois;8727618;;48.9666670000;2.2500000000;;f;FR;f;Europe/Paris;f;FRCFO;;f;;f;8704445;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+9745;Sannois;sannois;8727618;;48.9666670000;2.2500000000;;f;FR;f;Europe/Paris;f;FRCFO;;f;;f;8704445;f;;f;;f;;f;;;f;;f;8700430;f;;f;f;;;;;;;;;;;;;;;;;;
 9746;Garges—Sarcelles;garges-sarcelles;8727619;;48.9679070000;2.3978090000;;f;FR;f;Europe/Paris;f;FRCFP;;f;;f;8703377;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9747;Villiers-le-Bel—Gonesse—Arnouville;villiers-le-bel-gonesse-arnouville;8727622;;48.993538;2.415976;;f;FR;f;Europe/Paris;f;FRCFT;;f;;f;8704878;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9748;Les Noues;les-noues;8727623;;49.032542;2.476941;;f;FR;f;Europe/Paris;f;FRCFU;;f;;f;8703778;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -8289,12 +8289,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 9783;St-Crépin;st-crepin;;;44.7064560000;6.6069460000;;f;FR;f;Europe/Paris;f;FRSCP;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9784;Verneuil-l’Étang;verneuil-letang;8711607;;48.644595;2.824752;;f;FR;f;Europe/Paris;f;FRAKI;;f;;f;8702187;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9785;Mormant;mormant;8711608;;48.6000000000;2.8833330000;;f;FR;f;Europe/Paris;f;FRAKJ;;f;;f;8701571;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9786;Nangis;nangis;8711609;;48.5500000000;3.0000000000;;f;FR;f;Europe/Paris;f;FRAKK;;f;;f;8701666;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9787;Meaux;meaux;8711610;;48.9500000000;2.8666670000;;f;FR;f;Europe/Paris;f;FRAKL;;f;;f;8700517;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+9786;Nangis;nangis;8711609;;48.5500000000;3.0000000000;;f;FR;f;Europe/Paris;f;FRAKK;;f;;f;8701666;f;;f;;f;;f;;;f;;f;8700946;f;;f;f;;;;;;;;;;;;;;;;;;
+9787;Meaux;meaux;8711610;;48.9500000000;2.8666670000;;f;FR;f;Europe/Paris;f;FRAKL;;f;;f;8700517;f;;f;;f;;f;;;f;;f;8700957;f;;f;f;;;;;;;;;;;;;;;;;;
 9788;Chelles—Gournay;chelles-gournay;8711611;;48.874153;2.582708;;f;FR;f;Europe/Paris;f;FRAKM;;f;;f;8703085;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9789;Ste-Colombe—Septveilles;ste-colombe-septveilles;8711617;;48.530081;3.25725;;f;FR;f;Europe/Paris;f;FRAKO;;f;;f;8701941;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9790;Sauveterre-de-Béarn Centre;sauveterre-de-bearn-centre;8746511;87465112;43.4000000000;-0.9333330000;;f;FR;f;Europe/Paris;f;FRSCW;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-9791;Nemours-St-Pierre;nemours-st-pierre;8768412;87684126;48.2666670000;2.6833330000;;f;FR;f;Europe/Paris;f;FRGOA;NSP;f;;f;8704092;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+9791;Nemours-St-Pierre;nemours-st-pierre;8768412;87684126;48.2666670000;2.6833330000;;f;FR;f;Europe/Paris;f;FRGOA;NSP;f;;f;8704092;f;;f;;f;;f;;;f;;f;8700483;f;;f;f;;;;;;;;;;;;;;;;;;
 9792;Tournan;tournan;8711621;;48.739521;2.758789;;f;FR;f;Europe/Paris;f;FRAKQ;;f;;f;8704734;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9793;Bagneaux-sur-Loing;bagneaux-sur-loing;8768419;;48.2333330000;2.7000000000;;f;FR;f;Europe/Paris;f;FRGOB;;f;;f;8702755;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 9794;Marles-en-Brie;marles-en-brie;8711622;;48.7166670000;2.8833330000;;f;FR;f;Europe/Paris;f;FRAKR;;f;;f;8703913;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -8513,7 +8513,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 10007;La Beaume;la-beaume;;;44.5527000000;5.6375000000;;f;FR;f;Europe/Paris;f;FRIGL;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10008;La Fourchette;la-fourchette;8746256;;;;;f;FR;f;Europe/Paris;f;FRRCP;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10009;Antony;antony;8775875;;48.7500000000;2.3000000000;;f;FR;f;Europe/Paris;f;FRIDJ;;f;;f;8702672;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-10010;Chemin-d’Antony;chemin-dantony;8754631;;48.747818;2.313266;10009;f;FR;f;Europe/Paris;f;FRERU;;f;;f;8703088;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+10010;Chemin-d’Antony;chemin-dantony;8754631;;48.747818;2.313266;10009;f;FR;f;Europe/Paris;f;FRERU;;f;;f;8703088;f;;f;;f;;f;;;f;;f;8700377;f;;f;f;;;;;;;;;;;;;;;;;;
 10011;St-Pierre-d’Argenton;st-pierre-dargenton;8776322;;;;;f;FR;f;Europe/Paris;f;FRIGM;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10012;Aspremont;aspremont;8776326;;44.4833330000;5.7166670000;;f;FR;f;Europe/Paris;f;FRIGN;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10013;Montmaur;montmaur;;;44.5833330000;5.8833330000;;f;FR;f;Europe/Paris;f;FRIGO;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -8722,7 +8722,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 10216;Montauban-de-Bretagne Ville;montauban-de-bretagne-ville;8733841;;;;1645;f;FR;f;Europe/Paris;f;FRMNB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10217;Draguignan;draguignan;;;43.5333330000;6.4666670000;;f;FR;f;Europe/Paris;f;FRDRA;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10218;Hadancourt;hadancourt;8741994;;49.1833330000;1.8500000000;;f;FR;f;Europe/Paris;f;FRDRB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-10219;Hendaye-Plage — Les Deux Jumeaux;hendaye-plage-les-deux-jumeaux;8767710;87677104;43.36993020665726;-1.7643356323242185;5785;f;FR;f;Europe/Paris;t;FRGJU;HPZ;t;;f;8701248;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+10219;Hendaye-Plage — Les Deux Jumeaux;hendaye-plage-les-deux-jumeaux;8767710;87677104;43.36993020665726;-1.7643356323242185;5785;f;FR;f;Europe/Paris;t;FRGJU;HPZ;t;;f;8701248;f;;f;;f;;f;;;f;;f;8700294;f;;f;f;;;;;;;;;;;;;;;;;;
 10220;Hendaye Frontière;hendaye-frontiere;8767790;;;;5785;f;FR;f;Europe/Paris;f;FRGJV;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;Hendaya;;;;;;;アンダイエ;;;;Андай;;;昂代伊
 10221;Sérans;serans;8741995;;49.1833330000;1.8333330000;;f;FR;f;Europe/Paris;f;FRDRD;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10222;Montcenis;montcenis;8732092;;46.7833330000;4.3833330000;;f;FR;f;Europe/Paris;f;FRMNH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -8963,10 +8963,10 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 10457;Bologna Corticella;bologna-corticella;8305725;;44.55204;11.353987;22159;f;IT;f;Europe/Rome;t;ITAMH;;f;;f;8300995;f;;f;;f;8305725;t;S05725;;f;;f;;f;;f;f;;;;Bolonia;Bologne;;;;;;ボローニャ;볼로냐;Bolonia;Bolonha;Болонья;;Bolonya;博洛尼亚
 10458;;;;;;;;f;IT;f;Europe/Rome;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10459;Vicenza;vicenza;8302446;;45.541096;11.540774;;f;IT;f;Europe/Rome;t;ITAIN;;f;;f;8300126;f;;f;;f;8302446;t;S02446;;f;;f;;f;;f;f;;;;;Vicence;;;;;;ヴィチェンツァ;;;;Виченца;;;
-10460;Bardonecchia;bardonecchia;8300202;;45.0764640756508;6.709744334220886;;f;IT;f;Europe/Rome;t;ITBCC;;t;;f;8300004;f;;f;;f;8300202;t;S00202;;f;;f;;f;;f;f;;;;;Bardonèche;;;;;;バルドネッキア;;;;;;;
+10460;Bardonecchia;bardonecchia;8300202;;45.0764640756508;6.709744334220886;;f;IT;f;Europe/Rome;t;ITBCC;;t;;f;8300004;f;;f;;f;8300202;t;S00202;;f;;f;83005;f;;f;f;;;;;Bardonèche;;;;;;バルドネッキア;;;;;;;
 10461;Innsbruck;innsbruck;;;;;;t;AT;f;Europe/Vienna;f;ATINN;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-10462;Novara;novara;8300248;83002485;45.451258;8.625104;;f;IT;f;Europe/Rome;t;ITAAB;;t;;f;8300007;f;;f;;f;8300248;t;S00248;;f;;f;;f;;f;f;;;;;Novare;;;;;;ノヴァーラ;;;;Новара;;;
-10463;Vercelli;vercelli;8300245;83002451;45.330137;8.416501;;f;IT;f;Europe/Rome;t;ITAAC;;t;;f;8300008;f;;f;;f;8300245;t;S00245;;f;;f;;f;;f;f;;;;;Verceil;;;;;;ヴェルチェッリ;;;;Верчелли;;;
+10462;Novara;novara;8300248;83002485;45.451258;8.625104;;f;IT;f;Europe/Rome;t;ITAAB;;t;;f;8300007;f;;f;;f;8300248;t;S00248;;f;;f;8300008;f;;f;f;;;;;Novare;;;;;;ノヴァーラ;;;;Новара;;;
+10463;Vercelli;vercelli;8300245;83002451;45.330137;8.416501;;f;IT;f;Europe/Rome;t;ITAAC;;t;;f;8300008;f;;f;;f;8300245;t;S00245;;f;;f;8300009;f;;f;f;;;;;Verceil;;;;;;ヴェルチェッリ;;;;Верчелли;;;
 10464;Innsbruck Hbf;innsbruck-hbf;8101187;;47.2632770000;11.4010000000;10461;f;AT;f;Europe/Vienna;t;ATALA;;f;;f;8100108;t;;f;;f;8101187;f;;;f;;f;;f;;f;f;;;Main station;Estación central;Gare centrale;Stazione centrale;;;;;インスブルック;인스브루크;;;Инсбрук;;İnnsbruck;因斯布鲁克
 10465;Figueras (Figueres);figueras-figueres;;;;;;t;ES;f;Europe/Madrid;f;ESFRS;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10466;Autun St-Jean;autun-st-jean;8747850;87478503;;;;f;FR;f;Europe/Paris;f;FRSDY;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -9204,7 +9204,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 10698;;;8754843;;;;;f;FR;f;Europe/Paris;f;FREIH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10699;;;;;;;;t;FR;f;Europe/Paris;f;FRCQH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10700;Bussang;bussang;;;;;;t;FR;f;Europe/Paris;f;FRBGZ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-10701;Brétigny;bretigny;;;;;;t;FR;f;Europe/Paris;f;FREQB;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+10701;Brétigny;bretigny;;;;;;t;FR;f;Europe/Paris;f;FREQB;;f;;f;;f;;f;;f;;f;;;f;;f;8700016;f;;f;f;;;;;;;;;;;;;;;;;;
 10702;Bretenoux—Biars;bretenoux-biars;;;;;;t;FR;f;Europe/Paris;f;FRBWU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10703;Daubech;daubech;8754473;;45.602169;2.292465;;f;FR;f;Europe/Paris;t;FRDTB;;t;;f;8700562;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10704;;;8753361;;;;;f;FR;f;Europe/Paris;f;FRJFA;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -10244,7 +10244,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 11738;Förbau;forbau;8026026;;50.207522;11.910689;;f;DE;f;Europe/Berlin;t;;;f;;f;8002019;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 11739;Förtschendorf;fortschendorf;8022026;;50.392898;11.35013;;f;DE;f;Europe/Berlin;t;;;f;;f;8002020;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 11740;Forbach (fr);forbach-fr;8025396;;49.214089;6.94431;;f;DE;f;Europe/Berlin;f;;;f;;f;8002021;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-11741;Forbach;forbach;8014261;;48.680399;8.361487;;f;DE;f;Europe/Berlin;t;;;f;;f;8002022;t;;f;;f;;f;;;f;;f;;f;;f;f;;Schwarzwald;Black Forest;Selva Negra;Forêt Noire;Foresta Nera;;;;;;;;;;;;
+11741;Forbach;forbach;8014261;;48.680399;8.361487;;f;DE;f;Europe/Berlin;t;;;f;;f;8002022;t;;f;;f;;f;;;f;;f;8700931;f;;f;f;;Schwarzwald;Black Forest;Selva Negra;Forêt Noire;Foresta Nera;;;;;;;;;;;;
 11742;Forchheim (b Karlsruhe);forchheim-b-karlsruhe;8014234;;48.964782;8.338933;;f;DE;f;Europe/Berlin;t;;;f;;f;8002023;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;フォルヒハイム;;;;Форххайм;;;福希海姆
 11743;Fornsbach;fornsbach;8029584;;48.97538;9.638944;;f;DE;f;Europe/Berlin;t;;;f;;f;8002026;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 11744;Forsthaus;forsthaus;8015116;;51.303245;6.503075;;f;DE;f;Europe/Berlin;t;;;f;;f;8002027;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -16010,7 +16010,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 17534;Kloten;kloten;8503308;;47.4482030000;8.5833670000;;f;CH;f;Europe/Zurich;t;CHALJ;;f;;f;8503308;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;クローテン;;;;Клотен;;;克洛滕
 17535;Horgen;horgen;8503204;;47.2615870000;8.5969680000;;f;CH;f;Europe/Zurich;t;;;f;;f;8503204;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 17536;Davos Dorf DKB;davos-dorf-dkb;8509083;;46.8083950000;9.8384050000;;f;CH;f;Europe/Zurich;f;;;f;;f;8509083;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-17537;Brig;brig;8501609;;46.3194180000;7.9880840000;;f;CH;f;Europe/Zurich;t;CHZAA;;t;;f;8501609;t;;f;;f;8501609;t;;;f;;f;;f;;f;f;;;;;Brigue;Briga;;;;;ブリーク;;;Briga-Glis;Бриг;;;
+17537;Brig;brig;8501609;;46.3194180000;7.9880840000;;f;CH;f;Europe/Zurich;t;CHZAA;;t;;f;8501609;t;;f;;f;8501609;t;;;f;;f;8500080;f;;f;f;;;;;Brigue;Briga;;;;;ブリーク;;;Briga-Glis;Бриг;;;
 17538;Bruxelles-Midi Eurostar;bruxelles-midi-eurostar;;;50.8358950000;4.3353170000;5974;f;BE;f;Europe/Brussels;f;;;f;;f;8898004;t;;f;;f;;f;;;f;;f;;f;;f;f;5893;;;;;;;;;;;;;;;;;
 17540;Amstetten NÖ;amstetten-no;8101049;;48.1219080000;14.8774440000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100012;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 17541;Bad Ischl;bad-ischl;8101934;;47.7119550000;13.6270980000;;f;AT;f;Europe/Vienna;t;;;f;;f;8100157;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;バート・イシュル;바트이슐;;;Бад-Ишль;;;巴德伊舍
@@ -16204,7 +16204,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 17738;Bruxelles-Luxembourg;bruxelles-luxembourg;8811304;;50.8388080000;4.3739980000;5974;f;BE;f;Europe/Brussels;t;BEBQL;;f;;f;8800005;t;;f;;f;;f;;;f;;f;;f;;f;f;;Brüssel;Brussels;Bruselas;;;Brussel;Brusel;;Brüsszel;ブリュッセル;브뤼셀;Bruksela;Bruxelas;Брюссель;Bryssel;Brüksel;布鲁塞尔
 17739;Halle;halle;8814308;;50.7333730000;4.2400850000;;f;BE;f;Europe/Brussels;t;BEHAB;;f;;f;8800006;t;;f;;f;;f;;;f;;f;;f;;f;f;;Belgien;Belgium;Bélgica;Hal, Belgique;Belgio;België;;;;;;;;;;;
 17740;Antwerpen-Berchem;antwerpen-berchem;8821121;;51.1995270000;4.4324640000;;f;BE;f;Europe/Brussels;t;BEBHM;;f;;f;8800008;t;;f;;f;;f;;;f;;f;;f;;f;f;;;Antwerp;;Anvers;Anversa;;;;;;;;;;;;
-17741;Essen;essen;8821402;;51.4626410000;4.4509990000;;f;BE;f;Europe/Brussels;t;BEESS;;f;;f;8800009;t;;f;;f;;f;;;f;;f;;f;;f;f;;Belgien;Belgium;Bélgica;Belgique;Belgio;België;;;;;;;;;;;
+17741;Essen;essen;8821402;;51.4626410000;4.4509990000;;f;BE;f;Europe/Brussels;t;BEESS;;f;;f;8800009;t;;f;;f;;f;;;f;;f;8045292;f;;f;f;;Belgien;Belgium;Bélgica;Belgique;Belgio;België;;;;;;;;;;;
 17742;Mechelen;mechelen;8822004;;51.0175040000;4.4834680000;;f;BE;f;Europe/Brussels;t;BEAAH;;f;;f;8800010;t;;f;;f;;f;;;f;;f;;f;;f;f;;Mecheln;;Malinas;Malines;Malines;;;;;メヘレン;메헬렌;;;Мехелен;;;梅赫伦
 17743;Ans;ans;8841202;;50.6610280000;5.5096860000;;f;BE;f;Europe/Brussels;t;BEAAK;;f;;f;8800013;t;;f;;f;;f;;;f;;f;;f;;f;f;;Belgien;Belgium;Bélgica;Belgique;Belgio;België;;;;アンス;;;;Анс;;;昂斯
 17744;Rivage;rivage;8842705;;50.4850370000;5.5859680000;;f;BE;f;Europe/Brussels;t;BEAAL;;f;;f;8800014;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -16667,14 +16667,14 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 18201;Rougemont;rougemont;8501397;;46.4889910000;7.2095550000;;f;CH;f;Europe/Zurich;t;CHACC;;f;;f;8501397;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 18202;Saanen;saanen;8501398;;46.4885590000;7.2602270000;;f;CH;f;Europe/Zurich;t;CHACA;;f;;f;8501398;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;Занен;;;萨嫩
 18203;Gstaad;gstaad;8501399;;46.4747790000;7.2843900000;;f;CH;f;Europe/Zurich;t;CHZHK;;f;;f;8501399;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-18204;Aigle;aigle;8501400;85014001;46.3168560000;6.9636550000;;f;CH;f;Europe/Zurich;t;CHZDC;;t;;f;8501400;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+18204;Aigle;aigle;8501400;85014001;46.3168560000;6.9636550000;;f;CH;f;Europe/Zurich;t;CHZDC;;t;;f;8501400;t;;f;;f;;f;;;f;;f;8500025;f;;f;f;;;;;;;;;;;;;;;;;;
 18205;Bex;bex;8501402;;46.2514600000;7.0006730000;;f;CH;f;Europe/Zurich;t;CHBEX;;f;;f;8501402;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 18206;St-Maurice;st-maurice;8501403;;46.2163570000;7.0020390000;;f;CH;f;Europe/Zurich;t;CHAGD;;f;;f;8501403;t;;f;;f;8501403;f;;;f;;f;;f;;f;f;;Schweiz;Switzerland;Suiza;Suisse;Svizzera;;;;;;;;;;;;
 18207;Leysin TLSA;leysin-tlsa;;;46.3475090000;7.0173840000;;f;CH;f;Europe/Zurich;f;;;f;;f;8501467;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-18208;Sion;sion;8501506;;46.2274606182505;7.359364628791808;;f;CH;f;Europe/Zurich;t;CHSIR;;t;;f;8501506;t;;f;;f;8501506;t;S01225;;f;;f;;f;;f;f;;Sitten;;;;;;;;;シオン;시옹;;;Сьон;;;锡永
-18209;Sierre/Siders;sierre-siders;8501509;;46.2921180000;7.5328070000;;f;CH;f;Europe/Zurich;t;CHZKO;;t;;f;8501509;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
+18208;Sion;sion;8501506;;46.2274606182505;7.359364628791808;;f;CH;f;Europe/Zurich;t;CHSIR;;t;;f;8501506;t;;f;;f;8501506;t;S01225;;f;;f;8500585;f;;f;f;;Sitten;;;;;;;;;シオン;시옹;;;Сьон;;;锡永
+18209;Sierre/Siders;sierre-siders;8501509;;46.2921180000;7.5328070000;;f;CH;f;Europe/Zurich;t;CHZKO;;t;;f;8501509;t;;f;;f;;f;;;f;;f;8500242;f;;f;f;;;;;;;;;;;;;;;;;;
 18210;Sierre/Siders SMC;sierre-slash-siders-smc;;;46.2927830000;7.5299130000;;f;CH;f;Europe/Zurich;f;;;f;;f;8501590;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-18211;Leuk;leuk;8501601;;46.3119030000;7.6426280000;;f;CH;f;Europe/Zurich;t;CHAEP;;t;;f;8501601;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;Loèche;;;;;;;;;;;;;
+18211;Leuk;leuk;8501601;;46.3119030000;7.6426280000;;f;CH;f;Europe/Zurich;t;CHAEP;;t;;f;8501601;t;;f;;f;;f;;;f;;f;8500367;f;;f;f;;;;;Loèche;;;;;;;;;;;;;
 18212;Fiesch FE;fiesch-fe;;;46.4051120000;8.1367380000;;f;CH;f;Europe/Zurich;f;;;f;;f;8501646;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 18213;Leuk Bahnhof;leuk-bahnhof;;;46.3117950000;7.6440220000;;f;CH;f;Europe/Zurich;f;;;f;;f;8501650;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 18214;Fürgangen-Bellwald Talstation;furgangen-bellwald-talstation;8501671;;46.4118720000;8.1524160000;;f;CH;f;Europe/Zurich;t;;;f;;f;8501671;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -18842,7 +18842,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 20383;Treviglio;treviglio;8301708;;45.515036;9.588532;;;IT;f;Europe/Rome;t;;;f;;f;8300069;f;;f;;f;8301708;t;S01708;;f;;f;;f;;f;f;;;;;;;;;;;トレヴィーリオ;;;;Тревильо;;;
 20384;Treviglio Ovest;treviglio-ovest;8301601;;45.521904;9.580559;;;IT;f;Europe/Rome;t;;;f;;f;8302254;f;;f;;f;8301601;t;S01601;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 20385;Trivigno;trivigno;8311452;;40.588597;15.997823;;;IT;f;Europe/Rome;t;;;f;;f;8302430;f;;f;;f;8311452;t;S11452;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-20386;Trofarello;trofarello;8300455;;44.980268;7.735397;;;IT;f;Europe/Rome;t;;;f;;f;8300030;f;;f;;f;8300455;t;S00455;;f;;f;;f;;f;f;;;;;;;;;;;トロファレッロ;;;;;;;
+20386;Trofarello;trofarello;8300455;;44.980268;7.735397;;;IT;f;Europe/Rome;t;;;f;;f;8300030;f;;f;;f;8300455;t;S00455;;f;;f;8300064;f;;f;f;;;;;;;;;;;トロファレッロ;;;;;;;
 20387;Sanluri Stato;sanluri-stato;8312883;;39.526342;8.84979;;;IT;f;Europe/Rome;t;;;f;;f;8302203;f;;f;;f;8312883;t;S12883;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 20388;Sante Marie;sante-marie;8308521;;42.097023;13.216956;;;IT;f;Europe/Rome;t;;;f;;f;8302162;f;;f;;f;8308521;t;S08521;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 20389;Santeramo;santeramo;8311310;;40.802496;16.763875;;;IT;f;Europe/Rome;t;;;f;;f;8302688;f;;f;;f;8311310;t;S11310;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -21041,7 +21041,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 22587;Kołobrzeg;kolobrzeg;5100410;;54.182310;15.569649;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100025;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;Kolobřeh;;;;코워브제크;;;Колобжег;;;科沃布热格
 22598;Montpellier;montpellier;;;43.599448798154995;3.8961821794509888;;t;FR;f;Europe/Paris;t;;;f;;f;;f;spfb03;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;モンペリエ;몽펠리에;;;Монпелье;;;蒙彼利埃
 22599;Montpellier Les Sabines – Gare Routière;montpellier-les-sabines-gare-routiere;;;43.58409023914171;3.860406875610351;22598;f;FR;f;Europe/Paris;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;モンペリエ;몽펠리에;;;Монпелье;;;蒙彼利埃
-22600;Nîmes;nimes;;;43.836678232954476;4.360021948814392;;t;FR;f;Europe/Paris;t;;;f;;f;;f;spg16g;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ニーム;님;;;Ним;;;尼姆
+22600;Nîmes;nimes;;;43.836678232954476;4.360021948814392;;t;FR;f;Europe/Paris;t;;;f;;f;;f;spg16g;t;;f;;f;;;f;;f;8700302;f;;f;f;;;;;;;;;;;ニーム;님;;;Ним;;;尼姆
 22601;Nîmes Parnasse – Gare Routière;nimes-parnasse-gare-routiere;;;43.817711064991435;4.362017512321472;22600;f;FR;f;Europe/Paris;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ニーム;님;;;Ним;;;尼姆
 22602;Perca/Percha;perca-percha;8302018;;46.790372;11.978521;;f;IT;f;Europe/Rome;t;;;f;;f;8372315;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 22603;Alteckendorf Abri;alteckendorf-abri;8763995;;48.7916550000;7.5970460000;;f;FR;f;Europe/Paris;t;FRTMI;;t;;f;8706842;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;阿尔泰康多尔

--- a/stations.csv
+++ b/stations.csv
@@ -5202,8 +5202,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6613;Astorga;astorga;7120100;;42.459513;-6.047124;;f;ES;f;Europe/Madrid;t;ESATG;;f;;f;7100019;f;;f;;f;;f;;;f;;f;20100;t;;f;f;;;;;;;;;;;;;;;;;;
 6614;Ávila;avila;7110400;;40.657212;-4.682948;;f;ES;f;Europe/Madrid;t;ESAVI;;f;;f;7100001;f;;f;;f;;f;;;f;;f;10400;t;;f;f;;;;;;;;;;;;;;;;;;
 6615;Bilbao Abando;bilbao-abando;7113200;;43.259715;-2.927507;23776;f;ES;f;Europe/Madrid;t;ESBAB;;f;;f;7100011;f;;f;;f;;f;;;f;;f;13200;t;;f;f;;;;Bilbao-Abando Indalecio Prieto;;;;;;;;;;;;;;
-6616;Barcelona Sant Andreu Condal;barcelona-sant-andreu-condal;7179004;;41.435884;2.193529;6617;f;ES;f;Europe/Madrid;t;ESBAC;;f;;f;7100089;f;;f;;f;;f;;;f;;f;79004;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
-6617;Barcelona;barcelona;9900012;;41.38227072942428;2.177385091781616;;t;ES;f;Europe/Madrid;t;ESBCN;;t;;f;;f;sp3e3n;t;;f;;f;;;f;;f;BARCE;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
+6616;Barcelona Sant Andreu Condal;barcelona-sant-andreu-condal;7179004;;41.435884;2.193529;6617;f;ES;f;Europe/Madrid;f;ESBAC;;f;;f;7100089;f;;f;;f;;f;;;f;;f;79004;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
+6617;Barcelona;barcelona;9900012;;41.38227072942428;2.177385091781616;;t;ES;f;Europe/Madrid;t;ESBCN;;f;;f;;f;sp3e3n;t;;f;;f;;;f;;f;BARCE;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
 6618;Benicarló;benicarlo;7165311;;40.427088;0.414753;;f;ES;f;Europe/Madrid;t;ESBCO;;f;;f;7100195;f;;f;;f;;f;;;f;;f;65311;t;;f;f;;;;Benicarlo-Peñiscola;;;;;;;;;;;;;;
 6619;O Barco de Valdeorras;o-barco-de-valdeorras;7120211;;42.4182;-6.98493;;f;ES;f;Europe/Madrid;t;ESBCV;;f;;f;;f;;f;;f;;f;;;f;;f;20211;t;;f;f;;;;;;;;;;;;;;;;;;
 6620;Badajoz;badajoz;7137606;;38.890867;-6.981822;;f;ES;f;Europe/Madrid;t;ESBJZ;;f;;f;7100035;f;eygj1q;t;;f;;f;;;f;;f;37606;t;;f;f;;;;;;;;;;;;;;;;;;
@@ -5211,8 +5211,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6622;Bobadilla;bobadilla;7154400;;37.037445;-4.727831;;f;ES;f;Europe/Madrid;t;ESBOB;;f;;f;7100044;f;;f;;f;;f;;;f;;f;54400;t;;f;f;;;;;;;;;;;;;;;;;;
 6623;Barcelona Plazça de Catalunya;barcelona-plazca-de-catalunya;7178805;;41.387702;2.169285;6617;f;ES;f;Europe/Madrid;t;ESBPC;;f;;f;7100074;f;;f;;f;;f;;;f;;f;78805;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
 6624;Barcelona Paseig de Gracia;barcelona-paseig-de-gracia;7171802;;41.392089;2.164755;6617;f;ES;f;Europe/Madrid;t;ESBPG;;f;;f;7100063;f;;f;;f;;f;;;f;;f;71802;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
-6625;Barcelona Sants;barcelona-sants;7171801;71718010;41.378911;2.140367;6617;f;ES;f;Europe/Madrid;t;ESBST;;t;;f;7100064;f;;f;;f;;f;;;f;;f;71801;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
-6626;Barcelona Estació de França;barcelona-estacio-de-franca;7179400;;41.383657;2.186733;6617;f;ES;t;Europe/Madrid;t;ESBTO;;t;;f;7100067;f;;f;;f;;f;;;f;;f;79400;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
+6625;Barcelona Sants;barcelona-sants;7171801;71718010;41.378911;2.140367;6617;f;ES;f;Europe/Madrid;t;ESBST;;f;;f;7100064;f;;f;;f;;f;;;f;;f;71801;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
+6626;Barcelona Estació de França;barcelona-estacio-de-franca;7179400;;41.383657;2.186733;6617;f;ES;t;Europe/Madrid;t;ESBTO;;f;;f;7100067;f;;f;;f;;f;;;f;;f;79400;t;;f;f;;;;;Barcelone;Barcellona;;;;;バルセロナ;바르셀로나;;;Барселона;;Barselona;巴薩隆拿
 6627;Burgos;burgos;7111100;;;;;f;ES;f;Europe/Madrid;f;ESBUR;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6628;Bustarviejo-Valdemanco;bustarviejo-valdemanco;7117100;;;;;f;ES;f;Europe/Madrid;f;ESBVM;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6629;Cádiz;cadiz;7151405;;36.527945;-6.286893;;f;ES;f;Europe/Madrid;t;ESCAD;;f;;f;7100043;f;ey7xbd;t;;f;;f;;;f;;f;51405;t;;f;f;;;;;;;;;;;;;;;;;;
@@ -5241,7 +5241,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6652;Guadix;guadix;7156200;;37.3178;-3.127284;;f;ES;f;Europe/Madrid;t;ESGDX;;f;;f;7100047;f;;f;;f;;f;;;f;;f;56200;t;;f;f;;;;;;;;;;;;;;;;;;
 6653;Brenes;brenes;7150702;;37.5463;-5.86677;;f;ES;f;Europe/Madrid;t;ESGJR;;f;;f;;f;;f;;f;;f;;;f;;f;50702;t;;f;f;;;;;;;;;;;;;;;;;;
 6654;Granollers Centro;granollers-centro;7179100;;41.599308;2.29162;;f;ES;f;Europe/Madrid;t;ESGLC;;f;;f;7100075;f;;f;;f;;f;;;f;;f;79100;t;;f;f;;;;;;;;;;;;;;;;;;
-6655;Gerona;gerona;7179300;71793000;41.979516;2.816482;;f;ES;f;Europe/Madrid;t;ESGRO;;t;;f;7100077;f;sp6nb6;t;;f;;f;;;f;;f;79300;t;;f;f;;;;Girona;Gérone;;;;;;ジローナ;;;;Жерона;;;
+6655;Gerona;gerona;7179300;71793000;41.979516;2.816482;;f;ES;f;Europe/Madrid;t;ESGRO;;f;;f;7100077;f;sp6nb6;t;;f;;f;;;f;;f;79300;t;;f;f;;;;Girona;Gérone;;;;;;ジローナ;;;;Жерона;;;
 6656;Granada;granada;7105000;;37.183906;-3.609061;;f;ES;f;Europe/Madrid;t;ESGRX;;f;;f;7100182;f;eyt7tc;t;;f;;f;;;f;;f;05000;t;;f;f;;;;;Grenade;;;;;;;;;;;;;
 6657;Irún;irun;;;;;;t;ES;f;Europe/Madrid;f;ESIRU;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6658;Jaén;jaen;7103100;;37.780223;-3.790975;;f;ES;f;Europe/Madrid;t;ESJAN;;f;;f;7100204;f;;f;;f;;f;;;f;;f;03100;t;;f;f;;;;;;;;;;;;;;;;;;
@@ -5249,11 +5249,11 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6660;León;leon;7115100;;42.595888;-5.582382;;f;ES;f;Europe/Madrid;t;ESLEO;;f;;f;7100015;f;ezs437;t;;f;;f;;;f;;f;15100;t;;f;f;;;;;;;;;;;;;;;;;;
 6661;Lugo;lugo-estacion;7120309;;43.015307;-7.55226;;f;ES;f;Europe/Madrid;t;ESLGO;;f;;f;7100186;f;;f;;f;;f;;;f;;f;20309;t;;f;f;;Spanien;Spain;España;Espagne;Spagna;;;;;;;;;;;;
 6662;Valdestillas;valdestillas;7110503;;41.489083;-4.772633;;f;ES;f;Europe/Madrid;t;ESLIB;;f;;f;7110503;f;;f;;f;;f;;;f;;f;10503;t;;f;f;;;;;;;;;;;;;;;;;;
-6663;Madrid;madrid;;;40.416824;-3.703733;;t;ES;f;Europe/Madrid;t;ESMAD;;t;;f;;f;ezjmgt;t;;f;;f;;;f;;f;MADRI;t;;f;f;;;;;;;;;;;;;;;;;;
+6663;Madrid;madrid;;;40.416824;-3.703733;;t;ES;f;Europe/Madrid;t;ESMAD;;f;;f;;f;ezjmgt;t;;f;;f;;;f;;f;MADRI;t;;f;f;;;;;;;;;;;;;;;;;;
 6664;Madrid Príncipe Pio;madrid-principe-pio;7110000;;40.421272;-3.718846;6663;f;ES;f;Europe/Madrid;t;ESMPP;;f;;f;7100188;f;;f;;f;;f;;;f;;f;10000;t;;f;f;;;;;;;;;;;;;;;;;;
 6665;Madrid Vallecas;madrid-vallecas;;;;;;f;ES;f;Europe/Madrid;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6666;Madrid Villaverde;madrid-villaverde;7178608;;;;6663;f;ES;f;Europe/Madrid;f;ESMVV;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6667;Madrid Atocha;madrid-atocha;7160000;;40.405963;-3.689757;6663;f;ES;f;Europe/Madrid;t;ESMAT;;t;;f;7100049;f;;f;;f;;f;;;f;;f;60000;t;;f;f;;;;;;;;;;;;;;;;;;
+6667;Madrid Atocha;madrid-atocha;7160000;;40.405963;-3.689757;6663;f;ES;f;Europe/Madrid;t;ESMAT;;f;;f;7100049;f;;f;;f;;f;;;f;;f;60000;t;;f;f;;;;;;;;;;;;;;;;;;
 6668;Madrid Chamartín;madrid-chamartin;7117000;;40.472151;-3.68235;6663;f;ES;t;Europe/Madrid;t;ESMCH;;f;;f;7100017;f;;f;;f;;f;;;f;;f;17000;t;;f;f;;;;;;;;;;;;;;;;;;
 6669;Medina del Campo Estación;medina-del-campo-estacion;7110500;;41.317676;-4.910474;24164;f;ES;f;Europe/Madrid;t;ESMDC;;f;;f;7100002;f;;f;;f;;f;;;f;;f;10500;t;;f;f;;;;;;;;;;;;;;;;;;
 6670;Miranda de Ebro;miranda-de-ebro;7111200;;42.690554;-2.94091;;f;ES;f;Europe/Madrid;t;ESMEB;;f;;f;7100006;f;;f;;f;;f;;;f;;f;11200;t;;f;f;;;;;;;;;;;;;;;;;;
@@ -5270,7 +5270,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6681;San Fernando de Cádiz;san-fernando-de-cadiz;7151402;;36.4758;-6.19444;;f;ES;f;Europe/Madrid;t;ESSFD;;f;;f;;f;;f;;f;;f;;;f;;f;51402;t;;f;f;;;;;;;;;;;;;;;;;;
 6682;Salamanca;salamanca;7130100;;40.971547;-5.648659;;f;ES;f;Europe/Madrid;t;ESSLM;;f;;f;7100027;f;ez7cp3;t;;f;;f;;;f;;f;30100;t;;f;f;;;;;;;;;;;;;;;;;;
 6683;Sevilla;sevilla;;;37.389254;-5.984458;;t;ES;f;Europe/Madrid;t;ESSVQ;;f;;f;;f;eyesxu;t;;f;;f;;;f;;f;;f;;f;f;;;Seville;;Séville;Siviglia;;;;;;;Sewilla;Sevilha;Севилья;;;
-6684;Camp Tarragona;camp-tarragona;7104104;;41.192025;1.271587;24444;f;ES;f;Europe/Madrid;t;ESTAA;;t;;f;7104104;f;;f;;f;;f;;;f;;f;04104;t;;f;f;;;;;Tarragone;;;;;;;;;;;;;
+6684;Camp Tarragona;camp-tarragona;7104104;;41.192025;1.271587;24444;f;ES;f;Europe/Madrid;t;ESTAA;;f;;f;7104104;f;;f;;f;;f;;;f;;f;04104;t;;f;f;;;;;Tarragone;;;;;;;;;;;;;
 6685;Torremolinos;torremolinos;7154509;;36.6225;-4.49931;;f;ES;f;Europe/Madrid;t;ESTRM;;f;;f;;f;;f;;f;;f;;;f;;f;54509;t;;f;f;;;;;;;;;;;;;;;;;;
 6686;Tui;tui;7122401;;42.0565;-8.64302;;f;ES;f;Europe/Madrid;t;ESTUY;;f;;f;;f;;f;;f;;f;;;f;;f;22401;t;;f;f;;;;Tuy;;;;;;;;;;;;;;
 6687;Valencia de Alcantar;valencia-de-alcantar;;;;;;t;ES;f;Europe/Madrid;f;ESVAL;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -8984,7 +8984,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 10478;Autun Lycée technique;autun-lycee-technique;8753642;87536425;46.928761;4.22012;;f;FR;f;Europe/Paris;t;FRJFY;;t;;f;8706513;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;オータン;;;;Отён;;;
 10479;Les Huichards;les-huichards;8753648;;46.5825508386991;5.27094841003418;;f;FR;f;Europe/Paris;t;FRJFZ;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10480;La Chapelle-Glain;la-chapelle-glain;8753705;87537050;47.625865;-1.180175;;f;FR;f;Europe/Paris;t;FRPGC;;t;;f;8706519;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-10481;Figueres—Vilafant;figueres-vilafant;7104307;71043075;42.26478;2.943023;10465;f;ES;f;Europe/Madrid;t;ESFIR;;t;;f;7104307;f;;f;;f;;f;;;f;;f;04307;t;;f;f;;;;Figueras;;;;;;;;;;;;;;
+10481;Figueres—Vilafant;figueres-vilafant;7104307;71043075;42.26478;2.943023;10465;f;ES;f;Europe/Madrid;t;ESFIR;;f;;f;7104307;f;;f;;f;;f;;;f;;f;04307;t;;f;f;;;;Figueras;;;;;;;;;;;;;;
 10482;Rzepin;rzepin;5130955;;;;;f;PL;f;Europe/Warsaw;f;PLAAA;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10483;Poznań;poznan;5103060;;52.401996;16.910866;;f;PL;f;Europe/Warsaw;t;PLPOZ;;f;;f;5100081;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 10484;Kutno;kutno;5100224;;;;;f;PL;f;Europe/Warsaw;f;PLKNO;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -21117,7 +21117,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 22673;Ashford International;ashford-international;7050040;;51.143673;0.873628;;f;GB;f;Europe/London;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;8155;;;;;;;;;;;;;;;;;
 22674;Ebbsfleet International;ebbsfleet-international;7055660;;51.442961;0.320921;;f;GB;f;Europe/London;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;8224;;;;;;;;;;;;;;;;;
 22675;Tübingen Hbf;tubingen-hbf;8029318;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;7343;;;;;;;;;;;;;;;;;
-22676;Zaragoza Delicias;zaragoza-delicias;7104040;;41.658439;-0.909906;24575;f;ES;t;Europe/Madrid;t;ESZAA;;t;;f;7175506;f;;f;;f;;f;;;f;;f;04040;t;;f;f;;;;;Saragosse;Saragozza;;;;;;;;Saragoça;;;;
+22676;Zaragoza Delicias;zaragoza-delicias;7104040;;41.658439;-0.909906;24575;f;ES;t;Europe/Madrid;t;ESZAA;;f;;f;7175506;f;;f;;f;;f;;;f;;f;04040;t;;f;f;;;;;Saragosse;Saragozza;;;;;;;;Saragoça;;;;
 22677;Reutlingen Hbf;reutlingen-hbf;8029309;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;7213;;;;;;;;;;;;;;;;;
 22678;Lübeck Hbf;lubeck-hbf;8001631;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;7676;;;;;;;;;;;;;;;;;
 22679;Oldenburg (Oldb);oldenburg-oldb;8021207;;;;;f;DE;f;Europe/Berlin;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;7178;;;;;;;;;;;;;;;;;

--- a/stations.csv
+++ b/stations.csv
@@ -178,7 +178,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 224;Villeneuve-au-Chemin;villeneuve-au-chemin;8711036;87110361;48.082895;3.844281;;f;FR;f;Europe/Paris;t;FRAHC;;t;;f;8702200;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 230;Salvagnac;salvagnac;8711015;87110155;43.9166670000;1.7000000000;;f;FR;f;Europe/Paris;t;FRAHY;;t;;f;8704441;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 232;Maussac;maussac;8715241;;45.4833330000;2.1500000000;;f;FR;f;Europe/Paris;t;FRAIC;;t;;f;8703951;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-233;Aix-en-Provence TGV;aix-en-provence-tgv;8731901;87319012;43.455167;5.317227;23614;f;FR;f;Europe/Paris;t;FRAIE;AXV;t;AIE;t;8704980;t;;f;AIE;t;8731901;f;;;f;;f;8700912;f;;f;t;;;;;;;;;;;エクス＝アン＝プロヴァンス;엑상프로방스;;;Экс-ан-Прованс;;;普罗旺斯地区艾克斯
+233;Aix-en-Provence TGV;aix-en-provence-tgv;8731901;87319012;43.455167;5.317227;23614;f;FR;f;Europe/Paris;t;FRAIE;AXV;t;AIE;t;8704980;t;;f;AIE;t;8731901;f;;;f;;f;8700912;t;;f;t;;;;;;;;;;;エクス＝アン＝プロヴァンス;엑상프로방스;;;Экс-ан-Прованс;;;普罗旺斯地区艾克斯
 234;Moustéru;mousteru;8747351;87473512;48.5166670000;-3.2333330000;;f;FR;f;Europe/Paris;t;FRAIG;;t;;f;8704068;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 239;Aillevillers;aillevillers;8718562;87185629;47.9166670000;6.3333330000;;f;FR;f;Europe/Paris;t;FRAIL;;t;;f;8700256;f;;f;;f;;f;;;f;;f;8700899;f;;f;f;;;;;;;;;;;;;;;;;;
 241;Ailly-sur-Noye;ailly-sur-noye;8731322;87313221;49.7500000000;2.3666670000;;f;FR;f;Europe/Paris;t;FRAIN;;t;;f;8700605;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -345,7 +345,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 482;Froncles;froncles;8714224;87142240;48.3000000000;5.1500000000;;f;FR;f;Europe/Paris;t;FRAUS;;t;;f;8701111;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 483;Gudmont;gudmont;8714226;87142265;48.3500000000;5.1333330000;5551;f;FR;t;Europe/Paris;t;FRAUT;;t;;f;8701183;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 484;Donjeux;donjeux;8714227;87142273;48.3666670000;5.1500000000;;f;FR;f;Europe/Paris;t;FRAUU;;t;;f;8701035;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-485;Avignon TGV;avignon-tgv;8731896;87318964;43.92160621687953;4.785983562469482;489;f;FR;f;Europe/Paris;t;FRAVG;AVV;t;AVG;t;8704918;t;;f;AVG;t;8731896;f;;;f;;f;8700814;f;;f;t;;;;Aviñón;;Avignone;;;;;アヴィニョン;아비뇽;Awinion;Avinhão;Авиньон;;;亞維農
+485;Avignon TGV;avignon-tgv;8731896;87318964;43.92160621687953;4.785983562469482;489;f;FR;f;Europe/Paris;t;FRAVG;AVV;t;AVG;t;8704918;t;;f;AVG;t;8731896;f;;;f;;f;8700814;t;;f;t;;;;Aviñón;;Avignone;;;;;アヴィニョン;아비뇽;Awinion;Avinhão;Авиньон;;;亞維農
 486;Avail;avail;8730469;87304691;46.960187;2.05319;;f;FR;f;Europe/Paris;t;FRAVI;;t;;f;8700463;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 487;Damblain;damblain;8714249;87142497;48.09373173734836;5.656414031982422;;f;FR;f;Europe/Paris;t;FRAVL;;t;;f;8700997;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 488;Châtillon-sur-Seine;chatillon-sur-seine;8714255;87142554;47.86126131518925;4.574829339981079;;f;FR;f;Europe/Paris;t;FRAVM;;t;;f;8703071;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;シャティヨン＝シュル＝セーヌ;;;;Шатийон-сюр-Сен;;;塞纳河畔沙蒂隆
@@ -848,7 +848,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1063;Igney—Avricourt;igney-avricourt;8721510;87215103;48.647031;6.80531;;f;FR;f;Europe/Paris;t;FRBZO;;t;;f;8701299;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1064;Nouvel-Avricourt;nouvel-avricourt;8721511;87215111;48.646806;6.819252;;f;FR;f;Europe/Paris;t;FRBZP;;t;;f;8701696;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1065;Rechicourt-le-Château;rechicourt-le-chateau;8721512;87215129;48.6666670000;6.8500000000;;f;FR;f;Europe/Paris;t;FRBZQ;;t;;f;8701844;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1066;Béziers;beziers;8778100;87781005;43.33616601403274;3.2188332080841064;;f;FR;f;Europe/Paris;t;FRBZR;BZS;t;BZR;t;8700064;f;spdq95;t;;f;;f;;;f;;f;8700078;f;;f;t;;;;;;;;;;;ベジエ;베지에;;;Безье;;;贝济耶
+1066;Béziers;beziers;8778100;87781005;43.33616601403274;3.2188332080841064;;f;FR;f;Europe/Paris;t;FRBZR;BZS;t;BZR;t;8700064;f;spdq95;t;;f;;f;;;f;;f;8700078;t;;f;t;;;;;;;;;;;ベジエ;베지에;;;Безье;;;贝济耶
 1067;Gondrexange;gondrexange;8721513;;48.6833330000;6.9333330000;;f;FR;f;Europe/Paris;t;FRBZS;;t;;f;8771654;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1068;Heming;heming;8721514;87215145;48.7000000000;6.9500000000;;f;FR;f;Europe/Paris;t;FRBZT;;t;;f;8701267;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1069;Arzviller;arzviller;8721515;;48.7166670000;7.1666670000;17437;f;FR;f;Europe/Paris;t;FRBZU;;t;;f;8700647;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -889,7 +889,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 1114;Cravant-Bazarnes;cravant-bazarnes;8768364;87683649;47.678542;3.680929;;f;FR;f;Europe/Paris;t;FRCBZ;;t;;f;8703183;f;;f;;f;;f;;;f;;f;8700398;f;;f;f;;;;;;;;;;;;;;;;;;
 1115;Lamure-sur-Azergues;lamure-sur-azergues;8772186;87721860;46.0666670000;4.5000000000;;f;FR;f;Europe/Paris;t;FRCCB;;t;;f;8703638;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1116;Sorèze;soreze;8723565;87235655;43.454232;2.072912;;f;FR;f;Europe/Paris;t;FRCCC;;t;;f;8704507;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-1119;Carcassonne;carcassonne;8761528;87615286;43.21817571610827;2.3518198728561397;;f;FR;f;Europe/Paris;t;FRCCF;CNE;t;;f;8700100;f;;f;;f;;f;;;f;;f;8700176;f;;f;t;;;;Carcasona;;;;;;;カルカソンヌ;카르카손;;;Каркасон;;;卡尔卡松
+1119;Carcassonne;carcassonne;8761528;87615286;43.21817571610827;2.3518198728561397;;f;FR;f;Europe/Paris;t;FRCCF;CNE;t;;f;8700100;f;;f;;f;;f;;;f;;f;8700176;t;;f;t;;;;Carcasona;;;;;;;カルカソンヌ;카르카손;;;Каркасон;;;卡尔卡松
 1120;Balsièges;balsieges;8711186;87111864;44.482167;3.45637;;f;FR;f;Europe/Paris;t;FRCCG;;t;;f;8702765;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1121;Tournai Frontière;tournai-frontiere;8724164;;;;;f;BE;f;Europe/Brussels;f;FRCCH;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 1122;Froyennes;froyennes;8724175;;;;;f;BE;f;Europe/Brussels;f;FRCCK;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3506,7 +3506,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4673;Longueville;longueville;8711613;87116137;48.513573202492374;3.250059485435486;;f;FR;f;Europe/Paris;t;FRLON;LON;t;;f;8700275;f;;f;;f;;f;;;f;;f;8700945;f;;f;f;;;;;;;;;;;;;;;;;;
 4674;Lourches;lourches;8734347;87343475;50.3166670000;3.3500000000;;f;FR;f;Europe/Paris;t;FRLOU;;t;;f;8700356;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4675;Lozanne;lozanne;8772142;87721423;45.85408448617136;4.68142032623291;;f;FR;f;Europe/Paris;t;FRLOZ;LOZ;t;;f;8703846;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4676;Lyon Part-Dieu;lyon-part-dieu;8772319;87723197;45.760568;4.859991;4718;f;FR;t;Europe/Paris;t;FRLPD;LYD;t;LPD;f;8700152;t;;f;LPD;t;8772319;f;;;f;;f;8700303;f;;f;t;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
+4676;Lyon Part-Dieu;lyon-part-dieu;8772319;87723197;45.760568;4.859991;4718;f;FR;t;Europe/Paris;t;FRLPD;LYD;t;LPD;f;8700152;t;;f;LPD;t;8772319;f;;;f;;f;8700303;t;;f;t;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
 4677;Lyon Perrache;lyon-perrache;8772202;87722025;45.74836;4.825301;4718;f;FR;f;Europe/Paris;t;FRLPE;LPR;t;LPE;f;8700040;f;;f;LPE;t;;f;;;f;;f;;f;;f;t;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
 4678;Toulouse Gallieni Canceropôle;toulouse-gallieni-canceropole;8749746;87497461;43.574337;1.419216;5306;f;FR;f;Europe/Paris;t;FRLPF;;t;;f;8706432;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 4679;La Pauline—Hyères;la-pauline-hyeres;8775531;87755314;43.136293;6.034971;;f;FR;f;Europe/Paris;t;FRLPH;;t;;f;8701738;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3540,7 +3540,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4715;Longwy;longwy;8719400;87194001;49.51320053249328;5.769281387329102;5702;f;FR;t;Europe/Paris;t;FRLWY;LWY;t;;f;8700162;f;;f;;f;;f;;;f;;f;8700954;f;;f;f;;;;;;;;;;;ロンウィ;롱위;;;Лонгви;;;隆格维
 4716;St-Lyé-la-Forêt Mairie;st-lye-la-foret-mairie;8720853;;48.0500000000;1.9833330000;;f;FR;f;Europe/Paris;t;FRLYE;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4717;Lyon Gorge de Loup;lyon-gorge-de-loup;8772117;87721175;45.766051;4.804743;4718;f;FR;f;Europe/Paris;t;FRLYL;LYL;t;;f;8703871;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
-4718;Lyon;lyon;9919001;;45.76765767630457;4.834907054901123;;t;FR;f;Europe/Paris;t;FRLYS;;t;;f;8796002;t;u05kq2;t;LY1;t;;f;;;f;;f;87303;f;;f;f;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
+4718;Lyon;lyon;9919001;;45.76765767630457;4.834907054901123;;t;FR;f;Europe/Paris;t;FRLYS;;t;;f;8796002;t;u05kq2;t;LY1;t;;f;;;f;;f;87303;t;;f;f;;;;;;Lione;;;;;リヨン;리옹;;;Лион;;;里昂
 4719;Millau;millau;8778300;87783001;44.10248709022126;3.074476718902588;;f;FR;f;Europe/Paris;t;FRMAU;MAU;t;;f;8700093;f;;f;;f;;f;;;f;;f;8700134;f;;f;f;;;;;;;;;;;ミヨー;;;;Мийо;;;米约
 4720;Meymac;meymac;;;45.5333330000;2.1666670000;;t;FR;f;Europe/Paris;f;FRMAY;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4721;Meymac;meymac;8759427;87594275;45.530237;2.164099;4720;f;FR;t;Europe/Paris;t;FRMYC;MYC;t;;f;8701641;f;;f;;f;;f;;;f;;f;8700986;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3592,12 +3592,12 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4782;Moret—Veneux-les-Sablons;moret-veneux-les-sablons;8768227;87682278;48.378326;2.799501;;f;FR;f;Europe/Paris;t;FRMOR;MOR;t;;f;8701643;f;;f;;f;;f;;;f;;f;8700390;f;;f;f;;;;;;;;;;;;;;;;;;
 4784;Motteville;motteville;8741128;87411280;49.6333330000;0.8500000000;;f;FR;f;Europe/Paris;t;FRMOT;;t;;f;8704063;f;;f;;f;;f;;;f;;f;8700836;f;;f;f;;;;;;;;;;;;;;;;;;
 4785;Aéroport Marseille-Provence Bus;aeroport-marseille-provence-bus;8733749;87337493;43.44129735202746;5.237088203430176;;f;FR;f;Europe/Paris;t;FRMPA;;t;;f;8705262;f;;f;;f;8733749;f;;;f;;f;;f;;f;f;;Flughafen;Airport;Aeropuerto;;Aeroporto;;;;;;;;;;;;
-4786;Montpellier St-Roch;montpellier-st-roch;8777300;87773002;43.60423079220492;3.880383968353271;22598;f;FR;f;Europe/Paris;t;FRMPL;MPL;t;MPL;t;8700097;f;;f;MPL;t;;f;;;f;;f;8700173;f;;f;t;;;;;;;;;;;モンペリエ;몽펠리에;;;Монпелье;;;蒙彼利埃
+4786;Montpellier St-Roch;montpellier-st-roch;8777300;87773002;43.60423079220492;3.880383968353271;22598;f;FR;f;Europe/Paris;t;FRMPL;MPL;t;MPL;t;8700097;f;;f;MPL;t;;f;;;f;;f;8700173;t;;f;t;;;;;;;;;;;モンペリエ;몽펠리에;;;Монпелье;;;蒙彼利埃
 4787;Paris-Gare-Montparnasse-3-Vaugirard;paris-gare-montparnasse-3-vaugirard;8739110;;48.838384;2.315953;4916;f;FR;f;Europe/Paris;f;FRMPV;;t;;f;8704045;f;;f;;f;;f;;;f;;f;8700019;f;;f;t;;;;;;;;;;;;;;;;;;
 4788;Morée Salle des Fêtes;moree-salle-des-fetes;8745339;87453399;47.9000000000;1.2333330000;;f;FR;f;Europe/Paris;t;FRMRD;;t;;f;8706412;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4789;Margut;margut;;;49.5833330000;5.2666670000;;t;FR;f;Europe/Paris;f;FRMRG;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4790;Marseille;marseille;;;43.29640973957932;5.371000170707703;;t;FR;f;Europe/Paris;t;FRMRS;;t;;f;;f;spey63;t;;f;;f;;;f;;f;;f;;f;f;;;;Marsella;;Marsiglia;;;;;マルセイユ;마르세유;Marsylia;Marselha;Марсель;;Marsilya;马赛
-4791;Marseille St-Charles;marseille-st-charles;8775100;87751008;43.303816;5.381949;4790;f;FR;t;Europe/Paris;t;FRMSC;MSC;t;MSC;t;8700074;t;;f;MSC;t;8775100;t;;;f;;f;8700089;f;;f;t;;;;Marsella;;Marsiglia;;;;;マルセイユ;마르세유;Marsylia;Marselha;Марсель;;Marsilya;马赛
+4791;Marseille St-Charles;marseille-st-charles;8775100;87751008;43.303816;5.381949;4790;f;FR;t;Europe/Paris;t;FRMSC;MSC;t;MSC;t;8700074;t;;f;MSC;t;8775100;t;;;f;;f;8700089;t;;f;t;;;;Marsella;;Marsiglia;;;;;マルセイユ;마르세유;Marsylia;Marselha;Марсель;;Marsilya;马赛
 4793;Méreau;mereau;8730977;87309773;47.1666670000;2.0500000000;;f;FR;f;Europe/Paris;t;FRMRU;;t;;f;8705216;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4794;Merrey;merrey;8714240;87142406;48.0500000000;5.6000000000;;f;FR;f;Europe/Paris;t;FRMRY;;t;;f;8701596;f;;f;;f;;f;;;f;;f;8700992;f;;f;f;;;;;;;;;;;;;;;;;;
 4795;Mouans-Sartoux;mouans-sartoux;8740132;87401323;43.62045799139486;6.974247694015503;;f;FR;f;Europe/Paris;t;FRMSE;MUU;t;;f;8705360;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3696,13 +3696,13 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4914;Port-d’Atelier-Amance;port-datelier-amance;8718510;87185108;47.75922;6.0396;;f;FR;f;Europe/Paris;t;FRPAA;;t;;f;8700054;f;;f;;f;;f;;;f;;f;8700065;f;;f;f;;;;;;;;;;;;;;;;;;
 4915;Longchamp-sur-Aujon;longchamp-sur-aujon;8721557;87215574;48.1500000000;4.8333330000;;f;FR;f;Europe/Paris;t;FRPAJ;;t;;f;8705153;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4916;Paris;paris;9903001;;48.8534100000;2.3488000000;;t;FR;f;Europe/Paris;t;FRPAR;;t;PAR;t;8796001;t;u09tvm;t;;f;;f;;;f;;f;;f;;f;f;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4917;Paris-Gare-de-Bercy;paris-gare-de-bercy;8768666;87686667;48.839131;2.382887;4916;f;FR;f;Europe/Paris;t;FRPBE;PBY;t;;f;8702455;t;;f;;f;;f;;;f;;f;8700018;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4919;Paris-Gare-de-l’Est;paris-gare-de-lest;8711300;87113001;48.876975;2.35912;4916;f;FR;f;Europe/Paris;t;FRPST;PES;t;PST;f;8700011;t;;f;;f;8711300;f;;;f;;f;8700012;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4920;Paris-Gare-Montparnasse;paris-gare-montparnasse;8739100;87391003;48.840488;2.319576;4916;f;FR;f;Europe/Paris;t;FRPMO;PMP;t;PMO;t;8700013;f;;f;;f;;f;;;f;;f;8700014;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4921;Paris-Austerlitz;paris-austerlitz;8754700;87547000;48.84091003613604;2.3665666580200195;4916;f;FR;f;Europe/Paris;t;FRPAZ;PAZ;t;;f;8700010;t;;f;;f;8754700;f;;;f;;f;87011;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4922;Paris-Gare-du-Nord;paris-gare-du-nord;8727100;87271007;48.880885;2.354931;4916;f;FR;f;Europe/Paris;t;FRPNO;PNO;t;;f;8700014;f;;f;;f;8727100;f;;;f;;f;8700015;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4923;Paris-Gare-St-Lazare;paris-gare-st-lazare;8738400;87384008;48.876328;2.325338;4916;f;FR;f;Europe/Paris;t;FRPSL;PSL;t;;f;8700015;f;;f;;f;;f;;;f;;f;8700017;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
-4924;Paris-Gare-de-Lyon;paris-gare-de-lyon;8768600;87686006;48.844839;2.374069;4916;f;FR;f;Europe/Paris;t;FRPLY;PLY;t;PLY;t;8700012;f;;f;;f;8768600;t;;;f;;f;8700013;f;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4917;Paris-Gare-de-Bercy;paris-gare-de-bercy;8768666;87686667;48.839131;2.382887;4916;f;FR;f;Europe/Paris;t;FRPBE;PBY;t;;f;8702455;t;;f;;f;;f;;;f;;f;8700018;t;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4919;Paris-Gare-de-l’Est;paris-gare-de-lest;8711300;87113001;48.876975;2.35912;4916;f;FR;f;Europe/Paris;t;FRPST;PES;t;PST;f;8700011;t;;f;;f;8711300;f;;;f;;f;8700012;t;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4920;Paris-Gare-Montparnasse;paris-gare-montparnasse;8739100;87391003;48.840488;2.319576;4916;f;FR;f;Europe/Paris;t;FRPMO;PMP;t;PMO;t;8700013;f;;f;;f;;f;;;f;;f;8700014;t;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4921;Paris-Austerlitz;paris-austerlitz;8754700;87547000;48.84091003613604;2.3665666580200195;4916;f;FR;f;Europe/Paris;t;FRPAZ;PAZ;t;;f;8700010;t;;f;;f;8754700;f;;;f;;f;87011;t;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4922;Paris-Gare-du-Nord;paris-gare-du-nord;8727100;87271007;48.880885;2.354931;4916;f;FR;f;Europe/Paris;t;FRPNO;PNO;t;;f;8700014;f;;f;;f;8727100;f;;;f;;f;8700015;t;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4923;Paris-Gare-St-Lazare;paris-gare-st-lazare;8738400;87384008;48.876328;2.325338;4916;f;FR;f;Europe/Paris;t;FRPSL;PSL;t;;f;8700015;f;;f;;f;;f;;;f;;f;8700017;t;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
+4924;Paris-Gare-de-Lyon;paris-gare-de-lyon;8768600;87686006;48.844839;2.374069;4916;f;FR;f;Europe/Paris;t;FRPLY;PLY;t;PLY;t;8700012;f;;f;;f;8768600;t;;;f;;f;8700013;t;;f;t;;;;;;Parigi;Parijs;Paříž;;Párizs;パリ;파리;Paryż;;Париж;;;巴黎
 4926;Parthenay;parthenay;8748717;87487173;46.6482872235422;-0.24051904678344727;;f;FR;f;Europe/Paris;t;FRPAY;;t;;f;8704189;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4927;Largentière Garage des Rancs;largentiere-garage-des-rancs;8776482;87764829;44.54448;4.292178;;f;FR;f;Europe/Paris;t;FRPBI;;t;;f;8703656;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4929;Pouzauges Centre;pouzauges-centre;8733300;87333005;46.78237125977221;-0.8373051881790161;5018;f;FR;f;Europe/Paris;t;FRPBM;;t;;f;8704308;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3726,7 +3726,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 4952;Le Puy-en-Velay Lafayette;le-puy-en-velay-lafayette;8702438;87024380;45.04339;3.880283;5009;f;FR;f;Europe/Paris;t;FRPFY;;t;;f;8705030;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4953;Dives;dives;;;;;;t;FR;f;Europe/Paris;f;FRPGE;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4954;Dives-sur-Mer—Port-Guillaume;dives-sur-mer-port-guillaume;8733737;87337378;49.291090802259674;-0.10087251663208008;4953;f;FR;f;Europe/Paris;t;FRPGU;;t;;f;8705264;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-4955;Perpignan;perpignan;8778400;87784009;42.69607053922139;2.87940502166748;;f;FR;f;Europe/Paris;t;FRPGF;PPN;t;PGF;t;8700164;f;spd4cu;t;;f;;f;;;f;;f;8700374;f;;f;t;;;;Perpiñán;;Perpignano;;;;;ペルピニャン;페르피냥;;Perpinhã;Перпиньян;;;佩皮尼昂
+4955;Perpignan;perpignan;8778400;87784009;42.69607053922139;2.87940502166748;;f;FR;f;Europe/Paris;t;FRPGF;PPN;t;PGF;t;8700164;f;spd4cu;t;;f;;f;;;f;;f;8700374;t;;f;t;;;;Perpiñán;;Perpignano;;;;;ペルピニャン;페르피냥;;Perpinhã;Перпиньян;;;佩皮尼昂
 4956;Poitiers Gare Routière;poitiers-gare-routiere;8720248;87202481;46.5833330000;0.3333330000;4964;f;FR;f;Europe/Paris;f;FRPGR;;f;;f;8705079;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 4957;Périgueux;perigueux;;;45.1833330000;0.7166670000;;t;FR;f;Europe/Paris;f;FRPGX;;t;;f;;f;u00903;t;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 4958;Perrigny-sur-Loire;perrigny-sur-loire;8728233;87282335;46.5333330000;3.8333330000;;f;FR;f;Europe/Paris;t;FRPGY;;t;;f;8705220;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -3994,7 +3994,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5307;Toulouse St-Michel;toulouse-st-michel;8744372;87443721;43.586095272195166;1.447121500968933;5306;f;FR;f;Europe/Paris;t;FRUIC;;t;;f;8705995;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5308;Toulouse Langlade;toulouse-langlade;8744946;87449462;43.572045;1.44302;5306;f;FR;f;Europe/Paris;t;FRULK;;t;;f;8706103;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5310;Toulouse Croix de Pierre;toulouse-croix-de-pierre;8744999;87449991;43.5852870498513;1.4282548427581785;5306;f;FR;f;Europe/Paris;t;FRULL;;t;;f;8706104;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
-5311;Toulouse Matabiau;toulouse-matabiau;8761100;87611004;43.611409;1.453942;5306;f;FR;t;Europe/Paris;t;FRXYT;TSE;t;XYT;t;8700065;f;;f;;f;;f;;;f;;f;8700079;f;;f;t;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
+5311;Toulouse Matabiau;toulouse-matabiau;8761100;87611004;43.611409;1.453942;5306;f;FR;t;Europe/Paris;t;FRXYT;TSE;t;XYT;t;8700065;f;;f;;f;;f;;;f;;f;8700079;t;;f;t;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5312;Toulouse Jeanne d’Arc;toulouse-jeanne-darc;8744373;87443739;43.621522;1.465951;5306;f;FR;f;Europe/Paris;t;FRUIO;;t;;f;8705996;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5313;Toulouse Bellevue;toulouse-bellevue;8744371;87443713;43.604496;1.461502;5306;f;FR;f;Europe/Paris;t;FRUIB;;t;;f;8705994;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;Tolosa;;;;;トゥールーズ;툴루즈;Tuluza;;Тулуза;;;圖盧茲
 5314;Troyes St-Martin Delaunay;troyes-st-martin-delaunay;8713950;87139501;48.311787;4.047959;5342;f;FR;f;Europe/Paris;t;FRTMD;;t;;f;8705066;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4271,8 +4271,8 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5608;Uzer;uzer;8776481;87764811;44.523059;4.324251;;f;FR;f;Europe/Paris;t;FRUZR;;t;;f;8705284;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5609;Ailleville;ailleville;8721562;87215624;48.2500000000;4.6833330000;;f;FR;f;Europe/Paris;t;FRVAA;;t;;f;8705167;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5610;Valence Ville;valence-ville;8776100;87761007;44.927654;4.893475;5611;f;FR;f;Europe/Paris;t;FRVAF;VCE;t;;f;8700056;f;;f;;f;;f;;;f;;f;8700067;f;;f;t;;;;;;;;;;;;;;;;;;
-5611;Valence;valence;8724857;;44.93324;4.89236;;t;FR;f;Europe/Paris;t;FRVAV;;t;;f;;f;spgrxe;t;;f;;f;;;f;;f;87067;f;;f;f;;;;;;;;;;;;;;;;;;
-5614;Valence TGV;valence-tgv;8776302;87763029;44.991975191343265;4.978635907173157;5611;f;FR;f;Europe/Paris;t;FRVLA;VAL;t;;f;8704943;f;;f;VCE;t;8776302;f;;;f;;f;8700810;f;;f;t;;;;;;;;;;;;;;;;;;
+5611;Valence;valence;8724857;;44.93324;4.89236;;t;FR;f;Europe/Paris;t;FRVAV;;t;;f;;f;spgrxe;t;;f;;f;;;f;;f;87067;t;;f;f;;;;;;;;;;;;;;;;;;
+5614;Valence TGV;valence-tgv;8776302;87763029;44.991975191343265;4.978635907173157;5611;f;FR;f;Europe/Paris;t;FRVLA;VAL;t;;f;8704943;f;;f;VCE;t;8776302;f;;;f;;f;8700810;t;;f;t;;;;;;;;;;;;;;;;;;
 5616;Barbonvielle;barbonvielle;8713436;87134361;44.031331;0.67179;;f;FR;f;Europe/Paris;t;FRVBB;;t;;f;8705050;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5617;Vouciennes;vouciennes;8717333;87173336;48.844156;4.450631;;f;FR;f;Europe/Paris;t;FRVCN;;t;;f;8705188;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5618;Vouecourt;vouecourt;8727986;87279869;48.267354;5.132912;;f;FR;f;Europe/Paris;t;FRVCT;;t;;f;8705189;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4363,7 +4363,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5741;Arsonval;arsonval;8721570;87215707;48.2666670000;4.6500000000;;f;FR;f;Europe/Paris;t;FRXAA;;t;;f;8705168;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5742;Abbeville;abbeville;8731736;87317362;50.10215589451615;1.8243902921676636;;f;FR;f;Europe/Paris;t;FRXAB;ABB;t;;f;8700238;f;;f;;f;;f;;;f;;f;8700848;f;;f;t;;;;;;;;;;;アブヴィル;아브빌;;;Абвиль;;;阿贝维尔拉里维埃
 5743;Arcachon;arcachon;8758266;87582668;44.65897699818545;-1.1657309532165525;;f;FR;f;Europe/Paris;t;FRXAC;ARC;t;;f;8700197;f;ezznj3;t;;f;;f;;;f;;f;8700588;f;;f;f;;;;;;;;;;;アルカション;;;;Аркашон;;;阿尔卡雄
-5744;Agde;agde;8778127;87781278;43.31732542255665;3.4661972522735596;;f;FR;f;Europe/Paris;t;FRXAG;AGD;t;;f;8700145;f;spdw20;t;;f;;f;;;f;;f;8700287;f;;f;t;;;;;;;;;;;アグド;;;;Агд;;;阿格德
+5744;Agde;agde;8778127;87781278;43.31732542255665;3.4661972522735596;;f;FR;f;Europe/Paris;t;FRXAG;AGD;t;;f;8700145;f;spdw20;t;;f;;f;;;f;;f;8700287;t;;f;t;;;;;;;;;;;アグド;;;;Агд;;;阿格德
 5745;Aix-les-Bains—Le Revard;aix-les-bains-le-revard;8774113;87741132;45.68809730934939;5.909056663513184;;f;FR;f;Europe/Paris;t;FRXAI;AIX;t;XAI;f;8700048;f;;f;;f;8774113;f;;;f;;f;8700059;f;;f;t;;;;;;;;;;;;;;;;;;
 5746;Amboise;amboise;8757434;87574343;47.42146734975387;0.9812164306640625;;f;FR;f;Europe/Paris;t;FRXAM;AMQ;t;;f;8700607;f;;f;;f;;f;;;f;;f;8700637;f;;f;f;;;;;;;;;;;アンボワーズ;;;;Амбуаз;;;昂布瓦斯
 5747;Alençon;alencon;8744471;87444711;48.4339;0.0984;;f;FR;f;Europe/Paris;t;FRXAN;ALN;t;;f;8700141;f;;f;;f;;f;;;f;;f;8700280;f;;f;t;;;;Alenzón;;;;;;;アランソン;;;;Алансон;;;阿朗松
@@ -4423,7 +4423,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5803;Moulins-sur-Allier;moulins-sur-allier;8769632;87696328;46.561255;3.339267;;f;FR;f;Europe/Paris;t;FRXMU;MSA;t;;f;8700041;f;;f;;f;;f;;;f;;f;8700050;f;;f;t;;;;;;;;;;;;;;;;;;
 5804;Montauban Ville Bourbon;montauban-ville-bourbon;8761124;87611244;44.014287656042015;1.341281533241272;;f;FR;f;Europe/Paris;t;FRXMW;MBN;t;;f;8700057;f;;f;;f;;f;;;f;;f;8700068;f;;f;t;;;;;;;;;;;モントーバン;;;;Монтобан;;;蒙托邦
 5805;Mazamet;mazamet;8761554;87615542;43.49782621031005;2.374849319458008;9221;f;FR;t;Europe/Paris;t;FRXMZ;;t;;f;8703960;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-5806;Narbonne;narbonne;8778110;87781104;43.19059308540353;3.0056780576705933;;f;FR;f;Europe/Paris;t;FRXNA;NBN;t;;f;8700073;f;;f;;f;;f;;;f;;f;8700088;f;;f;t;;;;Narbona;;Narbona;;;;;ナルボンヌ;나르본;Narbona;Narbona;Нарбонна;;;纳博讷
+5806;Narbonne;narbonne;8778110;87781104;43.19059308540353;3.0056780576705933;;f;FR;f;Europe/Paris;t;FRXNA;NBN;t;;f;8700073;f;;f;;f;;f;;;f;;f;8700088;t;;f;t;;;;Narbona;;Narbona;;;;;ナルボンヌ;나르본;Narbona;Narbona;Нарбонна;;;纳博讷
 5807;Le Blanc;le-blanc;8720160;87201608;46.630784969862106;1.0635709762573242;;f;FR;f;Europe/Paris;t;FRXNC;;t;;f;8705084;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5808;Orange;orange;8776510;87765107;44.1375314225196;4.819436073303223;;f;FR;f;Europe/Paris;t;FRXOG;OGE;t;;f;8700433;f;;f;;f;;f;;;f;;f;8700172;f;;f;t;;;;;;;;;;;オランジュ;;;;Оранж;;;
 5809;Aulnoye-Aymeries;aulnoye-aymeries;8729560;87295600;50.19718374384137;3.843551874160766;;f;FR;f;Europe/Paris;t;FRXOY;AYE;t;;f;8700017;f;;f;;f;;f;;;f;;f;8700021;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -4450,7 +4450,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 5831;Saumur;saumur;;;47.2666670000;-0.0833330000;;t;FR;f;Europe/Paris;f;FRXSU;;t;;f;;f;;f;;f;;f;;;f;;f;;f;;f;t;;;;;;;;;;;;;;;;;;
 5832;Senlis;senlis;8727166;87271668;49.206849248842424;2.589753270149231;;f;FR;f;Europe/Paris;t;FRXSV;;t;;f;8704478;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5833;Seclin;seclin;8728651;87286518;50.5500000000;3.0333330000;;f;FR;f;Europe/Paris;t;FRXSX;;t;;f;8701949;f;;f;;f;;f;;;f;;f;8700340;f;;f;f;;;;;;;;;;;;;;;;;;
-5834;Sète;sete;8777320;87773200;43.41281046288451;3.696684837341308;;f;FR;f;Europe/Paris;t;FRXSY;STE;t;;f;8700099;f;;f;;f;;f;;;f;;f;8700175;f;;f;t;;;;;;;;;;;セット;세트;;;Сет;;;塞特港
+5834;Sète;sete;8777320;87773200;43.41281046288451;3.696684837341308;;f;FR;f;Europe/Paris;t;FRXSY;STE;t;;f;8700099;f;;f;;f;;f;;;f;;f;8700175;t;;f;t;;;;;;;;;;;セット;세트;;;Сет;;;塞特港
 5835;Maranville La Poste;maranville-la-poste;8727988;87279885;48.1333330000;4.8666670000;;f;FR;f;Europe/Paris;t;FRXTA;;t;;f;8705154;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 5836;Tarbes;tarbes;8767100;87671008;43.240271;0.069531;;f;FR;f;Europe/Paris;t;FRXTB;TBS;t;;f;8700104;f;sp8jcy;t;;f;;f;;;f;;f;8700183;f;;f;t;;;;;;;;;;;タルブ;;;;Тарб;;;塔布
 5837;St-Claude;st-claude;8774363;87743633;46.39006538884443;5.8603692054748535;;f;FR;f;Europe/Paris;t;FRXTC;;t;;f;8702464;f;;f;;f;;f;;;f;;f;8700325;f;;f;f;;;;;;;;;;;;;;;;;;
@@ -21041,7 +21041,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 22587;Kołobrzeg;kolobrzeg;5100410;;54.182310;15.569649;;f;PL;f;Europe/Warsaw;t;;;f;;f;5100025;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;Kolobřeh;;;;코워브제크;;;Колобжег;;;科沃布热格
 22598;Montpellier;montpellier;;;43.599448798154995;3.8961821794509888;;t;FR;f;Europe/Paris;t;;;f;;f;;f;spfb03;t;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;モンペリエ;몽펠리에;;;Монпелье;;;蒙彼利埃
 22599;Montpellier Les Sabines – Gare Routière;montpellier-les-sabines-gare-routiere;;;43.58409023914171;3.860406875610351;22598;f;FR;f;Europe/Paris;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;モンペリエ;몽펠리에;;;Монпелье;;;蒙彼利埃
-22600;Nîmes;nimes;;;43.836678232954476;4.360021948814392;;t;FR;f;Europe/Paris;t;;;f;;f;;f;spg16g;t;;f;;f;;;f;;f;8700302;f;;f;f;;;;;;;;;;;ニーム;님;;;Ним;;;尼姆
+22600;Nîmes;nimes;;;43.836678232954476;4.360021948814392;;t;FR;f;Europe/Paris;t;;;f;;f;;f;spg16g;t;;f;;f;;;f;;f;8700302;t;;f;f;;;;;;;;;;;ニーム;님;;;Ним;;;尼姆
 22601;Nîmes Parnasse – Gare Routière;nimes-parnasse-gare-routiere;;;43.817711064991435;4.362017512321472;22600;f;FR;f;Europe/Paris;f;;;f;;f;;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;ニーム;님;;;Ним;;;尼姆
 22602;Perca/Percha;perca-percha;8302018;;46.790372;11.978521;;f;IT;f;Europe/Rome;t;;;f;;f;8372315;t;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 22603;Alteckendorf Abri;alteckendorf-abri;8763995;;48.7916550000;7.5970460000;;f;FR;f;Europe/Paris;t;FRTMI;;t;;f;8706842;f;;f;;f;;f;;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;阿尔泰康多尔

--- a/test_data.rb
+++ b/test_data.rb
@@ -192,7 +192,12 @@ class StationsTest < Minitest::Test
 
       if !id.nil?
         if id_column_size
-          assert_equal id_column_size, row[id_column].size, "Invalid #{id_column}: #{row[id_column]} for station #{row["id"]}"
+          if id_column_size.is_a?(Array)
+
+            assert id_column_size.include?(row[id_column].size), "Invalid #{id_column}: #{row[id_column]} for station #{row["id"]}"
+          else
+            assert_equal id_column_size, row[id_column].size, "Invalid #{id_column}: #{row[id_column]} for station #{row["id"]}"
+          end
         end
 
         assert !unique_set.include?(row[id_column]), "Duplicated #{id_column} #{row[id_column]} for station #{row["id"]}"
@@ -250,7 +255,7 @@ class StationsTest < Minitest::Test
   end
 
   def test_renfe_enabled_an_id_columns
-    validate_enabled_and_id_columns("renfe", 5)
+    validate_enabled_and_id_columns("renfe", [5, 7])
   end
 
   def test_id_unicity


### PR DESCRIPTION
* Allow multiple column size in tests for Renfe ids
* `renfe_id`s taken from http://www.renfe.com/jsHome/estaciones.js
* Disables Spanish stations for SNCF
